### PR TITLE
Don't prune currently installed packages

### DIFF
--- a/scripts/print_rules.py
+++ b/scripts/print_rules.py
@@ -12,7 +12,7 @@ def print_rules(request, remote_repositories, installed_repository):
     pool.add_repository(installed_repository)
 
     solver = DependencySolver(pool, remote_repositories, installed_repository)
-    rules = solver._create_rules(request)
+    _, rules = solver._create_rules(request)
     for rule in rules:
         print(rule.to_string(pool))
 

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -45,7 +45,7 @@ class DependencySolver(object):
                     solution_ids, requirement_ids, self._pool)
                 relevant_packages = packages_to_install.union(installed_map)
                 solution_ids = [
-                    i for i in solution_ids if i in relevant_packages
+                    i for i in solution_ids if abs(i) in relevant_packages
                 ]
 
             return Transaction(self._pool, solution_ids, installed_map)

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -37,7 +37,7 @@ class DependencySolver(object):
 
         installed_map = set(
             self._pool.package_id(p)
-            for p in self._installed_repository.iter_packages()
+            for p in self._installed_repository
         )
 
         if self.use_pruning:

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -43,7 +43,7 @@ class DependencySolver(object):
             if self.use_pruning:
                 packages_to_install = _connected_packages(
                     solution_ids, requirement_ids, self._pool)
-                relevant_packages = packages_to_install | installed_map
+                relevant_packages = packages_to_install.union(installed_map)
                 solution_ids = [
                     i for i in solution_ids if i in relevant_packages
                 ]

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -35,15 +35,18 @@ class DependencySolver(object):
         else:
             solution_ids = _solution_to_ids(solution)
 
-            if self.use_pruning:
-                connected = _connected_packages(
-                    solution_ids, requirement_ids, self._pool)
-                solution_ids = [i for i in solution_ids if i in connected]
-
             installed_map = set(
                 self._pool.package_id(p)
                 for p in self._installed_repository.iter_packages()
             )
+
+            if self.use_pruning:
+                packages_to_install = _connected_packages(
+                    solution_ids, requirement_ids, self._pool)
+                relevant_packages = packages_to_install | installed_map
+                solution_ids = [
+                    i for i in solution_ids if i in relevant_packages
+                ]
 
             return Transaction(self._pool, solution_ids, installed_map)
 


### PR DESCRIPTION
A remake of #59.

The way pruning was done previously was incorrectly filtering out all packages marked for uninstallation.

This PR simply marks all currently installed packages as also relevant, so that they won't be pruned.
