### PR TITLE
Support removing packages

### DIFF
--- a/simplesat/rules_generator.py
+++ b/simplesat/rules_generator.py
@@ -315,9 +315,6 @@ class RulesGenerator(object):
         packages_all_versions = self._pool._packages_by_name[package.name]
         for other in packages_all_versions:
             self._add_package_rules(other)
-        rule = self._create_install_one_of_rule(
-            packages_all_versions, RuleType.package_installed)
-        self._add_rule(rule, "installed")
 
     def _add_job_rules(self):
         for job in self.request.jobs:

--- a/simplesat/tests/preserve_reverse_dependencies.yaml
+++ b/simplesat/tests/preserve_reverse_dependencies.yaml
@@ -1,0 +1,19 @@
+packages:
+    - requests 2.7.0-1
+    - browsey 1.1.0-1
+    - browsey 1.2.0-1; depends (requests ~= 2.7.0)
+
+installed:
+    - requests 2.7.0-1
+    - browsey 1.2.0-1
+
+request:
+    - operation: "remove"
+      requirement: "requests"
+
+transaction:
+  - kind: "update"
+    from: "browsey 1.2.0-1"
+    to: "browsey 1.1.0-1"
+  - kind: "remove"
+    package: "requests 2.7.0-1"

--- a/simplesat/tests/remove_reverse_dependencies.yaml
+++ b/simplesat/tests/remove_reverse_dependencies.yaml
@@ -1,0 +1,24 @@
+packages:
+    - MKL 10.2-1
+    - MKL 10.3-1
+    - numpy 1.6.1-1; depends (MKL == 10.2-1)
+    - numpy 1.7.1-1; depends (MKL == 10.3-1)
+    - numpy 1.8.1-1; depends (MKL == 10.3-1)
+    - pandas 1.0.0-1; depends (numpy == 1.6.1-1)
+
+installed:
+    - MKL 10.2-1
+    - numpy 1.6.1-1
+    - pandas 1.0.0-1
+
+request:
+    - operation: "remove"
+      requirement: "MKL"
+
+transaction:
+  - kind: "remove"
+    package: "pandas 1.0.0-1"
+  - kind: "remove"
+    package: "numpy 1.6.1-1"
+  - kind: "remove"
+    package: "MKL 10.2-1"

--- a/simplesat/tests/simple_numpy_removed.yaml
+++ b/simplesat/tests/simple_numpy_removed.yaml
@@ -11,4 +11,8 @@ installed:
 
 request:
     - operation: "remove"
-      requirement: "MKL"
+      requirement: "numpy"
+
+transaction:
+  - kind: "remove"
+    package: "numpy 1.6.1-1"

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -94,3 +94,6 @@ class TestInstallSet(TestCase, ScenarioTestAssistant):
 
     def test_blocked_downgrade(self):
         self._check_solution("simple_numpy_installed_blocking_downgrade.yaml")
+
+    def test_remove_no_reverse_dependencies(self):
+        self._check_solution("simple_numpy_removed.yaml")

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -101,3 +101,6 @@ class TestInstallSet(TestCase, ScenarioTestAssistant):
 
     def test_remove_no_reverse_dependencies(self):
         self._check_solution("simple_numpy_removed.yaml")
+
+    def test_remove_reverse_dependencies(self):
+        self._check_solution("remove_reverse_dependencies.yaml")

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -89,9 +89,13 @@ class TestInstallSet(TestCase, ScenarioTestAssistant):
     def test_ipython(self):
         self._check_solution("ipython_with_installed.yaml")
 
+    # This is not actually blocked until we support pinning packages
+    @expectedFailure
     def test_blocked_upgrade(self):
         self._check_solution("simple_numpy_installed_blocking.yaml")
 
+    # This is not actually blocked until we support pinning packages
+    @expectedFailure
     def test_blocked_downgrade(self):
         self._check_solution("simple_numpy_installed_blocking_downgrade.yaml")
 


### PR DESCRIPTION
This PR adds the ability to uninstall packages and their reverse dependencies.

It turns out this was already supported, but for reasons unclear to me extra rules were being generated to force all currently installed packages to remain so. I simply removed the call to create those rules.

Closes #43 