### PR TITLE
MAINT: clarify _solution_to_ids

### DIFF
--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -142,7 +142,5 @@ def _connected_nodes(node, neighborfunc, visited):
 
 def _solution_to_ids(solution):
     # Return solution as list of signed integers.
-    return sorted(
-        ((+1 if value else -1) * _id for _id, value in solution.items()),
-        key=lambda lit: abs(lit)
-    )
+    ids = (pkg_id if value else -pkg_id for pkg_id, value in solution.items())
+    return sorted(ids, key=lambda lit: abs(lit))

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -1,5 +1,7 @@
 import collections
 
+import six
+
 from egginst.errors import NoPackageFound
 from enstaller.solver import JobType
 from enstaller.new_solver import Requirement
@@ -94,7 +96,7 @@ def _connected_packages(solution, root_ids, pool):
     }
 
     solution_root_ids = set(
-        pkg_id for name, pkg_id in solution_name_to_id.items()
+        pkg_id for name, pkg_id in six.iteritems(solution_name_to_id)
         if name in root_names
     )
 
@@ -142,5 +144,6 @@ def _connected_nodes(node, neighborfunc, visited):
 
 def _solution_to_ids(solution):
     # Return solution as list of signed integers.
-    ids = (pkg_id if value else -pkg_id for pkg_id, value in solution.items())
+    ids = (pkg_id if value else -pkg_id
+           for pkg_id, value in six.iteritems(solution))
     return sorted(ids, key=lambda lit: abs(lit))


### PR DESCRIPTION
Just a style update. I'm not sure if the `+1` and `-1` was intended to make it easier to read, but I've removed it in favor of signed variables.

This should not introduce any functional changes.