### PR TITLE
Add installed packages rules

### DIFF
--- a/simplesat/tests/simple_numpy_installed_blocking.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking.yaml
@@ -1,0 +1,16 @@
+# Upgrade impossible because installed EPD_free depends on numpy < 1.8
+packages:
+    - MKL 10.2-1
+    - MKL 10.3-1
+    - EPD_free 7.3-1; depends (MKL == 10.2-1, numpy == 1.7.1-1)
+    - numpy 1.7.1-1; depends (MKL == 10.2-1)
+    - numpy 1.8.1-1; depends (MKL == 10.3-1)
+
+request:
+    - operation: "install"
+      requirement: "numpy > 1.8"
+
+installed:
+    - EPD_free 7.3-1
+    - MKL 10.2-1
+    - numpy 1.7.1-1

--- a/simplesat/tests/simple_numpy_installed_blocking_downgrade.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking_downgrade.yaml
@@ -1,0 +1,16 @@
+# Downgrade impossible because installed EPD_free depends on numpy > 1.8
+packages:
+    - MKL 10.2-1
+    - MKL 10.3-1
+    - EPD_free 7.4-1; depends (MKL == 10.3-1, numpy == 1.8.1-1)
+    - numpy 1.7.1-1; depends (MKL == 10.2-1)
+    - numpy 1.8.1-1; depends (MKL == 10.3-1)
+
+request:
+    - operation: "install"
+      requirement: "numpy < 1.8"
+
+installed:
+    - EPD_free 7.4-1
+    - MKL 10.3-1
+    - numpy 1.8.1-1

--- a/simplesat/tests/simple_numpy_installed_downgrade.yaml
+++ b/simplesat/tests/simple_numpy_installed_downgrade.yaml
@@ -1,0 +1,14 @@
+# Downgrade test
+packages:
+    - MKL 10.2-1
+    - MKL 10.3-1
+    - numpy 1.7.1-1; depends (MKL == 10.2-1)
+    - numpy 1.8.1-1; depends (MKL == 10.3-1)
+
+request:
+    - operation: "install"
+      requirement: "numpy < 1.8"
+
+installed:
+    - MKL 10.3-1
+    - numpy 1.8.1-1

--- a/simplesat/tests/simple_numpy_installed_no_upgrade.yaml
+++ b/simplesat/tests/simple_numpy_installed_no_upgrade.yaml
@@ -1,0 +1,13 @@
+packages:
+    - MKL 10.2-1
+    - MKL 10.3-1
+    - numpy 1.7.1-1; depends (MKL == 10.2-1)
+    - numpy 1.8.1-1; depends (MKL == 10.3-1)
+
+request:
+    - operation: "install"
+      requirement: "numpy"
+
+installed:
+    - MKL 10.2-1
+    - numpy 1.7.1-1

--- a/simplesat/tests/simple_numpy_installed_upgrade.yaml
+++ b/simplesat/tests/simple_numpy_installed_upgrade.yaml
@@ -1,0 +1,13 @@
+packages:
+    - MKL 10.2-1
+    - MKL 10.3-1
+    - numpy 1.7.1-1; depends (MKL == 10.2-1)
+    - numpy 1.8.1-1; depends (MKL == 10.3-1)
+
+request:
+    - operation: "install"
+      requirement: "numpy > 1.8"
+
+installed:
+    - MKL 10.2-1
+    - numpy 1.7.1-1


### PR DESCRIPTION
We now add rules for installed packages, of the form ` A | B | C | ...` where `A`, `B`, `C`, etc.. are the available versions of installed package `p`.