### PR TITLE
MAINT: clarify checks for undetermined clauses

### DIFF
--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -177,10 +177,10 @@ class MiniSATSolver(object):
         """
         solution_literals = {variable if status else -variable
                              for variable, status in solution_map.items()}
-        for clause in self.clauses:
-            if len(set(clause.lits) & solution_literals) == 0:
-                return False
-        return True
+        # True if any clause has no assigned literals and thus is undetermined
+        has_unknown_clause = any(solution_literals.isdisjoint(clause.lits)
+                                 for clause in self.clauses)
+        return not has_unknown_clause
 
     def analyze(self, conflict):
         """ Produce a reason clause for a conflict.

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -97,7 +97,7 @@ class InstalledFirstPolicy(IPolicy):
 
         for clause in clauses:
             # TODO Need clause.undecided_literals property
-            if signed_assignments.intersection(clause.lits):
+            if not signed_assignments.isdisjoint(clause.lits):
                 # Clause is true
                 continue
 


### PR DESCRIPTION
This just uses the appropriate method on `set` for what we want to do, which is to see if the clause shares any literals with the set of solution literals. I think it's easier to read.

It should also be slightly faster, assuming these are implemented well.