### PR TITLE
ENH: commandline flag for disabling pruning in scripts/solve.py

### DIFF
--- a/scripts/solve.py
+++ b/scripts/solve.py
@@ -8,11 +8,12 @@ from simplesat.dependency_solver import DependencySolver
 
 
 def solve_and_print(request, remote_repositories, installed_repository,
-                    print_ids):
+                    print_ids, prune=True):
     pool = Pool(remote_repositories)
     pool.add_repository(installed_repository)
 
-    solver = DependencySolver(pool, remote_repositories, installed_repository)
+    solver = DependencySolver(
+        pool, remote_repositories, installed_repository, use_pruning=prune)
     transaction = solver.solve(request)
     print(transaction)
 
@@ -23,12 +24,13 @@ def main(argv=None):
     p = argparse.ArgumentParser()
     p.add_argument("scenario", help="Path to the YAML scenario file.")
     p.add_argument("--print-ids", action="store_true")
+    p.add_argument("--no-prune", action="store_false")
 
     ns = p.parse_args(argv)
 
     scenario = Scenario.from_yaml(ns.scenario)
     solve_and_print(scenario.request, scenario.remote_repositories,
-                    scenario.installed_repository, ns.print_ids)
+                    scenario.installed_repository, ns.print_ids, ns.no_prune)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It's difficult to validate the behavior of pruning without a way to programmatically disable it. This PR adds a `--no-prune` flag to disable it.