### PR TITLE
Track the search path of the solver

### DIFF
--- a/scripts/solve.py
+++ b/scripts/solve.py
@@ -10,7 +10,7 @@ from simplesat.dependency_solver import DependencySolver
 
 
 def solve_and_print(request, remote_repositories, installed_repository,
-                    print_ids, prune=True):
+                    print_ids, prune=True, debug=False):
     pool = Pool(remote_repositories)
     pool.add_repository(installed_repository)
 
@@ -19,6 +19,8 @@ def solve_and_print(request, remote_repositories, installed_repository,
     transaction = solver.solve(request)
     print(transaction)
     print(solver._last_solve_time, file=sys.stderr)
+    if debug:
+        print(solver._policy._log_report(), file=sys.stderr)
 
 
 def main(argv=None):
@@ -27,13 +29,15 @@ def main(argv=None):
     p = argparse.ArgumentParser()
     p.add_argument("scenario", help="Path to the YAML scenario file.")
     p.add_argument("--print-ids", action="store_true")
-    p.add_argument("--no-prune", action="store_false")
+    p.add_argument("--no-prune", action="store_true")
+    p.add_argument("--debug", action="store_true")
 
     ns = p.parse_args(argv)
 
     scenario = Scenario.from_yaml(ns.scenario)
     solve_and_print(scenario.request, scenario.remote_repositories,
-                    scenario.installed_repository, ns.print_ids, ns.no_prune)
+                    scenario.installed_repository,
+                    ns.print_ids, prune=not ns.no_prune, debug=ns.debug)
 
 
 if __name__ == '__main__':

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -64,10 +64,10 @@ class DependencySolver(object):
             ]
             if len(requirement_ids) == 0:
                 raise NoPackageFound(str(requirement), requirement)
-            self._policy.add_packages_by_id(requirement_ids)
+            self._policy.add_requirements(requirement_ids)
 
         # Add installed packages.
