### PR TITLE
Prune unnecessary packages from solution

### DIFF
--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -75,8 +75,8 @@ class DependencySolver(object):
         return requirement_ids, list(rules_generator.iter_rules())
 
 
-def _connected_packages(solution, requirement_ids, pool):
-    """ Return packages which are associated with a requirement. """
+def _connected_packages(solution, pkg_ids, pool):
+    """ Return packages in `solution` which are associated with `pkg_ids`. """
 
     # Our strategy is as follows:
     # ... -> pkg.dependencies -> pkg strings -> ids -> _id_to_package -> ...
@@ -102,10 +102,10 @@ def _connected_packages(solution, requirement_ids, pool):
         neighbors = set(package_string_to_id[key] for key in pkg_keys)
         return neighbors
 
-    # A requirement can root its own independent graph, so we must start at
+    # Each package can root its own independent graph, so we must start at
     # each one individually
     connected = set()
-    for pkg_id in requirement_ids:
+    for pkg_id in pkg_ids:
         # We pass in `connected` to avoid re-walking a graph we've seen before
         connected.update(_connected_nodes(pkg_id, neighborfunc, connected))
 

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -10,10 +10,11 @@ from simplesat.transaction import Transaction
 
 class DependencySolver(object):
     def __init__(self, pool, remote_repositories, installed_repository,
-                 policy=None):
+                 policy=None, use_pruning=True):
         self._pool = pool
         self._installed_repository = installed_repository
         self._remote_repositories = remote_repositories
