### PR TITLE
Add marked packages to scenarios

### DIFF
--- a/simplesat/test_utils.py
+++ b/simplesat/test_utils.py
@@ -99,16 +99,19 @@ class Scenario(object):
         packages = collections.OrderedDict(
             parse_package_list(data.get("packages", []))
         )
-        operations = data.get("request", [])
+        scenario_requests = data.get("request", [])
 
-        marked = set(data.get("marked", []))
+        marked = list(data.get("marked", []))
 
         request = Request()
 
-        for operation in operations:
-            kind = operation["operation"]
-            requirement = Requirement._from_string(operation["requirement"])
-            marked.discard(requirement.name)
+        for s_request in scenario_requests:
+            kind = s_request["operation"]
+            requirement = Requirement._from_string(s_request["requirement"])
+            try:
+                marked.remove(requirement.name)
+            except ValueError:
+                pass
             getattr(request, kind)(requirement)
 
         for package_str in marked:

--- a/simplesat/test_utils.py
+++ b/simplesat/test_utils.py
@@ -5,7 +5,7 @@ import six
 import yaml
 
 from enstaller import Repository
-from enstaller.new_solver import Pool, Requirement
+from enstaller.new_solver import Requirement
 from enstaller.new_solver.package_parser import PrettyPackageStringParser
 from enstaller.package import RepositoryPackageMetadata
 from enstaller.repository_info import BroodRepositoryInfo
@@ -87,6 +87,7 @@ def installed_repository(yaml_data, packages):
 
 
 class Scenario(object):
+
     @classmethod
     def from_yaml(cls, file_or_filename):
         if isinstance(file_or_filename, six.string_types):
@@ -153,4 +154,3 @@ class Scenario(object):
             package = pool._id_to_package[package_id]
             print("{}: {} {}".format(package_id, package.name,
                                      package.full_version))
-

--- a/simplesat/test_utils.py
+++ b/simplesat/test_utils.py
@@ -100,12 +100,18 @@ class Scenario(object):
         )
         operations = data.get("request", [])
 
+        marked = set(data.get("marked", []))
+
         request = Request()
 
         for operation in operations:
             kind = operation["operation"]
             requirement = Requirement._from_string(operation["requirement"])
+            marked.discard(requirement.name)
             getattr(request, kind)(requirement)
+
+        for package_str in marked:
+            request.install(Requirement._from_string(package_str))
 
         decisions = data.get("decisions", {})
 

--- a/simplesat/tests/preserve_marked.yaml
+++ b/simplesat/tests/preserve_marked.yaml
@@ -7,6 +7,9 @@ installed:
     - requests 2.7.0-1
     - browsey 1.2.0-1
 
+marked:
+    - browsey
+
 request:
     - operation: "remove"
       requirement: "requests"

--- a/simplesat/tests/remove_marked_package.yaml
+++ b/simplesat/tests/remove_marked_package.yaml
@@ -1,0 +1,31 @@
+# Downgrade possible because requests can override marking
+packages:
+    - MKL 10.2-1
+    - MKL 10.3-1
+    - EPD_free 7.4-1; depends (MKL == 10.3-1, numpy == 1.8.1-1)
+    - numpy 1.7.1-1; depends (MKL == 10.2-1)
+    - numpy 1.8.1-1; depends (MKL == 10.3-1)
+
+marked:
+    - EPD_free
+
+request:
+    - operation: "remove"
+      requirement: "EPD_free"
+    - operation: "install"
+      requirement: "numpy < 1.8"
+
+installed:
+    - EPD_free 7.4-1
+    - MKL 10.3-1
+    - numpy 1.8.1-1
+
+transaction:
+    - kind: "update"
+      from: "MKL 10.3-1"
+      to: "MKL 10.2-1"
+    - kind: "update"
+      from: "numpy 1.8.1-1"
+      to: "numpy 1.7.1-1"
+    - kind: "remove"
+      package: "EPD_free 7.4-1"

--- a/simplesat/tests/simple_numpy_installed_blocking.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking.yaml
@@ -6,6 +6,9 @@ packages:
     - numpy 1.7.1-1; depends (MKL == 10.2-1)
     - numpy 1.8.1-1; depends (MKL == 10.3-1)
 
+marked:
+    - EPD_free
+
 request:
     - operation: "install"
       requirement: "numpy > 1.8"

