### PR TITLE
BUG: _find_updates should allow lower version to handle downgrades.

### DIFF
--- a/simplesat/tests/common.py
+++ b/simplesat/tests/common.py
@@ -109,8 +109,8 @@ class Scenario(object):
             if operation["kind"] == "install":
                 operations.append(InstallOperation(operation["package"]))
             elif operation["kind"] == "update":
-                operations.append(UpdateOperation(operation["from"],
-                                                  operation["to"]))
+                operations.append(UpdateOperation(operation["to"],
+                                                  operation["from"]))
             elif operation["kind"] == "remove":
                 operations.append(RemoveOperation(operation["package"]))
             else:

--- a/simplesat/tests/numpy_downgrade.yaml
+++ b/simplesat/tests/numpy_downgrade.yaml
@@ -36,7 +36,12 @@ installed:
   - libgfortran 3.0.0-2
   - numpy 1.9.2-1
 
+decisions:
+  3: MKL 10.3-1
+  5: libgfortran 3.0.0-2
+  26: numpy 1.8.1-3
+
 transaction:
-    - kind: "dowgrade"
+    - kind: "update"
       from: "numpy 1.9.2-1"
       to: "numpy 1.8.1-3"

--- a/simplesat/tests/numpy_downgrade.yaml
+++ b/simplesat/tests/numpy_downgrade.yaml
@@ -29,7 +29,7 @@ packages:
 
 request:
     - operation: "install"
-      requirement: "numpy < 1.9"
+      requirement: "numpy < 1.8"
 
 installed:
   - MKL 10.3-1
@@ -38,10 +38,9 @@ installed:
 
 decisions:
   3: MKL 10.3-1
-  5: libgfortran 3.0.0-2
   26: numpy 1.8.1-3
 
 transaction:
     - kind: "update"
       from: "numpy 1.9.2-1"
-      to: "numpy 1.8.1-3"
+      to: "numpy 1.7.1-3"

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -68,5 +68,8 @@ class TestInstallSet(TestCase, ScenarioTestAssistant):
     def test_simple_numpy(self):
         self._check_solution("simple_numpy_installed.yaml")
 
+    def test_numpy_downgrade(self):
+        self._check_solution("numpy_downgrade.yaml")
+
     def test_ipython(self):
         self._check_solution("ipython_with_installed.yaml")

--- a/simplesat/transaction.py
+++ b/simplesat/transaction.py
@@ -99,8 +99,9 @@ class Transaction(object):
 
     def _find_updates(self, pool, package):
         requirement = Requirement._from_string(package.name)
-        return [p for p in pool.what_provides(requirement)
-                if p.version > package.version]
+        return [
+            p for p in pool.what_provides(requirement) if p != package
+        ]
 
     def _compute_means_update_map(self, pool, decisions, installed_map):
         means_update_map = OrderedDict()

--- a/simplesat/transaction.py
+++ b/simplesat/transaction.py
@@ -42,7 +42,7 @@ class Transaction(object):
                                                    operation.package)
                 )
             elif isinstance(operation, RemoveOperation):
-                lines.append("Removing {}".format(operation.package))
+                lines.append("Removing\n\t{}".format(operation.package))
             else:
                 msg = "Unknown operation: {!r}".format(operation)
                 raise ValueError(msg)


### PR DESCRIPTION
The `_find_updates` was only considering versions higher than the given package, which prevents `_find_updates` to work with downgrades.

@johntyree @jvkersch 