### PR TITLE
Raise error for unsatisfiable requirement

### DIFF
--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -1,5 +1,6 @@
 import collections
 
+from egginst.errors import NoPackageFound
 from enstaller.solver import JobType
 
 from simplesat.sat.policy import InstalledFirstPolicy
@@ -52,6 +53,8 @@ class DependencySolver(object):
             pool.package_id(package)
             for package in pool.what_provides(requirement)
         ]
+        if len(requirement_ids) == 0:
+            raise NoPackageFound(str(requirement), requirement)
         self._policy.add_packages_by_id(requirement_ids)
 
         # Add installed packages.

--- a/simplesat/tests/no_candidate.yaml
+++ b/simplesat/tests/no_candidate.yaml
@@ -1,0 +1,8 @@
+packages:
+    - MKL 10.3-1
+    - libgfortran 3.0.0-2
+    - numpy 1.9.2-1; depends (libgfortran ~= 3.0.0, MKL == 10.3-1)
+
+request:
+    - operation: "install"
+      requirement: "numpy >= 2.0"

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -64,11 +64,8 @@ class TestNoInstallSet(TestCase, ScenarioTestAssistant):
         self._check_solution("iris.yaml")
 
     def test_no_candidate(self):
-        self.assertRaises(
-            NoPackageFound,
-            self._check_solution,
-            "no_candidate.yaml",
-        )
+        with self.assertRaises(NoPackageFound):
+            self._check_solution("no_candidate.yaml")
 
 
 class TestInstallSet(TestCase, ScenarioTestAssistant):

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -2,6 +2,7 @@ import os.path
 
 from unittest import TestCase, expectedFailure
 
+from egginst.errors import NoPackageFound
 from enstaller.new_solver import Pool
 
 from simplesat.dependency_solver import DependencySolver
@@ -61,6 +62,13 @@ class TestNoInstallSet(TestCase, ScenarioTestAssistant):
 
     def test_iris(self):
         self._check_solution("iris.yaml")
+
+    def test_no_candidate(self):
+        self.assertRaises(
+            NoPackageFound,
+            self._check_solution,
+            "no_candidate.yaml",
+        )
 
 
 class TestInstallSet(TestCase, ScenarioTestAssistant):


### PR DESCRIPTION
When the pool cannot provide any packages that satisfy a requirement, we now raise a `egginst.errors.NoPackageFound` exception with a pretty string.

Closes #47