### PR TITLE
Speed up the UndeterminedClausePolicy

### DIFF
--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -66,11 +66,6 @@ class DependencySolver(object):
                 raise NoPackageFound(str(requirement), requirement)
             self._policy.add_requirements(requirement_ids)
 
-        # Add installed packages.
-        self._policy.add_requirements(
-            [pool.package_id(package) for package in installed_repository]
-        )
-
         installed_map = collections.OrderedDict()
         for package in installed_repository:
             installed_map[pool.package_id(package)] = package

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -124,11 +124,11 @@ class DefaultPolicy(IPolicy):
     def get_next_package_id(self, assignments, _):
         # Given a dictionary of partial assignments, get an undecided variable
         # to be decided next.
-        undecided = [
+        undecided = (
             package_id for package_id, status in six.iteritems(assignments)
             if status is None
-        ]
-        return undecided[0]
+        )
+        return next(undecided)
 
 
 class UndeterminedClausePolicy(IPolicy):

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -16,7 +16,15 @@ class IPolicy(six.with_metaclass(abc.ABCMeta)):
     @abc.abstractmethod
     def get_next_package_id(self, assignments, clauses):
         """ Returns a undecided variable (i.e. integer > 0) for the given sets
-        of assignements and clauses.
+        of assignments and clauses.
+
+        Parameters
+        ----------
+        assignments : AssignmentSet
+            The current assignments of each literal. Keys are variables
+            (integer > 0) and values are one of (True, False, None).
+        clauses : List of Clause
+            The collection of Clause objects to satisfy.
         """
 
 

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -135,3 +135,8 @@ class TestInstallSet(ScenarioTestAssistant, TestCase):
 
     def test_remove_reverse_dependencies(self):
         self._check_solution("remove_reverse_dependencies.yaml")
+
+    # We haven't clearly laid out how this should behave yet
+    @expectedFailure
+    def test_update_reverse_dependencies(self):
+        self._check_solution("update_reverse_dependencies.yaml")

--- a/simplesat/tests/update_reverse_dependencies.yaml
+++ b/simplesat/tests/update_reverse_dependencies.yaml
@@ -1,0 +1,67 @@
+packages:
+  - A 0.0.0-1; depends (C ~= 0.0.0)
+  - A 3.0.0-1; depends (G ~= 1.0.0)
+  - B 0.0.0-1; depends (D ~= 0.0.0)
+  - B 1.0.0-1
+  - C 0.0.0-1
+  - D 0.0.0-1
+  - E 0.0.0-1; depends (A ~= 0.0.0)
+  - E 1.0.0-1; depends (I ~= 0.0.0, B ~= 1.0.0-1)
+  - F 0.0.0-1
+  - G 1.0.0-1
+  - I 0.0.0-1; depends (J ~= 0.0.0)
+  - J 0.0.0-1
+  - X 0.0.0-1; depends (A ~= 0.0.0, B ~= 0.0.0)
+  - X 1.0.0-1; depends (A ~= 3.0.0, B ~= 1.0.0)
+  - Y 0.0.0-1; depends (X ~= 0.0.0)
+  - Y 1.0.0-1
+    # This drags F in, even though Y 2.0.0 isn't in the solution
+  - Y 2.0.0-1; depends (F ~= 0.0.0)
+  - Y 3.0.0-1; depends (X ~= 1.0.0)
+    # None of our direct requirements depend or reverse-depend on Z, but it
+    # must not be pruned
+  - Z 0.0.0-1; depends (E ~= 0.0.0)
+  - Z 1.0.0-1; depends (E ~= 1.0.0)
+
+
+request:
+  - operation: "install"
+    requirement: "E ~= 1.0.0"
+
+
+installed:
+  - A 0.0.0-1
+  - B 0.0.0-1
+  - C 0.0.0-1
+  - D 0.0.0-1
+  - E 0.0.0-1
+  - X 0.0.0-1
+  - Y 0.0.0-1
+  - Z 0.0.0-1
+
+
+transaction:
+  - kind: "install"
+    package: "J 0.0.0-1"
+  - kind: "install"
+    package: "I 0.0.0-1"
+  - kind: "update"
+    from: "B 0.0.0-1"
+    to: "B 1.0.0-1"
+  - kind: "update"
+    from: "E 0.0.0-1"
+    to: "E 1.0.0-1"
+  - kind: "update"
+    from: "Z 0.0.0-1"
+    to: "Z 1.0.0-1"
+  - kind: "install"
+    package: "G 1.0.0-1"
+  - kind: "update"
+    from: "A 0.0.0-1"
+    to: "A 3.0.0-1"
+  - kind: "update"
+    from: "X 0.0.0-1"
+    to: "X 1.0.0-1"
+  - kind: "update"
+    from: "Y 0.0.0-1"
+    to: "Y 3.0.0-1"


### PR DESCRIPTION
This PR was extracted from #65. It tries to improve on the `UndeterminedClausePolicy` by computing as little as possible with each request for a new suggested package and then reusing as much of the result as possible.

It does change the behavior slightly, but since the old behavior was quite wrong anyway, I'm not worried about preserving it.

The goal right now is to get this into a usable state. From there we can worry about nuanced behavior.