### PR TITLE
FIX: _setup_assignments should not erase previous assignments.

### DIFF
--- a/simplesat/minisat.py
+++ b/simplesat/minisat.py
@@ -153,9 +153,11 @@ class Solver(object):
     def _setup_assignments(self):
         """Initialize assignments table.
         """
-        self.assignments = OrderedDict(
-            (abs(lit), None) for clause in self.clauses for lit in clause
-        )
+        variables = {abs(lit) for clause in self.clauses for lit in clause}
+        assignments = self.assignments
+        for variable in variables:
+            if variable not in assignments:
+                assignments[variable] = None
 
     def propagate(self):
         while len(self.prop_queue) > 0:

--- a/tests/test_minisat.py
+++ b/tests/test_minisat.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import unittest
 
 import mock
@@ -224,6 +225,19 @@ class TestSolver(unittest.TestCase):
         self.assertItemsEqual(s.watches[-3], [cl2])
         self.assertItemsEqual(s.watches[-2], [cl1])
         self.assertItemsEqual(s.watches[1], [cl1, cl2])
+
+    def test_setup_does_not_overwrite_assignments(self):
+        # Given
+        s = Solver()
+        s.add_clause([-1])
+        s.add_clause([1, 2, 3])
+        expected_assignments = OrderedDict([(1, False), (2, None), (3, None)])
+
+        # When
+        s._setup_assignments()
+
+        # Then
+        self.assertEqual(s.assignments, expected_assignments)
 
     def _assertWatchesNotTrue(self, watches, assignments):
         for watch, clauses in watches.items():

--- a/tests/test_minisat_problems.py
+++ b/tests/test_minisat_problems.py
@@ -7,6 +7,24 @@ from simplesat.examples.van_der_waerden import van_der_waerden
 class TestMinisatProblems(unittest.TestCase):
     """Run the Minisat solver on a range of test problems.
     """
+    def test_unit_assignments_are_remembered(self):
+        # Regression test for #31 (calling _setup_assignments() after enqueueing unit
+        # clauses caused unit assignments to be erased).
+
+        # Given
+        s = Solver()
+        s.add_clause([1, 2, 3])
+        s.add_clause([-1, 2, 3])
+        s.add_clause([-2])
+        s.add_clause([-3])
+        s._setup_assignments()
+
+        # When
+        solution =  s.search()
+
+        # Then
+        self.assertFalse(solution)
+
     def test_no_assumptions(self):
         # A simple problem with only unit propagation, no assumptions (except
         # for the initial one), no backtracking, and no conflicts.


### PR DESCRIPTION
@cournape This fixes #31 (unit clauses not being taken into account properly). The problem was that `_setup_assignments` would erase whatever information was already in the assignments dictionary, so that unit clauses were effectively being ignored.