+        self.use_pruning = use_pruning
 
         self._policy = policy or InstalledFirstPolicy(
             pool, installed_repository
@@ -23,7 +24,7 @@ class DependencySolver(object):
         """Given a request, computes the set of operations to apply to
         resolve it, or None if no resolution could be found.
         """
-        rules = self._create_rules(request)
+        requirement_ids, rules = self._create_rules(request)
         sat_solver = MiniSATSolver.from_rules(rules, self._policy)
         solution = sat_solver.search()
 
@@ -31,6 +32,13 @@ class DependencySolver(object):
             return None
         else:
             solution_ids = _solution_to_ids(solution)
+
+            if self.use_pruning:
+                disconnected = _disconnected_packages(
+                    solution_ids, requirement_ids, self._pool)
+
+                solution_ids = [i for i in solution_ids
+                                if i not in disconnected]
 
             installed_map = set(
                 self._pool.package_id(p)
@@ -65,12 +73,64 @@ class DependencySolver(object):
 
         rules_generator = RulesGenerator(pool, request, installed_map)
 
-        return list(rules_generator.iter_rules())
+        return requirement_ids, list(rules_generator.iter_rules())
+
+
+def _disconnected_packages(solution, requirement_ids, pool):
+    """ Return packages which are not associated with a requirement. """
+
+    # Our strategy is as follows:
+    # ... -> pkg.dependencies -> pkg strings -> ids -> _id_to_package -> ...
+
+    # We only need to identify packages which will be installed
+    sol_set = set(s for s in solution if s > 0)
+
+    # This dict can recover ids from the strings produced by pkg.dependencies
+    package_string_to_id = {}
+    for pkg_id in sol_set:
+        pkg = pool._id_to_package[pkg_id]
+        pkg_key = pkg.name
+        package_string_to_id[pkg_key] = pkg_id
+
+    def neighborfunc(pkg_id):
+        """ Given a pkg id, return the pkg ids of the dependencies that
+        appeared in our solution. """
+        dep_strings = pool._id_to_package[pkg_id].dependencies
+        pkg_keys = (d.split()[0] for d in dep_strings)
+        neighbors = set(package_string_to_id[key] for key in pkg_keys)
+        return neighbors
+
+    # A requirement can root its own independent graph, so we must start at
+    # each one individually
+    connected = set()
+    for pkg_id in requirement_ids:
+        # We pass in `connected` to avoid re-walking a graph we've seen before
+        connected.update(_connected_nodes(pkg_id, neighborfunc, connected))
+
+    disconnected = sol_set - connected
+
+    return disconnected
+
+
+def _connected_nodes(node, neighborfunc, visited):
+    """ Recursively build up a set of nodes connected to `node` by following
+    neighbors as given by `neighborfunc(node)`. """
+    visited.add(node)
+    queued = set([node])
+
+    while queued:
+        node = queued.pop()
+        visited.add(node)
+        neighbors = neighborfunc(node)
+        queued.update(neighbors)
+        queued.difference_update(visited)
+
+    return visited
 
 
 def _solution_to_ids(solution):
     # Return solution as list of signed integers.
     return sorted(
-        [(+1 if value else -1) * _id for _id, value in solution.items()],
+        ((+1 if value else -1) * _id for _id, value in solution.items()),
         key=lambda lit: abs(lit)
     )

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -1,6 +1,7 @@
 import collections
 
 from enstaller.solver import JobType
+from enstaller.new_solver import Requirement
 
 from simplesat.sat.policy import InstalledFirstPolicy
 from simplesat.sat import MiniSATSolver
@@ -94,7 +95,10 @@ def _connected_packages(solution, requirement_ids, pool):
         """ Given a pkg id, return the pkg ids of the dependencies that
         appeared in our solution. """
         dep_strings = pool._id_to_package[pkg_id].dependencies
-        pkg_keys = (d.split()[0] for d in dep_strings)
+        pkg_keys = (
+            Requirement.from_legacy_requirement_string(d).name
+            for d in dep_strings
+        )
         neighbors = set(package_string_to_id[key] for key in pkg_keys)
         return neighbors
 

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -34,11 +34,9 @@ class DependencySolver(object):
             solution_ids = _solution_to_ids(solution)
 
             if self.use_pruning:
-                disconnected = _disconnected_packages(
+                connected = _connected_packages(
                     solution_ids, requirement_ids, self._pool)
-
-                solution_ids = [i for i in solution_ids
-                                if i not in disconnected]
+                solution_ids = [i for i in solution_ids if i in connected]
 
             installed_map = set(
                 self._pool.package_id(p)
@@ -76,8 +74,8 @@ class DependencySolver(object):
         return requirement_ids, list(rules_generator.iter_rules())
 
 
-def _disconnected_packages(solution, requirement_ids, pool):
-    """ Return packages which are not associated with a requirement. """
+def _connected_packages(solution, requirement_ids, pool):
+    """ Return packages which are associated with a requirement. """
 
     # Our strategy is as follows:
     # ... -> pkg.dependencies -> pkg strings -> ids -> _id_to_package -> ...
@@ -107,9 +105,7 @@ def _disconnected_packages(solution, requirement_ids, pool):
         # We pass in `connected` to avoid re-walking a graph we've seen before
         connected.update(_connected_nodes(pkg_id, neighborfunc, connected))
 
-    disconnected = sol_set - connected
-
-    return disconnected
+    return connected
 
 
 def _connected_nodes(node, neighborfunc, visited):

--- a/simplesat/tests/iris.yaml
+++ b/simplesat/tests/iris.yaml
@@ -487,8 +487,6 @@ transaction:
     - kind: "install"
       package: "OWSLib 0.8.8-4"
     - kind: "install"
-      package: "zlib 1.2.6-1"
-    - kind: "install"
       package: "cartopy 0.11.0-5"
     - kind: "install"
       package: "libgdal 1.11.0-7"


### PR DESCRIPTION
This PR implements a simple pruning algorithm to avoid installing packages which end up in the solution but which have no packages that depend on them. It recursively gathers up all of the dependencies of each required package and then does an intersection of those packages with the solution (preserving order).

I think it should be possible to avoid this entirely by being smarter with how backtracking is handled and thereby avoiding this altogether, but that sounds hard and this was very easy.

As a bonus, it revealed that the `iris.yaml` scenario incorrectly includes `zlib` in the expected installed packages, even though no one is asking for it. I have updated the scenario so that tox passes.