### PR TITLE
BUG: don't crash when decision_set contains assigned lits

### DIFF
--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -29,8 +29,7 @@ class InstalledFirstPolicy(IPolicy):
         self._pool = pool
         self._decision_set = set()
         self._installed_map = set(
-            pool.package_id(package) for package in
-            installed_repository.iter_packages()
+            pool.package_id(package) for package in installed_repository
         )
 
     def add_packages_by_id(self, package_ids):

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -43,6 +43,12 @@ class InstalledFirstPolicy(IPolicy):
         """
 
         decision_set = self._decision_set
+        # Remove everything that is currently assigned
+        if len(decision_set) > 0:
+            decision_set.difference_update(
+                a for a, v in six.iteritems(assignments)
+                if v is not None
+            )
         if len(decision_set) == 0:
             decision_set, candidate_id = \
                 self._handle_empty_decision_set(assignments, clauses)
@@ -63,8 +69,6 @@ class InstalledFirstPolicy(IPolicy):
         assert assignments[candidate_id] is None, \
             "Trying to assign to a variable which is already assigned."
 
-        # Clear out decision set.
-        self._decision_set = set()
         return candidate_id
 
     def _group_packages_by_name(self, decision_set):

--- a/simplesat/tests/directly_implied_solution.yaml
+++ b/simplesat/tests/directly_implied_solution.yaml
@@ -27,6 +27,18 @@ packages:
   - numpy 1.8.1-3; depends (libgfortran ~= 3.0.0, MKL == 10.3-1)
   - numpy 1.9.2-1; depends (libgfortran ~= 3.0.0, MKL == 10.3-1)
 
+
+# There is only one possible solution. It should be found immediately via
+# propagation without any assumptions.
 request:
     - operation: "install"
       requirement: "numpy >= 1.9.2"
+
+
+transaction:
+    - kind: "install"
+      package: "libgfortran 3.0.0-2"
+    - kind: "install"
+      package: "MKL 10.3-1"
+    - kind: "install"
+      package: "numpy 1.9.2-1"

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -1,6 +1,6 @@
 import os.path
 
-from unittest import TestCase, expectedFailure
+from unittest import TestCase
 
 from egginst.errors import NoPackageFound
 from enstaller.new_solver import Pool
@@ -62,10 +62,10 @@ class ScenarioTestAssistant(object):
             self.fail("Length of operations differ")
 
 
-class TestNoInstallSet(TestCase, ScenarioTestAssistant):
-    @expectedFailure
-    def test_crash(self):
-        self._check_solution("crash.yaml")
+class TestNoInstallSet(ScenarioTestAssistant, TestCase):
+
+    def test_directly_implied_solution(self):
+        self._check_solution("directly_implied_solution.yaml")
 
     def test_simple_numpy(self):
         self._check_solution("simple_numpy.yaml")


### PR DESCRIPTION
The original `InstalledFirstPolicy` based on inspecting clauses used to crash if the state of any of the currently installed packages could be directly inferred from the requirements. This PR fixes that by simply filtering those packages out.

As an added bonus, this lets us preserve the `decision_set` across calls, which results in massive speedup. This is now the fastest policy.

Closes #42 and #52.

:sob: