### PR TITLE
MAINT: move _composer_utils back to simplesat.

### DIFF
--- a/scripts/print_operations.php.in
+++ b/scripts/print_operations.php.in
@@ -20,6 +20,7 @@ use Composer\Repository\FilesystemRepository;
 use Composer\Repository\InstalledFilesystemRepository;
 use Composer\Repository\PackageRepository;
 use Composer\Repository\WritableArrayRepository;
+use Composer\Semver\VersionParser;
 
 $loader = new ArrayLoader();
 
@@ -48,13 +49,10 @@ $pool = new Pool("dev");
 $pool->addRepository($remote_repo);
 $pool->addRepository($installed_repo);
 
+$parser = new VersionParser();
 $request = new Request($pool);
 {% for operation, requirement_name, constraints in request_parts %}
-$constraints = array();
-{% for constraint in constraints %}
-$constraints[] = new {{constraint}};
-{% endfor %}
-$request_constraints = new MultiConstraint($constraints);
+$request_constraints = $parser->parseConstraints("{{constraints}}");
 $request->{{operation}}("{{requirement_name}}", $request_constraints);
 {% endfor %}
 

--- a/scripts/print_rules.php.in
+++ b/scripts/print_rules.php.in
@@ -20,6 +20,7 @@ use Composer\Repository\FilesystemRepository;
 use Composer\Repository\InstalledFilesystemRepository;
 use Composer\Repository\PackageRepository;
 use Composer\Repository\WritableArrayRepository;
+use Composer\Semver\VersionParser;
 
 $loader = new ArrayLoader();
 
@@ -49,13 +50,11 @@ $pool->addRepository($remote_repo);
 $pool->addRepository($installed_repo);
 
 
+$parser = new VersionParser();
+
 $request = new Request($pool);
 {% for operation, requirement_name, constraints in request_parts %}
-$constraints = array();
-{% for constraint in constraints %}
-$constraints[] = new {{constraint}};
-{% endfor %}
-$request_constraints = new MultiConstraint($constraints);
+$request_constraints = $parser->parseConstraints("{{constraints}}");
 $request->{{operation}}("{{requirement_name}}", $request_constraints);
 {% endfor %}
 

--- a/scripts/scenario_to_php.py
+++ b/scripts/scenario_to_php.py
@@ -6,9 +6,7 @@ import jinja2
 
 from enstaller.new_solver.yaml_utils import Scenario
 
-from enstaller.new_solver._composer_utils import (
-    scenario_to_php_template_variables,
-)
+from simplesat.utils._composer_utils import scenario_to_php_template_variables
 
 
 def main(argv=None):