-        self._policy.add_packages_by_id(
+        self._policy.add_requirements(
             [pool.package_id(package) for package in installed_repository]
         )
 

--- a/simplesat/sat/assignment_set.py
+++ b/simplesat/sat/assignment_set.py
@@ -7,7 +7,8 @@ import six
 
 
 class _MISSING(object):
-    pass
+    def __str__(self):
+        return '<MISSING>'
 MISSING = _MISSING()
 
 

--- a/simplesat/sat/clause.py
+++ b/simplesat/sat/clause.py
@@ -11,6 +11,7 @@ class Clause(Constraint):
 
     def __init__(self, lits, learned=False):
         self.learned = learned
+        # This maintains the ordering while removing duplicate values
         self.lits = list(OrderedDict.fromkeys(lits).keys())
 
     def rewatch(self, assignments, lit):

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -34,7 +34,12 @@ class DefaultPolicy(IPolicy):
         return undecided[0]
 
 
-class InstalledFirstPolicy(IPolicy):
+class UndeterminedClausePolicy(IPolicy):
+
+    """ An IPolicy that gathers all undetermined packages from clauses whose
+    truth value is not yet known and suggests them in descending order by
+    package version number. """
+
     def __init__(self, pool, installed_repository):
         self._pool = pool
         self._decision_set = set()
@@ -127,3 +132,6 @@ class InstalledFirstPolicy(IPolicy):
             return self._decision_set, -min(unassigned_ids)
         else:
             return self._decision_set, None
+
+
+InstalledFirstPolicy = UndeterminedClausePolicy

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -1,4 +1,5 @@
 import abc
+from collections import Counter
 
 import six
 
@@ -17,6 +18,94 @@ class IPolicy(six.with_metaclass(abc.ABCMeta)):
         """ Returns a undecided variable (i.e. integer > 0) for the given sets
         of assignements and clauses.
         """
+
+
+class PolicyLogger(IPolicy):
+
+    def __init__(self, policy):
+        self._policy = policy
+        self._log_pool = policy._pool
+        self._log_installed = policy._installed_ids.copy()
+        self._log_preferred = getattr(policy, '_preferred_ids', set()).copy()
+        self._log_required = []
+        self._log_suggestions = []
+        self._log_assignment_changes = []
+
+    def get_next_package_id(self, assignments, clauses):
+        self._log_assignment_changes.append(assignments.get_changelog())
+        pkg_id = self._policy.get_next_package_id(assignments, clauses)
+        self._log_suggestions.append(pkg_id)
+        assignments.consume_changelog()
+        return pkg_id
+
+    def add_requirements(self, package_ids):
+        self._log_required.extend(package_ids)
+        self._log_preferred.difference_update(package_ids)
+        self._log_installed.difference_update(package_ids)
+        self._policy.add_requirements(package_ids)
+
+    def _log_histogram(self, pkg_ids=None):
+        if pkg_ids is None:
+            pkg_ids = map(abs, self._log_suggestions)
+        c = Counter(pkg_ids)
+        lines = (
+            "{:>25} {}".format(self._log_pretty_pkg_id(k), v)
+            for k, v in c.most_common()
+        )
+        pretty = '\n'.join(lines)
+        return c, pretty
+
+    def _log_pretty_pkg_id(self, pkg_id):
+        package = self._log_pool._id_to_package[pkg_id]
+        name_ver = '{} {}'.format(package.name, package.version)
+        fill = '.' if pkg_id % 2 else ''
+        return "{:{fill}<30} {}".format(name_ver, pkg_id, fill=fill)
+
+    def _log_report(self, ids=None):
+
+        def pkg_name(pkg_id):
+            return pkg_key(pkg_id)[0]
+
+        def pkg_key(pkg_id):
+            pkg = self._log_pool._id_to_package[pkg_id]
+            return pkg.name, pkg.version
+
+        if ids is None:
+            ids = map(abs, self._log_suggestions)
+        report = []
+        changes = []
+        for pkg, change in self._log_assignment_changes[0].items():
+            name = self._log_pretty_pkg_id(pkg)
+            if change[1] is not None:
+                changes.append("{} : {}".format(name, change[1]))
+        report.append('\n'.join(changes))
+
+        required = set(self._log_required)
+        preferred = set(self._log_preferred)
+        installed = set(self._log_installed)
+        for (i, sugg) in enumerate(ids):
+            pretty = self._log_pretty_pkg_id(sugg)
+            R = 'R' if sugg in required else ' '
+            P = 'P' if sugg in preferred else ' '
+            I = 'I' if sugg in installed else ' '
+            changes = []
+            try:
+                items = self._log_assignment_changes[i + 1].items()
+                for pkg, change in sorted(items, key=lambda p: pkg_key(p[0])):
+                    if pkg_name(pkg) != pkg_name(sugg):
+                        _pretty = self._log_pretty_pkg_id(pkg)
+                        fro, to = map(str, change)
+                        msg = "{:10} - {:10} : {}"
+                        changes.append(msg.format(fro, to, _pretty))
+                if changes:
+                    changes = '\n\t\t'.join([''] + changes)
+                else:
+                    changes = ""
+            except IndexError:
+                changes = ""
+            msg = "{:>4} {}{}{} - {}{}"
+            report.append(msg.format(i, R, P, I, pretty, changes))
+        return '\n'.join(report)
 
 
 class DefaultPolicy(IPolicy):
@@ -133,5 +222,7 @@ class UndeterminedClausePolicy(IPolicy):
         else:
             return self._decision_set, None
 
+def LoggedUndeterminedClausePolicy(pool, installed_repository):
+    return PolicyLogger(UndeterminedClausePolicy(pool, installed_repository))
 
-InstalledFirstPolicy = UndeterminedClausePolicy
+InstalledFirstPolicy = LoggedUndeterminedClausePolicy

--- a/simplesat/tests/ipython.yaml
+++ b/simplesat/tests/ipython.yaml
@@ -1,7 +1,7 @@
 packages:
     - appinst 2.1.0-1
     - appinst 2.1.2-1
-    - AppInst 2.0.4-1
+    - appInst 2.0.4-1
     - appinst 2.1.1-1
     - tornado 4.0.2-1; depends (ssl_match_hostname ~= 3.4.0.2)
     - tornado 3.1.1-1

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -1,6 +1,7 @@
 import os.path
-
 from unittest import TestCase, expectedFailure
+
+import six
 
 from egginst.errors import NoPackageFound
 from enstaller.new_solver import Pool
@@ -8,6 +9,32 @@ from enstaller.new_solver import Pool
 from simplesat.errors import SatisfiabilityError
 from simplesat.dependency_solver import DependencySolver
 from .common import Scenario
+
+
+def _pretty_operations(ops):
+    ret = []
+    for p in ops:
+        try:
+            name = p.package.name
+            version = str(p.package.version)
+        except AttributeError:
+            name, version = p.package.split()
+        ret.append((name, version))
+    return ret
+
+
+def _pkg_delta(operations, scenario_operations):
+    pkg_delta = {}
+    for p in operations:
+        name, version = _pretty_operations([p])[0]
+        pkg_delta.setdefault(name, [None, None])[0] = version
+    for p in scenario_operations:
+        name, version = _pretty_operations([p])[0]
+        pkg_delta.setdefault(name, [None, None])[1] = version
+    for n, v in list(six.iteritems(pkg_delta)):
+        if v[0] == v[1]:
+            pkg_delta.pop(n)
+    return pkg_delta
 
 
 class ScenarioTestAssistant(object):

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -73,7 +73,8 @@ class ScenarioTestAssistant(object):
                                        scenario.operations)
 
     def assertEqualOperations(self, operations, scenario_operations):
-        for i, (left, right) in enumerate(zip(operations, scenario_operations)):
+        pairs = zip(operations, scenario_operations)
+        for i, (left, right) in enumerate(pairs):
             if not type(left) == type(right):
                 msg = "Item {0!r} differ in kinds: {1!r} vs {2!r}"
                 self.fail(msg.format(i, type(left), type(right)))
@@ -108,7 +109,7 @@ class TestNoInstallSet(ScenarioTestAssistant, TestCase):
             self._check_solution("no_candidate.yaml")
 
 
-class TestInstallSet(TestCase, ScenarioTestAssistant):
+class TestInstallSet(ScenarioTestAssistant, TestCase):
 
     def test_simple_numpy(self):
         self._check_solution("simple_numpy_installed.yaml")


### PR DESCRIPTION
Adds a `PolicyLogger` class which tracks the suggestions of a Policy and the effect that they have on the assignments. This gives us a crude way to mentally retrace the path that the SAT solver took through the problem. It helps with identifying why particular decisions were made along the way, such as which suggested package forced a particular decision and when.

It should have no effect on the results themselves or the outcome of any testing.