### PR TITLE
BUG: fix missing import in test case

### DIFF
--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -41,6 +41,7 @@ class InstalledFirstPolicy(IPolicy):
         """Get the next unassigned package.
         """
 
+        self._decision_set.update(self._installed_map)
         decision_set = self._decision_set
         # Remove everything that is currently assigned
         if len(decision_set) > 0:

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -1,6 +1,6 @@
 import os.path
 
-from unittest import TestCase
+from unittest import TestCase, expectedFailure
 
 from egginst.errors import NoPackageFound
 from enstaller.new_solver import Pool


### PR DESCRIPTION
I'm not sure how this made it through testing, but `expectedFailure` needs to be imported before we use it :)