--- a/simplesat/utils/_composer_utils.py
+++ b/simplesat/utils/_composer_utils.py
@@ -1,0 +1,181 @@
+"""
+Useful code to compare solver behaviour with PHP's Composer. Obviously
+don't use this in enstaller itself.
+"""
+import collections
+import json
+
+from enstaller.new_solver.constraint_types import (
+    Any, EnpkgUpstreamMatch, Equal, GEQ, GT, LEQ, LT
+)
+from enstaller.new_solver.requirement import Requirement
+from enstaller.solver import JobType
+
+
+# We ignore alpha/rc/etc... as composer does not allow to combine those with
+# patch versions, which we use to emulate build numbers.
+_TO_NORMALIZE = {
+    "1.0a3": "1.0.0",
+    "2011n": "2011.14.0.0",
+    "0.14.1rc1": "0.14.1.0",
+}
+
+
+JOB_KIND_TO_PHP_METHOD = {
+    JobType.install: "install",
+    JobType.remove: "remove",
+}
+
+
+def repository_to_composer_json_dict(repository):
+    """ Generator of composer-compatible dict representation of an enstaller
+    Repository's entries.
+
+    Assuming the string returned by this function is written into the file
+    'repository.json' file, you can load it as follows w/ Composer::
+
+        $json_string = file_get_contents("remote.json");
+        $packages = JsonFile::parseJson($json_string);
+
+        $repository = new ArrayRepository();
+        $loader = new ArrayLoader();
+
+        foreach ($packages as $packageData) {
+            $package = $loader->load($packageData):
+            $repository.addPackage($package);
+        }
+
+    Parameters
+    ----------
+    repository : Repository
+        The repository to convert
+    """
+    for package in repository.iter_packages():
+        version_normalized = _normalize_php_version(package.version)
+        requires = [Requirement.from_legacy_requirement_string(p) for
+                    p in package.dependencies]
+        yield {
+            "name": package.name,
+            "version": _fix_php_version(package.version),
+            "version_normalized": version_normalized,
+            "require": _requirements_to_php_dict(requires),
+        }
+
+
+def request_to_php_parts(request):
+    parts = []
+    for job in request.jobs:
+        name, constraints = _requirement_to_php_constraints(
+            job.requirement
+        )
+        php_constraints = ", ".join(
+            "{0} {1}".format(kind, version)
+            for kind, version in constraints
+        )
+        parts.append((JOB_KIND_TO_PHP_METHOD[job.kind], name, php_constraints))
+    return parts
+
+
+def scenario_to_php_template_variables(scenario, remote_definition,
+                                       installed_definition):
+
+    remote_repository = scenario.remote_repositories[0]
+    with open(remote_definition, "wt") as fp:
+        entries_iterator = repository_to_composer_json_dict(remote_repository)
+        fp.write(json.dumps(list(entries_iterator), indent=4))
+
+    installed_repository = scenario.installed_repository
+    with open(installed_definition, "wt") as fp:
+        entries_iterator = repository_to_composer_json_dict(installed_repository)
+        fp.write(json.dumps(list(entries_iterator), indent=4))
+
+    return {"remote_definition": remote_definition,
+            "installed_definition": installed_definition,
+            "request_parts": request_to_php_parts(scenario.request)}
+
+
+def _fix_php_version(version):
+    """ 'Normalize' an EnpkgVersion to a valid composer version
+    string.
+    """
+    return str(version)
+
+
+def _normalize_php_version(version):
+    """ 'Normalize' an EnpkgVersion to a valid normalized composer version
+    string.
+    """
+    upstream = str(version.upstream)
+    upstream = _TO_NORMALIZE.get(upstream, upstream)
+    while upstream.count(".") < 3:
+        upstream += ".0"
+    return "{0}-patch{1}".format(upstream, version.build)
+
+
+def _normalize_php_version_constraint(version):
+    """ 'Normalize' an EnpkgVersion to a valid normalized composer version
+    string when used in constraints.
+    """
+    upstream = str(version.upstream)
+    upstream = _TO_NORMALIZE.get(upstream, upstream)
+    while upstream.count(".") < 3:
+        upstream += ".0"
+
+    if version.build == 0:
+        return upstream
+    else:
+        return "{0}-patch{1}".format(upstream, version.build)
+
+
+def _requirement_to_php_constraints(requirement):
+    constraint_to_string = {
+        GEQ: ">=",
+        GT: ">",
+        LEQ: "<=",
+        LT: "<",
+    }
+    constraint_types = tuple(constraint_to_string.keys())
+    parts = []
+    for constraint in requirement._constraints._constraints:
+        if isinstance(constraint, constraint_types):
+            constraint_string = constraint_to_string[constraint.__class__]
+            version = _normalize_php_version_constraint(constraint.version)
+            parts.append((constraint_string, version))
+        elif not isinstance(constraint, Any):
+            raise ValueError("Unsupported constraint: %s" % constraint)
+
+    return requirement.name, parts
+
+
+def _requirement_to_php_string(requirement):
+    """ Convert an enstaller requirement into a composer constraint string.
+    """
+    parts = []
+    for constraint in requirement._constraints._constraints:
+        if isinstance(constraint, EnpkgUpstreamMatch):
+            normalized = _normalize_php_version_constraint(constraint.version)
+            parts.append("~{0}".format(normalized))
+        elif isinstance(constraint, Any):
+            parts.append("*")
+        elif isinstance(constraint, Equal):
+            normalized = _normalize_php_version_constraint(constraint.version)
+            parts.append("{0}".format(normalized))
+        else:
+            raise NotImplementedError(constraint)
+    return ", ".join(parts)
+
+
+def _requirements_to_php_dict(requirements):
+    """ Convert a list of requirements into a mapping
+    name -> composer_requirement_string
+
+    Parameters
+    ----------
+    requirements : seq
+        Iterable of Requirement instances.
+    """
+    php_dict = collections.defaultdict(list)
+    for requirement in requirements:
+        php_dict[requirement.name].append(_requirement_to_php_string(requirement))
+
+    return dict((k, ", ".join(v)) for k, v in php_dict.items())


### PR DESCRIPTION
It will be easier to track composer in one package than two.

It also updates the code to work with more recent versions of composer.