--- a/simplesat/tests/simple_numpy_installed_blocking_downgrade.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking_downgrade.yaml
@@ -6,6 +6,9 @@ packages:
     - numpy 1.7.1-1; depends (MKL == 10.2-1)
     - numpy 1.8.1-1; depends (MKL == 10.3-1)
 
+marked:
+    - EPD_free
+
 request:
     - operation: "install"
       requirement: "numpy < 1.8"

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -136,3 +136,6 @@ class TestInstallSet(ScenarioTestAssistant, TestCase):
 
     def test_preserve_marked_packages(self):
         self._check_solution("preserve_marked.yaml")
+
+    def test_remove_marked_packages(self):
+        self._check_solution("remove_marked_package.yaml")

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -135,3 +135,6 @@ class TestInstallSet(ScenarioTestAssistant, TestCase):
 
     def test_remove_reverse_dependencies(self):
         self._check_solution("remove_reverse_dependencies.yaml")
+
+    def test_preserve_marked_packages(self):
+        self._check_solution("preserve_marked.yaml")

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -1,5 +1,5 @@
 import os.path
-from unittest import TestCase, expectedFailure
+from unittest import TestCase
 
 import six
 
@@ -120,13 +120,11 @@ class TestInstallSet(ScenarioTestAssistant, TestCase):
     def test_ipython(self):
         self._check_solution("ipython_with_installed.yaml")
 
-    # This is not actually blocked until we support pinning packages
-    @expectedFailure
+    # This is currently handled using marked packages
     def test_blocked_upgrade(self):
         self._check_solution("simple_numpy_installed_blocking.yaml")
 
-    # This is not actually blocked until we support pinning packages
-    @expectedFailure
+    # This is currently handled using marked packages
     def test_blocked_downgrade(self):
         self._check_solution("simple_numpy_installed_blocking_downgrade.yaml")
 

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -56,8 +56,6 @@ class ScenarioTestAssistant(object):
             pool, scenario.remote_repositories, scenario.installed_repository
         )
 
-        solver._policy._log_report()
-
         # Then
         try:
             transaction = solver.solve(request)

--- a/simplesat/tests/test_test_utils.py
+++ b/simplesat/tests/test_test_utils.py
@@ -39,7 +39,7 @@ class TestRepositoryFactory(unittest.TestCase):
         repository_info = BroodRepositoryInfo("https://acme.com", "acme/loony")
         r_numpy = P(
             "numpy 1.8.1-2; depends (MKL ~= 10.3)", repository_info,
-             PythonImplementation.from_running_python()
+            PythonImplementation.from_running_python()
         )
 
         # When

--- a/simplesat/tests/test_test_utils.py
+++ b/simplesat/tests/test_test_utils.py
@@ -121,3 +121,55 @@ class TestScenario(unittest.TestCase):
 
         jobs = scenario.request.jobs
         self.assertEqual(jobs, r_jobs)
+
+    def test_simple_marked(self):
+        # Given
+        yaml = StringIO(textwrap.dedent("""\
+        packages:
+            - MKL 10.3-1
+
+        remote:
+            - MKL 10.3-1
+
+        installed:
+            - MKL 10.3-1
+
+        marked:
+            - MKL
+        """))
+        r_jobs = [_Job(Requirement._from_string("MKL"), JobType.install)]
+
+        # When
+        scenario = Scenario.from_yaml(yaml)
+
+        # Then
+        jobs = scenario.request.jobs
+        self.assertEqual(jobs, r_jobs)
+
+    def test_modify_marked(self):
+        # Given
+        yaml = StringIO(textwrap.dedent("""\
+        packages:
+            - MKL 10.3-1
+
+        remote:
+            - MKL 10.3-1
+
+        installed:
+            - MKL 10.3-1
+
+        marked:
+            - MKL
+
+        request:
+            - operation: remove
+              requirement: MKL
+        """))
+        r_jobs = [_Job(Requirement._from_string("MKL"), JobType.remove)]
+
+        # When
+        scenario = Scenario.from_yaml(yaml)
+
+        # Then
+        jobs = scenario.request.jobs
+        self.assertEqual(jobs, r_jobs)


### PR DESCRIPTION
This is based on #82 

This adds support for a `marked` list to the `Scenario` and a few tests for it.

This helps define explicit what behavior should be. If a package is marked then some version of it *must* remain installed. If it is not marked and not involved in a request, then whether or not the package will be removed is unspecified.