### PR TITLE
BUG: prefer installed packages over remote for same version

### DIFF
--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -1,5 +1,4 @@
 import collections
-from operator import attrgetter
 
 import six
 
@@ -76,7 +75,9 @@ class DependencySolver(object):
 
             if job.kind == JobType.update:
                 # An update request *must* install the latest package version
-                providers = [max(providers, key=attrgetter('version'))]
+                def key(package):
+                    return (package.version, package in installed_repository)
+                providers = [max(providers, key=key)]
 
             requirement_ids = [pool.package_id(p) for p in providers]
             self._policy.add_requirements(requirement_ids)

--- a/simplesat/rules_generator.py
+++ b/simplesat/rules_generator.py
@@ -1,6 +1,5 @@
 import collections
 import enum
-from operator import attrgetter
 
 from enstaller.errors import EnstallerException
 
@@ -316,7 +315,10 @@ class RulesGenerator(object):
         if len(packages) == 0:
             return
         # An update request *must* install the latest package version
-        package = max(packages, key=attrgetter('version'))
+        def key(package):
+            installed = self._pool.package_id(package) in self.installed_map
+            return (package.version, installed)
+        package = max(packages, key=key)
         self._add_package_rules(package)
         rule = PackageRule(
             (self._pool.package_id(package),),

--- a/simplesat/tests/test_rules_generator.py
+++ b/simplesat/tests/test_rules_generator.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import io
+import unittest
+
+from enstaller.new_solver import Pool
+
+from ..rules_generator import RuleType, RulesGenerator
+from ..test_utils import Scenario
+
+
+class TestRulesGenerator(unittest.TestCase):
+
+    def test_prefer_installed(self):
+
+        self.yaml = """
+            packages:
+                - A 1.0.0-1
+            installed:
+                - A 1.0.0-1
+            marked:
+                - A
+            request:
+                - operation: "update_all"
+        """
+
+        scenario = Scenario.from_yaml(io.StringIO(self.yaml))
+        repos = list(scenario.remote_repositories)
+        repos.append(scenario.installed_repository)
+        pool = Pool(repos)
+        installed_map = {
+            pool.package_id(p): p for p in scenario.installed_repository}
+        rules_generator = RulesGenerator(pool, scenario.request, installed_map)
+        rules = list(rules_generator.iter_rules())
+
+        self.assertEqual(len(rules), 2)
+
+        (one_of, update) = rules
+        self.assertEqual(update.reason, RuleType.job_update)
+        self.assertEqual(one_of.reason, RuleType.package_same_name)
+
+        (pkg_id,) = update.literals
+        package = pool._id_to_package[pkg_id]
+
+        self.assertEqual(package.repository_info.name, "installed")

--- a/simplesat/tests/test_rules_generator.py
+++ b/simplesat/tests/test_rules_generator.py
@@ -14,7 +14,7 @@ class TestRulesGenerator(unittest.TestCase):
 
     def test_prefer_installed(self):
 
-        self.yaml = """
+        self.yaml = u"""
             packages:
                 - A 1.0.0-1
             installed:
@@ -33,14 +33,16 @@ class TestRulesGenerator(unittest.TestCase):
             pool.package_id(p): p for p in scenario.installed_repository}
         rules_generator = RulesGenerator(pool, scenario.request, installed_map)
         rules = list(rules_generator.iter_rules())
+        updates = [r for r in rules if r.reason == RuleType.job_update]
 
-        self.assertEqual(len(rules), 2)
+        self.assertEqual(len(updates), 1)
 
-        (one_of, update) = rules
+        update = updates[0]
+
         self.assertEqual(update.reason, RuleType.job_update)
-        self.assertEqual(one_of.reason, RuleType.package_same_name)
+        self.assertEqual(len(update.literals), 1)
 
-        (pkg_id,) = update.literals
+        pkg_id = update.literals[0]
         package = pool._id_to_package[pkg_id]
 
         self.assertEqual(package.repository_info.name, "installed")

--- a/simplesat/tests/test_rules_generator.py
+++ b/simplesat/tests/test_rules_generator.py
@@ -36,10 +36,10 @@ class TestRulesGenerator(unittest.TestCase):
         rules = list(rules_generator.iter_rules())
 
         # Then
-        self.assertEqual(len(rules), 1)
+        self.assertEqual(len(rules), 2)
 
         # Given/When
-        update = rules[0]
+        update = rules[1]
 
         # Then
         self.assertEqual(update.reason, RuleType.job_update)

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -149,6 +149,9 @@ class TestInstallSet(ScenarioTestAssistant, TestCase):
     def test_update_all_conflict(self):
         self._check_solution("update_all_conflict.yaml")
 
+    def test_update_all_noop(self):
+        self._check_solution("update_all_noop.yaml")
+
     def test_ipython_upgrade(self):
         self._check_solution("ipython_upgrade.yaml")
 

--- a/simplesat/tests/update_all_noop.yaml
+++ b/simplesat/tests/update_all_noop.yaml
@@ -1,0 +1,2709 @@
+packages:
+  - _distribute_remove 1.0.0-1
+  - abstract_rendering 0.5.1-1
+  - agw 0.9.1-1
+  - alabaster 0.7.3-1
+  - alabaster 0.7.6-1
+  - amqp 1.4.5-1
+  - aniso8601 0.92-1
+  - anyjson 0.3.3-2
+  - anyjson 0.3.3-3
+  - apipkg 1.4-1
+  - appinst 2.0.4-1
+  - appinst 2.1.0-1
+  - appinst 2.1.1-1
+  - appinst 2.1.2-1
+  - appinst 2.1.5-1
+  - apptools 3.4.1-1; depends (configobj)
+  - apptools 4.0.0-1; depends (configobj)
+  - apptools 4.0.1-1; depends (configobj)
+  - apptools 4.1.0-1; depends (configobj)
+  - apptools 4.2.0-1; depends (configobj)
+  - apptools 4.2.0-2; depends (envisage ~= 4.3.0, configobj, traitsui ~= 4.3.0)
+  - apptools 4.2.0-4; depends (envisage ~= 4.4.0, configobj, traitsui ~= 4.4.0)
+  - apptools 4.2.1-1; depends (envisage ~= 4.4.0, configobj, traitsui ~= 4.4.0)
+  - apptools 4.2.1-2; depends (traitsui ~= 4.4.0, envisage ~= 4.4.0, configobj ~= 5.0.5)
+  - apptools 4.2.1-3; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 4.4.0)
+  - apptools 4.3.0-1; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 4.4.0)
+  - apptools 4.3.0-2; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 4.4.0)
+  - apptools 4.3.0-3; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 4.5.1)
+  - apptools 4.3.0-4; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 4.5.1)
+  - apptools 4.3.0-5; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 4.5.1)
+  - apptools 4.3.0-6; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 4.5.1)
+  - apptools 4.3.0-7; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 5.0.0)
+  - apptools 4.3.0-8; depends (configobj ~= 5.0.6, envisage ~= 4.4.0, traitsui ~= 5.0.0)
+  - arch 3.0-2; depends (matplotlib ~= 1.4.3, scipy ~= 0.15.1)
+  - arch 3.0-3; depends (matplotlib ~= 1.4.3, six ~= 1.9.0, scipy ~= 0.15.1)
+  - arch 3.0-4; depends (matplotlib ~= 1.4.3, six ~= 1.9.0, scipy ~= 0.15.1)
+  - arch 3.0-5; depends (matplotlib ~= 1.4.3, six ~= 1.9.0, scipy ~= 0.15.1)
+  - arch 3.0-6; depends (scipy ~= 0.16.0, matplotlib ~= 1.4.3, six ~= 1.9.0)
+  - arch 3.0-7; depends (scipy ~= 0.16.0, matplotlib ~= 1.4.3, six ~= 1.10.0)
+  - arch 3.0-9; depends (scipy ~= 0.16.1, matplotlib ~= 1.4.3, six ~= 1.10.0)
+  - arch 3.0-10; depends (matplotlib ~= 1.5.0, scipy ~= 0.16.1, six ~= 1.10.0)
+  - arch 3.0-11; depends (matplotlib ~= 1.5.0, scipy ~= 0.16.1, six ~= 1.10.0)
+  - argcomplete 0.8.1-1
+  - argcomplete 0.8.3-1
+  - argcomplete 0.8.4-1
+  - argcomplete 0.8.9-1
+  - argcomplete 1.0.0-1
+  - astropy 0.2.4-1; depends (numpy ~= 1.7.1)
+  - astropy 0.2.4-2; depends (numpy ~= 1.8.0)
+  - astropy 0.3.0-1; depends (numpy ~= 1.8.0)
+  - astropy 0.3.2-1; depends (numpy ~= 1.8.0)
+  - astropy 0.3.2-2; depends (numpy ~= 1.8.1)
+  - astropy 0.4.1-1; depends (numpy ~= 1.8.1)
+  - astropy 0.4.2-1; depends (numpy ~= 1.8.1)
+  - astropy 0.4.4-1; depends (numpy ~= 1.8.1)
+  - astropy 1.0-1; depends (numpy ~= 1.8.1)
+  - astropy 1.0.1-1; depends (numpy ~= 1.8.1)
+  - astropy 1.0.2-1; depends (numpy ~= 1.8.1)
+  - astropy 1.0.2-2; depends (numpy ~= 1.9.2)
+  - astropy 1.0.3-1; depends (numpy ~= 1.9.2)
+  - astropy 1.0.4-1; depends (numpy ~= 1.9.2)
+  - astropy 1.0.4-2; depends (numpy ~= 1.9.2)
+  - astropy 1.0.7-1; depends (numpy ~= 1.9.2)
+  - atom 0.3.5-1
+  - atom 0.3.8-1
+  - atom 0.3.9-1
+  - attrs 15.1.0-1
+  - attrs 15.2.0-1
+  - babel 1.3-1; depends (pytz ~= 2014.9.0)
+  - babel 2.1.1-1; depends (pytz ~= 2014.9.0)
+  - backports.lzma 0.0.3-1; depends (xz ~= 5.2.2, backports_lzma_remove ~= 1.0.0)
+  - backports_abc 0.4-1
+  - backports_lzma 0.0.3-1; depends (xz ~= 5.2.2)
+  - backports_lzma_remove 1.0.0-1
+  - basemap 1.0-2; depends (numpy ~= 1.5.1, matplotlib ~= 1.0.1)
+  - basemap 1.0-3; depends (numpy ~= 1.6.0, matplotlib ~= 1.0.1)
+  - basemap 1.0.1-1; depends (numpy ~= 1.6.0, matplotlib ~= 1.0.1)
+  - basemap 1.0.1-2; depends (numpy ~= 1.6.1, matplotlib ~= 1.0.1)
+  - basemap 1.0.1-3; depends (matplotlib ~= 1.1.0, numpy ~= 1.6.1)
+  - basemap 1.0.2-1; depends (matplotlib ~= 1.1.0, numpy ~= 1.6.1)
+  - basemap 1.0.6-1; depends (matplotlib ~= 1.2.0, numpy ~= 1.6.1)
+  - basemap 1.0.6-2; depends (matplotlib ~= 1.2.0, numpy ~= 1.6.1)
+  - basemap 1.0.6-3; depends (matplotlib ~= 1.2.0, numpy ~= 1.7.1)
+  - basemap 1.0.6-4; depends (matplotlib ~= 1.2.1, numpy ~= 1.7.1)
+  - basemap 1.0.6-5; depends (matplotlib ~= 1.3.0, numpy ~= 1.7.1)
+  - basemap 1.0.6-6; depends (matplotlib ~= 1.3.1, numpy ~= 1.7.1)
+  - basemap 1.0.6-7; depends (numpy ~= 1.8.0, matplotlib ~= 1.3.1)
+  - basemap 1.0.7-1; depends (numpy ~= 1.8.0, matplotlib ~= 1.3.1)
+  - basemap 1.0.7-2; depends (matplotlib ~= 1.3.1, numpy ~= 1.8.1)
+  - basemap 1.0.7-3; depends (matplotlib ~= 1.4.0, numpy ~= 1.8.1)
+  - basemap 1.0.7-4; depends (geos ~= 3.4.2, matplotlib ~= 1.4.0, numpy ~= 1.8.1)
+  - basemap 1.0.7-5; depends (geos ~= 3.4.2, matplotlib ~= 1.4.2, numpy ~= 1.8.1)
+  - basemap 1.0.7-6; depends (geos ~= 3.4.2, matplotlib ~= 1.4.3, numpy ~= 1.8.1)
+  - basemap 1.0.7-7; depends (geos ~= 3.4.2, matplotlib ~= 1.4.3, numpy ~= 1.9.2)
+  - basemap 1.0.7-8; depends (geos ~= 3.4.2, matplotlib ~= 1.5.0, numpy ~= 1.9.2)
+  - basemap 1.0.7-9; depends (geos ~= 3.5.0, matplotlib ~= 1.5.0, numpy ~= 1.9.2)
+  - basemap_ld 1.0.1-1; depends (basemap ~= 1.0.1)
+  - basemap_ld 1.0.2-1; depends (basemap ~= 1.0.2)
+  - basemap_ld 1.0.6-1; depends (basemap ~= 1.0.6)
+  - basemap_ld 1.0.7-1; depends (basemap ~= 1.0.7)
+  - bcolz 0.7.1-1; depends (numpy ~= 1.8.1)
+  - bcolz 0.7.2-1; depends (numpy ~= 1.8.1)
+  - bcolz 0.8.0-1; depends (numpy ~= 1.8.1, libblosc ~= 1.4.1)
+  - bcolz 0.8.1-1; depends (numpy ~= 1.8.1, libblosc ~= 1.4.1)
+  - bcolz 0.8.1-2; depends (numpy ~= 1.9.2, libblosc ~= 1.4.1)
+  - bcolz 0.9.0-1; depends (numpy ~= 1.9.2, libblosc ~= 1.4.1)
+  - bcolz 0.10.0-1; depends (numpy ~= 1.9.2, libblosc ~= 1.4.1)
+  - bcolz 0.11.3-1; depends (numpy ~= 1.9.2)
+  - bcolz 0.11.3-2; depends (numpy ~= 1.9.2)
+  - bcolz 0.11.3-3; depends (numpy ~= 1.9.2)
+  - bcrypt 1.0.2-1; depends (cffi ~= 0.8.6)
+  - bcrypt 1.0.2-2; depends (cffi ~= 0.9.2)
+  - bcrypt 1.0.2-3; depends (cffi ~= 1.0.3)
+  - bcrypt 1.0.2-4; depends (cffi ~= 1.1.2)
+  - bcrypt 1.0.2-5; depends (cffi ~= 1.2.1)
+  - bcrypt 1.0.2-6; depends (cffi ~= 1.2.1)
+  - bcrypt 1.0.2-7; depends (cffi ~= 1.2.1)
+  - bcrypt 1.0.2-8; depends (cffi ~= 1.3.1)
+  - beautifulsoup4 4.3.2-1; depends (html5lib ~= 0.999, lxml ~= 3.4.0)
+  - beautifulsoup4 4.3.2-2; depends (html5lib ~= 0.999, lxml ~= 3.4.1)
+  - beautifulsoup4 4.3.2-3; depends (lxml ~= 3.4.2, html5lib ~= 0.999)
+  - beautifulsoup4 4.3.2-4; depends (lxml ~= 3.4.3, html5lib ~= 0.999)
+  - beautifulsoup4 4.3.2-5; depends (lxml ~= 3.4.4, html5lib ~= 0.999)
+  - biggus 0.7.0-1; depends (numpy ~= 1.8.1, pep8 ~= 1.5.7)
+  - biggus 0.7.0-2; depends (numpy ~= 1.8.1, pep8 ~= 1.5.7)
+  - biggus 0.7.0-3; depends (numpy ~= 1.8.1, pep8 ~= 1.6.1)
+  - biggus 0.7.0-4; depends (numpy ~= 1.8.1, pep8 ~= 1.6.2)
+  - biggus 0.7.0-5; depends (numpy ~= 1.9.2, pep8 ~= 1.6.2)
+  - billiard 3.3.0.18-1
+  - billiard 3.3.0.18-2
+  - biopython 1.56-1; depends (numpy ~= 1.5.1)
+  - biopython 1.57-1; depends (numpy ~= 1.5.1)
+  - biopython 1.57-2; depends (numpy ~= 1.6.0)
+  - biopython 1.57-3; depends (numpy ~= 1.6.1)
+  - biopython 1.58-1; depends (numpy)
+  - biopython 1.59-1; depends (numpy)
+  - biopython 1.59-2; depends (numpy)
+  - biopython 1.59-3; depends (numpy)
+  - biopython 1.62.0-1; depends (numpy ~= 1.8.0)
+  - biopython 1.64.0-1; depends (numpy ~= 1.8.0)
+  - biopython 1.64.0-2; depends (numpy ~= 1.8.1)
+  - biopython 1.65-1; depends (numpy ~= 1.8.1)
+  - biopython 1.65-2; depends (numpy ~= 1.9.2)
+  - biopython 1.66-1; depends (numpy ~= 1.9.2)
+  - bitarray 0.3.5-3
+  - bitarray 0.5.0-1
+  - bitarray 0.5.1-1
+  - bitarray 0.5.2-1
+  - bitarray 0.6.0-1
+  - bitarray 0.7.0-1
+  - bitarray 0.8.0-1
+  - bitarray 0.8.1-1
+  - blaze 0.7.0-1; depends (datashape ~= 0.4.2, numpy ~= 1.8.1, h5py ~= 2.4.0, numba ~= 0.15.1, bcolz ~= 0.7.2, flask ~= 0.10.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, into ~= 0.1.3, pymongo ~= 2.7.2, requests ~= 2.5.1, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1, psutil ~= 2.2.0)
+  - blaze 0.7.0-2; depends (into ~= 0.1.4, datashape ~= 0.4.2, numpy ~= 1.8.1, h5py ~= 2.4.0, numba ~= 0.15.1, bcolz ~= 0.7.2, flask ~= 0.10.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, pymongo ~= 2.7.2, requests ~= 2.5.1, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1, psutil ~= 2.2.0)
+  - blaze 0.7.0-3; depends (into ~= 0.1.4, datashape ~= 0.4.2, bcolz ~= 0.8.0, numba ~= 0.17.0, numpy ~= 1.8.1, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, pymongo ~= 2.7.2, requests ~= 2.5.1, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1, psutil ~= 2.2.0)
+  - blaze 0.7.0-4; depends (datashape ~= 0.4.2, bcolz ~= 0.8.0, numba ~= 0.17.0, into ~= 0.2.1, numpy ~= 1.8.1, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, pymongo ~= 2.7.2, requests ~= 2.5.1, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1, psutil ~= 2.2.0)
+  - blaze 0.7.2-1; depends (bcolz ~= 0.8.0, datashape ~= 0.4.3, numba ~= 0.17.0, numpy ~= 1.8.1, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, into ~= 0.2.2, python_dateutil ~= 2.2.0, pymongo ~= 2.7.2, requests ~= 2.5.1, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1, psutil ~= 2.2.0)
+  - blaze 0.7.2-2; depends (psutil ~= 2.2.1, bcolz ~= 0.8.0, datashape ~= 0.4.3, numba ~= 0.17.0, numpy ~= 1.8.1, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, into ~= 0.2.2, python_dateutil ~= 2.2.0, requests ~= 2.5.1, pymongo ~= 2.8, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - blaze 0.7.2-3; depends (psutil ~= 2.2.1, bcolz ~= 0.8.0, datashape ~= 0.4.3, numba ~= 0.17.0, numpy ~= 1.8.1, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, into ~= 0.2.2, python_dateutil ~= 2.2.0, pymongo ~= 2.8, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, requests ~= 2.5.3, toolz ~= 0.7.1)
+  - blaze 0.7.2-4; depends (psutil ~= 2.2.1, datashape ~= 0.4.3, numba ~= 0.17.0, numpy ~= 1.8.1, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, into ~= 0.2.2, python_dateutil ~= 2.2.0, pymongo ~= 2.8, bcolz ~= 0.8.1, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, requests ~= 2.5.3, toolz ~= 0.7.1)
+  - blaze 0.7.2-6; depends (psutil ~= 2.2.1, datashape ~= 0.4.3, numba ~= 0.17.0, numpy ~= 1.8.1, pandas ~= 0.16.0, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, into ~= 0.2.2, python_dateutil ~= 2.2.0, requests ~= 2.6.0, pymongo ~= 2.8, bcolz ~= 0.8.1, cytoolz ~= 0.7.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - blaze 0.7.2-7; depends (psutil ~= 2.2.1, datashape ~= 0.4.3, numba ~= 0.17.0, numpy ~= 1.8.1, pandas ~= 0.16.0, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, into ~= 0.2.2, python_dateutil ~= 2.2.0, requests ~= 2.6.0, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - blaze 0.7.2-8; depends (psutil ~= 2.2.1, datashape ~= 0.4.3, numpy ~= 1.8.1, pandas ~= 0.16.0, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.8, into ~= 0.2.2, python_dateutil ~= 2.2.0, requests ~= 2.6.0, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, numba ~= 0.18.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - blaze 0.7.2-9; depends (psutil ~= 2.2.1, datashape ~= 0.4.3, numpy ~= 1.8.1, pandas ~= 0.16.0, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.9, into ~= 0.2.2, python_dateutil ~= 2.2.0, requests ~= 2.6.0, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, numba ~= 0.18.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - blaze 0.7.3-1; depends (datashape ~= 0.4.4, psutil ~= 2.2.1, numpy ~= 1.8.1, pandas ~= 0.16.0, h5py ~= 2.4.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 0.9.9, odo ~= 0.3.1, python_dateutil ~= 2.2.0, requests ~= 2.6.0, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, numba ~= 0.18.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - blaze 0.7.3-2; depends (datashape ~= 0.4.4, psutil ~= 2.2.1, numpy ~= 1.8.1, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, pandas ~= 0.16.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 1.0.0, odo ~= 0.3.1, requests ~= 2.6.0, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1, numba ~= 0.18.2)
+  - blaze 0.7.3-3; depends (datashape ~= 0.4.4, psutil ~= 2.2.1, numpy ~= 1.8.1, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, pandas ~= 0.16.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 1.0.1, odo ~= 0.3.1, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, multipledispatch ~= 0.4.7, requests ~= 2.6.2, numba ~= 0.18.2, toolz ~= 0.7.1)
+  - blaze 0.7.3-4; depends (datashape ~= 0.4.4, psutil ~= 2.2.1, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, pandas ~= 0.16.0, pytables ~= 3.1.1, flask ~= 0.10.1, sqlalchemy ~= 1.0.1, odo ~= 0.3.1, numpy ~= 1.9.2, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, multipledispatch ~= 0.4.7, requests ~= 2.6.2, numba ~= 0.18.2, toolz ~= 0.7.1)
+  - blaze 0.8.0-1; depends (toolz ~= 0.7.1, psutil ~= 2.2.1, odo ~= 0.3.2, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, pandas ~= 0.16.0, pytables ~= 3.1.1, flask ~= 0.10.1, numpy ~= 1.9.2, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, datashape ~= 0.4.5, multipledispatch ~= 0.4.7, requests ~= 2.6.2, numba ~= 0.18.2, sqlalchemy ~= 1.0.4)
+  - blaze 0.8.0-2; depends (psutil ~= 2.2.1, odo ~= 0.3.2, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, pandas ~= 0.16.0, pytables ~= 3.1.1, flask ~= 0.10.1, requests ~= 2.7.0, numpy ~= 1.9.2, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, datashape ~= 0.4.5, multipledispatch ~= 0.4.7, sqlalchemy ~= 1.0.4, numba ~= 0.18.2, toolz ~= 0.7.1)
+  - blaze 0.8.0-3; depends (psutil ~= 2.2.1, odo ~= 0.3.2, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, pytables ~= 3.1.1, flask ~= 0.10.1, requests ~= 2.7.0, numpy ~= 1.9.2, cytoolz ~= 0.7.2, pymongo ~= 2.8, bcolz ~= 0.8.1, datashape ~= 0.4.5, pandas ~= 0.16.1, multipledispatch ~= 0.4.7, sqlalchemy ~= 1.0.4, numba ~= 0.18.2, toolz ~= 0.7.1)
+  - blaze 0.8.0-4; depends (psutil ~= 2.2.1, odo ~= 0.3.2, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, pytables ~= 3.1.1, flask ~= 0.10.1, bcolz ~= 0.9.0, requests ~= 2.7.0, numpy ~= 1.9.2, cytoolz ~= 0.7.2, pymongo ~= 2.8, datashape ~= 0.4.5, toolz ~= 0.7.2, pandas ~= 0.16.1, multipledispatch ~= 0.4.7, sqlalchemy ~= 1.0.4, numba ~= 0.18.2)
+  - blaze 0.8.0-6; depends (psutil ~= 2.2.1, odo ~= 0.3.2, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, pytables ~= 3.1.1, flask ~= 0.10.1, bcolz ~= 0.9.0, requests ~= 2.7.0, numpy ~= 1.9.2, cytoolz ~= 0.7.2, pandas ~= 0.16.2, datashape ~= 0.4.5, pymongo ~= 2.8, toolz ~= 0.7.2, multipledispatch ~= 0.4.7, numba ~= 0.19.2, sqlalchemy ~= 1.0.4)
+  - blaze 0.8.0-7; depends (psutil ~= 2.2.1, odo ~= 0.3.2, h5py ~= 2.5.0, python_dateutil ~= 2.4.2, flask ~= 0.10.1, bcolz ~= 0.9.0, requests ~= 2.7.0, numpy ~= 1.9.2, cytoolz ~= 0.7.2, pandas ~= 0.16.2, datashape ~= 0.4.5, pymongo ~= 2.8, pytables ~= 3.2.0, multipledispatch ~= 0.4.7, numba ~= 0.19.2, sqlalchemy ~= 1.0.4, toolz ~= 0.7.2)
+  - blaze 0.8.0-8; depends (psutil ~= 2.2.1, sqlalchemy ~= 1.0.6, odo ~= 0.3.2, h5py ~= 2.5.0, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, flask ~= 0.10.1, bcolz ~= 0.9.0, requests ~= 2.7.0, numpy ~= 1.9.2, pandas ~= 0.16.2, pymongo ~= 2.8, datashape ~= 0.4.5, pytables ~= 3.2.0, toolz ~= 0.7.2, multipledispatch ~= 0.4.7, numba ~= 0.19.2)
+  - blaze 0.8.0-9; depends (psutil ~= 2.2.1, sqlalchemy ~= 1.0.6, odo ~= 0.3.2, h5py ~= 2.5.0, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, flask ~= 0.10.1, bcolz ~= 0.9.0, requests ~= 2.7.0, numpy ~= 1.9.2, pandas ~= 0.16.2, pymongo ~= 2.8, datashape ~= 0.4.5, pytables ~= 3.2.0, toolz ~= 0.7.2, multipledispatch ~= 0.4.7, numba ~= 0.19.2)
+  - blaze 0.8.2-1; depends (psutil ~= 2.2.1, sqlalchemy ~= 1.0.6, odo ~= 0.3.2, h5py ~= 2.5.0, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, flask ~= 0.10.1, bcolz ~= 0.9.0, numba ~= 0.20.0, numpy ~= 1.9.2, requests ~= 2.7.0, pandas ~= 0.16.2, pymongo ~= 2.8, datashape ~= 0.4.5, pytables ~= 3.2.0, toolz ~= 0.7.2, multipledispatch ~= 0.4.7)
+  - blaze 0.8.2-2; depends (toolz ~= 0.7.4, datashape ~= 0.4.6, psutil ~= 2.2.1, sqlalchemy ~= 1.0.6, h5py ~= 2.5.0, cytoolz ~= 0.7.3, odo ~= 0.3.3, python_dateutil ~= 2.4.2, flask ~= 0.10.1, multipledispatch ~= 0.4.8, bcolz ~= 0.10.0, requests ~= 2.7.0, numba ~= 0.20.0, numpy ~= 1.9.2, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0)
+  - blaze 0.8.2-3; depends (toolz ~= 0.7.4, datashape ~= 0.4.6, sqlalchemy ~= 1.0.6, h5py ~= 2.5.0, cytoolz ~= 0.7.3, odo ~= 0.3.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, flask ~= 0.10.1, multipledispatch ~= 0.4.8, bcolz ~= 0.10.0, requests ~= 2.7.0, numba ~= 0.20.0, numpy ~= 1.9.2, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0)
+  - blaze 0.8.2-4; depends (toolz ~= 0.7.4, datashape ~= 0.4.6, sqlalchemy ~= 1.0.6, h5py ~= 2.5.0, cytoolz ~= 0.7.3, odo ~= 0.3.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, flask ~= 0.10.1, multipledispatch ~= 0.4.8, bcolz ~= 0.10.0, requests ~= 2.7.0, numpy ~= 1.9.2, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0, numba ~= 0.21.0)
+  - blaze 0.8.2-5; depends (toolz ~= 0.7.4, datashape ~= 0.4.6, h5py ~= 2.5.0, cytoolz ~= 0.7.3, odo ~= 0.3.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, flask ~= 0.10.1, multipledispatch ~= 0.4.8, bcolz ~= 0.10.0, requests ~= 2.7.0, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0, numba ~= 0.21.0)
+  - blaze 0.8.3-1; depends (toolz ~= 0.7.4, datashape ~= 0.4.7, h5py ~= 2.5.0, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, flask ~= 0.10.1, multipledispatch ~= 0.4.8, bcolz ~= 0.10.0, requests ~= 2.7.0, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, odo ~= 0.3.4, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0, numba ~= 0.21.0)
+  - blaze 0.8.3-2; depends (toolz ~= 0.7.4, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, multipledispatch ~= 0.4.8, flask ~= 0.10.1, requests ~= 2.7.0, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, odo ~= 0.3.4, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0, bcolz ~= 0.11.3, numba ~= 0.21.0)
+  - blaze 0.8.3-3; depends (toolz ~= 0.7.4, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, multipledispatch ~= 0.4.8, flask ~= 0.10.1, requests ~= 2.7.0, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, odo ~= 0.3.4, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0, bcolz ~= 0.11.3, numba ~= 0.21.0)
+  - blaze 0.8.3-4; depends (toolz ~= 0.7.4, requests ~= 2.8.0, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, multipledispatch ~= 0.4.8, flask ~= 0.10.1, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, odo ~= 0.3.4, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0, bcolz ~= 0.11.3, numba ~= 0.21.0)
+  - blaze 0.8.3-5; depends (toolz ~= 0.7.4, requests ~= 2.8.0, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, multipledispatch ~= 0.4.8, flask ~= 0.10.1, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, odo ~= 0.3.4, pandas ~= 0.16.2, pymongo ~= 2.8, pytables ~= 3.2.0, bcolz ~= 0.11.3, numba ~= 0.21.0)
+  - blaze 0.8.3-6; depends (toolz ~= 0.7.4, requests ~= 2.8.0, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, multipledispatch ~= 0.4.8, flask ~= 0.10.1, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, odo ~= 0.3.4, pymongo ~= 2.8, pytables ~= 3.2.0, bcolz ~= 0.11.3, numba ~= 0.21.0, pandas ~= 0.17.1)
+  - blaze 0.8.3-7; depends (toolz ~= 0.7.4, requests ~= 2.8.0, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, multipledispatch ~= 0.4.8, flask ~= 0.10.1, numba ~= 0.22.1, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, odo ~= 0.3.4, pymongo ~= 2.8, pytables ~= 3.2.0, bcolz ~= 0.11.3, pandas ~= 0.17.1)
+  - blaze 0.8.3-8; depends (toolz ~= 0.7.4, requests ~= 2.8.0, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, multipledispatch ~= 0.4.8, flask ~= 0.10.1, numba ~= 0.22.1, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, odo ~= 0.3.4, pymongo ~= 2.8, bcolz ~= 0.11.3, pytables ~= 3.2.2, pandas ~= 0.17.1)
+  - blaze 0.8.3-9; depends (toolz ~= 0.7.4, requests ~= 2.8.0, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, sqlalchemy ~= 1.0.10, multipledispatch ~= 0.4.8, flask ~= 0.10.1, numba ~= 0.22.1, numpy ~= 1.9.2, odo ~= 0.3.4, pymongo ~= 2.8, bcolz ~= 0.11.3, pytables ~= 3.2.2, pandas ~= 0.17.1)
+  - blaze 0.8.3-10; depends (toolz ~= 0.7.4, h5py ~= 2.5.0, datashape ~= 0.4.7, cytoolz ~= 0.7.3, python_dateutil ~= 2.4.2, psutil ~= 3.2.1, requests ~= 2.9.0, multipledispatch ~= 0.4.8, flask ~= 0.10.1, numba ~= 0.22.1, sqlalchemy ~= 1.0.10, numpy ~= 1.9.2, odo ~= 0.3.4, pymongo ~= 2.8, bcolz ~= 0.11.3, pytables ~= 3.2.2, pandas ~= 0.17.1)
+  - blaze 0.8.3-11; depends (toolz ~= 0.7.4, h5py ~= 2.5.0, datashape ~= 0.4.7, python_dateutil ~= 2.4.2, sqlalchemy ~= 1.0.10, psutil ~= 3.2.1, requests ~= 2.9.0, multipledispatch ~= 0.4.8, flask ~= 0.10.1, numba ~= 0.22.1, cytoolz ~= 0.7.4, numpy ~= 1.9.2, odo ~= 0.3.4, pymongo ~= 2.8, bcolz ~= 0.11.3, pytables ~= 3.2.2, pandas ~= 0.17.1)
+  - blist 1.3.4-1
+  - blist 1.3.6-1
+  - blockcanvas 3.2.1-1
+  - blockcanvas 4.0.0-1
+  - blockcanvas 4.0.1-1
+  - blockcanvas 4.0.3-1
+  - blosc 1.2.3-1; depends (numpy ~= 1.8.0, libblosc ~= 1.3.5)
+  - blosc 1.2.3-2; depends (libblosc ~= 1.3.5, numpy ~= 1.8.1)
+  - blosc 1.2.3-3; depends (numpy ~= 1.8.1, libblosc ~= 1.4.1)
+  - blosc 1.2.3-4; depends (numpy ~= 1.9.2, libblosc ~= 1.4.1)
+  - blosc 1.2.8-1; depends (numpy ~= 1.9.2)
+  - blz 0.6.2-1; depends (libblosc ~= 1.3.5, numexpr ~= 2.2.2)
+  - blz 0.6.2-4; depends (libblosc ~= 1.3.5, numexpr ~= 2.4.0)
+  - blz 0.6.2-5; depends (numexpr ~= 2.4.0, libblosc ~= 1.4.1)
+  - blz 0.6.2-6; depends (numexpr ~= 2.4.0, libblosc ~= 1.4.1)
+  - bokeh 0.6.1-2; depends (pyzmq ~= 14.3.1, gevent ~= 1.0.1, flask ~= 0.10.1, pandas ~= 0.15.0, tornado ~= 4.0.2)
+  - bokeh 0.6.1-4; depends (gevent ~= 1.0.1, pyzmq ~= 14.4.1, pandas ~= 0.15.1, flask ~= 0.10.1, tornado ~= 4.0.2)
+  - bokeh 0.6.1-5; depends (gevent ~= 1.0.1, pyzmq ~= 14.4.1, pandas ~= 0.15.1, flask ~= 0.10.1, tornado ~= 4.0.2)
+  - bokeh 0.6.1-6; depends (gevent ~= 1.0.1, pyzmq ~= 14.4.1, pandas ~= 0.15.2, flask ~= 0.10.1, tornado ~= 4.0.2)
+  - bokeh 0.6.1-7; depends (gevent ~= 1.0.1, pyzmq ~= 14.4.1, pandas ~= 0.15.2, flask ~= 0.10.1, tornado ~= 4.0.2)
+  - bokeh 0.6.1-8; depends (gevent ~= 1.0.1, pandas ~= 0.15.2, flask ~= 0.10.1, pyzmq ~= 14.5.0, tornado ~= 4.0.2)
+  - bokeh 0.7.1-1; depends (gevent ~= 1.0.1, pandas ~= 0.15.2, flask ~= 0.10.1, pyzmq ~= 14.5.0, tornado ~= 4.0.2)
+  - bokeh 0.7.1-2; depends (gevent ~= 1.0.1, pandas ~= 0.15.2, flask ~= 0.10.1, pyzmq ~= 14.5.0, tornado ~= 4.1)
+  - bokeh 0.7.1-3; depends (gevent ~= 1.0.1, pandas ~= 0.15.2, flask ~= 0.10.1, pyzmq ~= 14.5.0, tornado ~= 4.1)
+  - bokeh 0.7.1-4; depends (gevent ~= 1.0.1, pandas ~= 0.15.2, flask ~= 0.10.1, pyzmq ~= 14.5.0, tornado ~= 4.1)
+  - bokeh 0.8.0-1; depends (gevent ~= 1.0.1, pandas ~= 0.15.2, flask ~= 0.10.1, pyzmq ~= 14.5.0, tornado ~= 4.1)
+  - bokeh 0.8.1-1; depends (gevent ~= 1.0.1, pandas ~= 0.15.2, flask ~= 0.10.1, pyzmq ~= 14.5.0, tornado ~= 4.1)
+  - bokeh 0.8.1-2; depends (pandas ~= 0.16.0, gevent ~= 1.0.1, flask ~= 0.10.1, pyzmq ~= 14.5.0, tornado ~= 4.1)
+  - bokeh 0.8.2-1; depends (pyzmq ~= 14.5.0, pandas ~= 0.16.0, abstract_rendering ~= 0.5.1, flask ~= 0.10.1, gevent ~= 1.0.1, tornado ~= 4.1, ipython ~= 3.0.0, blaze ~= 0.7.2)
+  - bokeh 0.8.2-2; depends (pyzmq ~= 14.5.0, pandas ~= 0.16.0, abstract_rendering ~= 0.5.1, flask ~= 0.10.1, gevent ~= 1.0.1, blaze ~= 0.7.3, tornado ~= 4.1, ipython ~= 3.0.0)
+  - bokeh 0.8.2-3; depends (pyzmq ~= 14.5.0, pandas ~= 0.16.0, abstract_rendering ~= 0.5.1, flask ~= 0.10.1, gevent ~= 1.0.1, blaze ~= 0.7.3, ipython ~= 3.1.0, tornado ~= 4.1)
+  - bokeh 0.8.2-4; depends (pandas ~= 0.16.0, abstract_rendering ~= 0.5.1, flask ~= 0.10.1, gevent ~= 1.0.1, ipython ~= 3.1.0, tornado ~= 4.1, pyzmq ~= 14.6.0, blaze ~= 0.8.0)
+  - bokeh 0.8.2-5; depends (abstract_rendering ~= 0.5.1, flask ~= 0.10.1, gevent ~= 1.0.1, ipython ~= 3.1.0, tornado ~= 4.1, pyzmq ~= 14.6.0, pandas ~= 0.16.1, blaze ~= 0.8.0)
+  - bokeh 0.9.0-1; depends (abstract_rendering ~= 0.5.1, flask ~= 0.10.1, gevent ~= 1.0.1, ipython ~= 3.1.0, tornado ~= 4.1, pyzmq ~= 14.6.0, pandas ~= 0.16.1, blaze ~= 0.8.0)
+  - bokeh 0.9.0-2; depends (abstract_rendering ~= 0.5.1, flask ~= 0.10.1, gevent ~= 1.0.1, ipython ~= 3.1.0, pandas ~= 0.16.2, tornado ~= 4.1, pyzmq ~= 14.6.0, blaze ~= 0.8.0)
+  - bokeh 0.9.0-3; depends (tornado ~= 4.2, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, ipython ~= 3.2.0, flask ~= 0.10.1, gevent ~= 1.0.1, pandas ~= 0.16.2, blaze ~= 0.8.0)
+  - bokeh 0.9.1-1; depends (tornado ~= 4.2, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, ipython ~= 3.2.0, flask ~= 0.10.1, gevent ~= 1.0.1, pandas ~= 0.16.2, blaze ~= 0.8.0)
+  - bokeh 0.9.1-2; depends (tornado ~= 4.2, blaze ~= 0.8.2, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, ipython ~= 3.2.0, flask ~= 0.10.1, gevent ~= 1.0.1, pandas ~= 0.16.2)
+  - bokeh 0.9.1-3; depends (tornado ~= 4.2, blaze ~= 0.8.2, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, ipython ~= 3.2.1, gevent ~= 1.0.1, pandas ~= 0.16.2)
+  - bokeh 0.9.3-1; depends (tornado ~= 4.2, blaze ~= 0.8.2, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, ipython ~= 3.2.1, gevent ~= 1.0.1, pandas ~= 0.16.2)
+  - bokeh 0.9.3-2; depends (tornado ~= 4.2, ipython ~= 4.0.0, blaze ~= 0.8.2, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, gevent ~= 1.0.1, pandas ~= 0.16.2)
+  - bokeh 0.9.3-3; depends (ipython ~= 4.0.0, blaze ~= 0.8.2, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, tornado ~= 4.2.1, gevent ~= 1.0.1, pandas ~= 0.16.2)
+  - bokeh 0.10.0-1; depends (ipython ~= 4.0.0, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, tornado ~= 4.2.1, gevent ~= 1.0.1, blaze ~= 0.8.3, pandas ~= 0.16.2)
+  - bokeh 0.10.0-2; depends (ipython ~= 4.0.0, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, tornado ~= 4.2.1, gevent ~= 1.0.1, blaze ~= 0.8.3, pandas ~= 0.16.2)
+  - bokeh 0.10.0-3; depends (ipython ~= 4.0.0, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, tornado ~= 4.2.1, gevent ~= 1.0.1, blaze ~= 0.8.3, pandas ~= 0.16.2)
+  - bokeh 0.10.0-5; depends (ipython ~= 4.0.0, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, tornado ~= 4.2.1, gevent ~= 1.0.1, blaze ~= 0.8.3, pandas ~= 0.17.1)
+  - bokeh 0.10.0-7; depends (ipython ~= 4.0.0, abstract_rendering ~= 0.5.1, pyzmq ~= 14.7.0, flask ~= 0.10.1, blaze ~= 0.8.3, gevent ~= 1.0.2, tornado ~= 4.3, pandas ~= 0.17.1)
+  - boto 2.19.0-1; depends (rsa ~= 3.1.2, pyyaml ~= 3.10, paramiko ~= 1.10.1, requests ~= 1.2.3, keyring ~= 0.9.2, lxml ~= 3.2.3)
+  - boto 2.19.0-2; depends (keyring ~= 3.7.0, requests ~= 2.2.1, lxml ~= 3.3.5, rsa ~= 3.1.2, pyyaml ~= 3.10, paramiko ~= 1.10.1)
+  - boto 2.29.1-1; depends (keyring ~= 3.7.0, lxml ~= 3.3.5, rsa ~= 3.1.2, pyyaml ~= 3.10, paramiko ~= 1.14.0, requests ~= 2.3.0)
+  - boto 2.32.1-1; depends (keyring ~= 3.7.0, lxml ~= 3.3.5, rsa ~= 3.1.2, paramiko ~= 1.14.0, requests ~= 2.3.0, pyyaml ~= 3.11)
+  - boto 2.32.1-2; depends (requests ~= 2.4.0, rsa ~= 3.1.2, keyring ~= 4.0, paramiko ~= 1.14.0, lxml ~= 3.3.6, pyyaml ~= 3.11)
+  - boto 2.34.0-1; depends (requests ~= 2.4.3, paramiko ~= 1.15.1, rsa ~= 3.1.2, keyring ~= 4.0, pyyaml ~= 3.11, lxml ~= 3.4.0)
+  - boto 2.34.0-2; depends (requests ~= 2.5.0, paramiko ~= 1.15.1, rsa ~= 3.1.2, keyring ~= 4.0, lxml ~= 3.4.1, pyyaml ~= 3.11)
+  - boto 2.35.1-1; depends (rsa ~= 3.1.2, paramiko ~= 1.15.2, keyring ~= 4.0, lxml ~= 3.4.1, requests ~= 2.5.1, pyyaml ~= 3.11)
+  - boto 2.36.0-1; depends (rsa ~= 3.1.2, paramiko ~= 1.15.2, keyring ~= 4.0, lxml ~= 3.4.1, requests ~= 2.5.1, pyyaml ~= 3.11)
+  - boto 2.36.0-2; depends (lxml ~= 3.4.2, paramiko ~= 1.15.2, rsa ~= 3.1.2, keyring ~= 4.0, requests ~= 2.5.1, pyyaml ~= 3.11)
+  - boto 2.36.0-3; depends (lxml ~= 3.4.2, paramiko ~= 1.15.2, rsa ~= 3.1.2, keyring ~= 4.0, pyyaml ~= 3.11, requests ~= 2.5.3)
+  - boto 2.36.0-4; depends (lxml ~= 3.4.2, paramiko ~= 1.15.2, rsa ~= 3.1.2, keyring ~= 4.0, requests ~= 2.6.0, pyyaml ~= 3.11)
+  - boto 2.36.0-5; depends (rsa ~= 3.1.2, lxml ~= 3.4.3, paramiko ~= 1.15.2, keyring ~= 4.0, pyyaml ~= 3.11, requests ~= 2.6.2)
+  - boto 2.38.0-1; depends (rsa ~= 3.1.2, lxml ~= 3.4.3, paramiko ~= 1.15.2, keyring ~= 4.0, pyyaml ~= 3.11, requests ~= 2.6.2)
+  - boto 2.38.0-2; depends (rsa ~= 3.1.2, lxml ~= 3.4.3, paramiko ~= 1.15.2, keyring ~= 4.0, requests ~= 2.7.0, pyyaml ~= 3.11)
+  - boto 2.38.0-3; depends (rsa ~= 3.1.2, paramiko ~= 1.15.2, keyring ~= 4.0, requests ~= 2.7.0, lxml ~= 3.4.4, pyyaml ~= 3.11)
+  - boto 2.38.0-4; depends (requests ~= 2.8.0, rsa ~= 3.1.2, paramiko ~= 1.15.2, keyring ~= 4.0, lxml ~= 3.4.4, pyyaml ~= 3.11)
+  - boto 2.38.0-5; depends (requests ~= 2.8.0, rsa ~= 3.1.2, keyring ~= 4.0, paramiko ~= 1.16.0, lxml ~= 3.4.4, pyyaml ~= 3.11)
+  - boto 2.38.0-6; depends (rsa ~= 3.1.2, requests ~= 2.9.0, keyring ~= 4.0, paramiko ~= 1.16.0, lxml ~= 3.4.4, pyyaml ~= 3.11)
+  - bottleneck 0.6.0-2; depends (numpy ~= 1.7.1)
+  - bottleneck 0.6.0-3; depends (numpy ~= 1.7.1)
+  - bottleneck 0.7.0-1; depends (numpy ~= 1.7.1)
+  - bottleneck 0.7.0-2; depends (numpy ~= 1.8.0)
+  - bottleneck 0.7.0-4; depends (numpy ~= 1.8.0)
+  - bottleneck 0.7.0-5; depends (numpy ~= 1.8.1)
+  - bottleneck 0.7.0-6; depends (numpy ~= 1.9.2)
+  - bottleneck 1.0.0-1; depends (numpy ~= 1.9.2)
+  - bottleneck 1.0.0-2; depends (numpy ~= 1.9.2)
+  - brewer2mpl 1.3.1-2
+  - brewer2mpl 1.4.0-3
+  - brewer2mpl 1.4.0-4
+  - brood_json_schemas 0.3.0-1
+  - brood_json_schemas 0.4.0-1
+  - bsdiff4 1.0.0-1
+  - bsdiff4 1.0.1-1
+  - bsdiff4 1.1.0-1
+  - bsdiff4 1.1.1-1
+  - bsdiff4 1.1.4-1
+  - bz2file 0.98-1
+  - cachecontrol 0.11.5-1; depends (requests ~= 2.7.0)
+  - cachecontrol 0.11.5-2; depends (requests ~= 2.8.0)
+  - cachecontrol 0.11.5-3; depends (requests ~= 2.9.0)
+  - cartopy 0.10.0-1; depends (libproj ~= 4.8.0, pil ~= 1.1.7, shapely ~= 1.2.17, pyshp ~= 1.2.0, scipy ~= 0.13.3, matplotlib ~= 1.3.1)
+  - cartopy 0.10.0-2; depends (matplotlib ~= 1.3.1, pil ~= 1.1.7, shapely ~= 1.2.17, pyshp ~= 1.2.0, scipy ~= 0.13.3)
+  - cartopy 0.10.0-3; depends (libproj ~= 4.8.0, pil ~= 1.1.7, shapely ~= 1.2.17, pyshp ~= 1.2.0, scipy ~= 0.13.3, matplotlib ~= 1.3.1)
+  - cartopy 0.10.0-4; depends (libproj ~= 4.8.0, pil ~= 1.1.7, shapely ~= 1.2.17, pyshp ~= 1.2.0, scipy ~= 0.14.0, matplotlib ~= 1.3.1)
+  - cartopy 0.10.0-5; depends (libproj ~= 4.8.0, shapely ~= 1.3.2, pil ~= 1.1.7, pyshp ~= 1.2.0, scipy ~= 0.14.0, matplotlib ~= 1.3.1)
+  - cartopy 0.10.0-8; depends (libproj ~= 4.8.0, shapely ~= 1.3.2, pil ~= 1.1.7, pyshp ~= 1.2.0, scipy ~= 0.14.0, matplotlib ~= 1.4.0)
+  - cartopy 0.11.0-1; depends (libproj ~= 4.8.0, shapely ~= 1.3.2, pil ~= 1.1.7, pyshp ~= 1.2.0, scipy ~= 0.14.0, matplotlib ~= 1.4.0, owslib ~= 0.8.8)
+  - cartopy 0.11.0-2; depends (libproj ~= 4.8.0, pil ~= 1.1.7, pyshp ~= 1.2.0, scipy ~= 0.14.0, shapely ~= 1.4.1, geos ~= 3.4.2, matplotlib ~= 1.4.0, owslib ~= 0.8.8)
+  - cartopy 0.11.0-3; depends (libproj ~= 4.8.0, pil ~= 1.1.7, matplotlib ~= 1.4.2, pyshp ~= 1.2.0, scipy ~= 0.14.0, shapely ~= 1.4.1, geos ~= 3.4.2, owslib ~= 0.8.8)
+  - cartopy 0.11.0-4; depends (libproj ~= 4.8.0, pil ~= 1.1.7, matplotlib ~= 1.4.2, pyshp ~= 1.2.0, scipy ~= 0.14.0, geos ~= 3.4.2, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.0-5; depends (libproj ~= 4.8.0, pil ~= 1.1.7, matplotlib ~= 1.4.2, pyshp ~= 1.2.0, scipy ~= 0.14.1rc1, geos ~= 3.4.2, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-1; depends (libproj ~= 4.8.0, pil ~= 1.1.7, matplotlib ~= 1.4.2, pyshp ~= 1.2.0, scipy ~= 0.14.1rc1, geos ~= 3.4.2, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-2; depends (libproj ~= 4.8.0, scipy ~= 0.15.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, pyshp ~= 1.2.0, geos ~= 3.4.2, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-3; depends (libproj ~= 4.8.0, scipy ~= 0.15.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, pyshp ~= 1.2.0, geos ~= 3.4.2, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-4; depends (libproj ~= 4.8.0, scipy ~= 0.15.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, pyshp ~= 1.2.0, geos ~= 3.4.2, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-5; depends (libproj ~= 4.8.0, scipy ~= 0.15.1, pil ~= 1.1.7, pyshp ~= 1.2.0, geos ~= 3.4.2, matplotlib ~= 1.4.3, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-6; depends (pillow ~= 2.8.1, libproj ~= 4.8.0, scipy ~= 0.15.1, pyshp ~= 1.2.0, geos ~= 3.4.2, matplotlib ~= 1.4.3, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-7; depends (libproj ~= 4.8.0, pillow ~= 2.9.0, scipy ~= 0.15.1, pyshp ~= 1.2.0, geos ~= 3.4.2, matplotlib ~= 1.4.3, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-8; depends (libproj ~= 4.8.0, pillow ~= 2.9.0, scipy ~= 0.16.0, pyshp ~= 1.2.0, geos ~= 3.4.2, matplotlib ~= 1.4.3, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-9; depends (scipy ~= 0.16.1, libproj ~= 4.8.0, pillow ~= 2.9.0, pyshp ~= 1.2.0, geos ~= 3.4.2, matplotlib ~= 1.4.3, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-10; depends (scipy ~= 0.16.1, libproj ~= 4.8.0, pillow ~= 2.9.0, pyshp ~= 1.2.0, matplotlib ~= 1.5.0, geos ~= 3.4.2, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.11.2-11; depends (scipy ~= 0.16.1, libproj ~= 4.8.0, pillow ~= 2.9.0, pyshp ~= 1.2.0, matplotlib ~= 1.5.0, geos ~= 3.4.2, owslib ~= 0.8.8, shapely ~= 1.5.1)
+  - cartopy 0.13.0-1; depends (geos ~= 3.5.0, libproj ~= 4.8.0, pillow ~= 2.9.0, scipy ~= 0.16.1, shapely ~= 1.5.13, pyshp ~= 1.2.0, matplotlib ~= 1.5.0, owslib ~= 0.8.8)
+  - cartopy 0.13.0-2; depends (geos ~= 3.5.0, libproj ~= 4.8.0, scipy ~= 0.16.1, shapely ~= 1.5.13, pyshp ~= 1.2.0, matplotlib ~= 1.5.0, owslib ~= 0.8.8, pillow ~= 3.0.0)
+  - cassowarypy 0.27-1
+  - casuarius 1.0b1-1
+  - casuarius 1.0-1
+  - casuarius 1.1-1
+  - casuarius 1.1-2
+  - casuarius 1.1-3
+  - casuarius 1.1-5
+  - casuarius 1.1-6
+  - cdecimal 2.3-1
+  - celery 3.1.13-2; depends (pytz ~= 2013.8.0, kombu ~= 3.0.21, billiard ~= 3.3.0.18)
+  - celery 3.1.13-3; depends (kombu ~= 3.0.21, pytz ~= 2014.9.0, billiard ~= 3.3.0.18)
+  - certifi 14.05.14-1
+  - certifi 2015.11.20.1-1
+  - cffi 0.8.2-1; depends (pycparser ~= 2.10.0, libffi ~= 3.0.13)
+  - cffi 0.8.6-1; depends (pycparser ~= 2.10.0, libffi ~= 3.0.13)
+  - cffi 0.9.2-1; depends (pycparser ~= 2.10.0, libffi ~= 3.0.13)
+  - cffi 0.9.2-2; depends (libffi ~= 3.0.13, pycparser ~= 2.12)
+  - cffi 1.0.3-1; depends (pycparser ~= 2.13, libffi ~= 3.0.13)
+  - cffi 1.1.2-1; depends (pycparser ~= 2.13, libffi ~= 3.0.13)
+  - cffi 1.2.1-1; depends (libffi ~= 3.0.13, pycparser ~= 2.14)
+  - cffi 1.2.1-2; depends (libffi ~= 3.0.13, pycparser ~= 2.14)
+  - cffi 1.3.1-1; depends (libffi ~= 3.0.13, pycparser ~= 2.14)
+  - chaco 3.4.0-1; depends (numpy ~= 1.5.1, enable ~= 3.4.0)
+  - chaco 4.0.0-1; depends (numpy ~= 1.6.0, enable ~= 4.0.0)
+  - chaco 4.0.0-2; depends (numpy ~= 1.6.1, enable ~= 4.0.0)
+  - chaco 4.0.1-1; depends (numpy ~= 1.6.1, enable ~= 4.0.0)
+  - chaco 4.1.0-1; depends (enable ~= 4.1.0, numpy ~= 1.6.1)
+  - chaco 4.2.0-1; depends (enable ~= 4.2.0, numpy ~= 1.6.1)
+  - chaco 4.3.0-1; depends (enable ~= 4.3.0, numpy ~= 1.6.1)
+  - chaco 4.3.0-2; depends (enable ~= 4.3.0, numpy ~= 1.7.1)
+  - chaco 4.3.0-3; depends (numpy ~= 1.8.0, enable ~= 4.3.0)
+  - chaco 4.4.1-1; depends (numpy ~= 1.8.0, enable ~= 4.3.0)
+  - chaco 4.4.1-2; depends (numpy ~= 1.8.0, enable ~= 4.4.1)
+  - chaco 4.4.1-3; depends (enable ~= 4.4.1, numpy ~= 1.8.1)
+  - chaco 4.5.0-1; depends (enable ~= 4.4.1, numpy ~= 1.8.1)
+  - chaco 4.5.0-2; depends (numpy ~= 1.8.1, enable ~= 4.5.1)
+  - chaco 4.5.0-3; depends (numpy ~= 1.9.2, enable ~= 4.5.1)
+  - chameleon 2.16-1
+  - chameleon 2.18-1
+  - chameleon 2.19-1
+  - chameleon 2.20-1
+  - chameleon 2.22-1
+  - characteristic 14.3.0-1
+  - chardet 2.3.0-1
+  - cheetah 2.4.3-2
+  - cheetah 2.4.4-1
+  - chest 0.2.2-1; depends (numpy ~= 1.8.1, heapdict ~= 1.0.0)
+  - chest 0.2.2-2; depends (numpy ~= 1.9.2, heapdict ~= 1.0.0)
+  - chest 0.2.3-1; depends (numpy ~= 1.9.2, heapdict ~= 1.0.0)
+  - chest 0.2.3-2; depends (numpy ~= 1.9.2, heapdict ~= 1.0.0)
+  - click 2.1.0-1; depends (colorama ~= 0.3.1)
+  - click 3.3-1; depends (colorama ~= 0.3.1)
+  - click 3.3-2; depends (colorama ~= 0.3.3)
+  - click 4.0-1; depends (colorama ~= 0.3.3)
+  - click 4.1-1; depends (colorama ~= 0.3.3)
+  - click 6.2-1; depends (colorama ~= 0.3.3)
+  - clint 0.4.1-1
+  - cloud 2.1.6-1
+  - cloud 2.2.0-1
+  - cloud 2.2.2-1
+  - cloud 2.2.4-1
+  - cloud 2.3.0-1
+  - cloud 2.3.8-1
+  - cloud 2.3.9-1
+  - cloud 2.4.1-1
+  - cloud 2.4.6-1
+  - cmake 2.6.2-1
+  - cmake 2.8.1-1
+  - cmake 2.8.2-1
+  - cmake 2.8.3-1
+  - cmake 2.8.3-2
+  - cmake 3.0.2-1
+  - cmake 3.0.2-2
+  - cmake 3.1.1-1
+  - codetools 3.2.0-1
+  - codetools 4.0.0-1
+  - codetools 4.1.0-1
+  - codetools 4.1.0-2; depends (traits ~= 4.3.0)
+  - codetools 4.2.0-1; depends (traits ~= 4.4.0)
+  - codetools 4.2.0-2; depends (traits ~= 4.5.0)
+  - colorama 0.3.1-1
+  - colorama 0.3.3-1
+  - configobj 4.7.2-2
+  - configobj 5.0.5-1
+  - configobj 5.0.6-1
+  - coverage 3.4-2
+  - coverage 3.5-1
+  - coverage 3.5.1-1
+  - coverage 3.5.2-1
+  - coverage 3.7.1-1
+  - cryptography 0.6.1-1
+  - cryptography 0.6.1-2; depends (cffi ~= 0.8.6)
+  - cryptography 0.6.1-3; depends (cffi ~= 0.9.2)
+  - cryptography 0.8.1-1; depends (enum34 ~= 1.0.4, setuptools ~= 14.3.1, cffi ~= 0.9.2, pyasn1 ~= 0.1.7, six ~= 1.9.0)
+  - cryptography 0.8.1-2; depends (enum34 ~= 1.0.4, setuptools ~= 14.3.1, cffi ~= 0.9.2, pyasn1 ~= 0.1.7, six ~= 1.9.0)
+  - cryptography 0.8.2-1; depends (enum34 ~= 1.0.4, setuptools ~= 14.3.1, cffi ~= 0.9.2, pyasn1 ~= 0.1.7, six ~= 1.9.0)
+  - cryptography 0.8.2-2; depends (enum34 ~= 1.0.4, cffi ~= 0.9.2, pyasn1 ~= 0.1.7, setuptools ~= 15.1, six ~= 1.9.0)
+  - cryptography 0.8.2-3; depends (enum34 ~= 1.0.4, cffi ~= 0.9.2, pyasn1 ~= 0.1.7, six ~= 1.9.0, setuptools ~= 15.2)
+  - cryptography 0.8.2-4; depends (enum34 ~= 1.0.4, pyasn1 ~= 0.1.7, cffi ~= 1.0.3, six ~= 1.9.0, setuptools ~= 15.2)
+  - cryptography 0.8.2-5; depends (enum34 ~= 1.0.4, pyasn1 ~= 0.1.7, cffi ~= 1.0.3, six ~= 1.9.0, setuptools ~= 16.0)
+  - cryptography 0.8.2-6; depends (enum34 ~= 1.0.4, pyasn1 ~= 0.1.7, cffi ~= 1.0.3, six ~= 1.9.0, setuptools ~= 17.1.1)
+  - cryptography 0.9.1-1; depends (enum34 ~= 1.0.4, setuptools ~= 17.1.1, six ~= 1.9.0, cffi ~= 1.1.2, idna ~= 2.0, pyasn1 ~= 0.1.7)
+  - cryptography 0.9.3-1; depends (enum34 ~= 1.0.4, setuptools ~= 17.1.1, six ~= 1.9.0, cffi ~= 1.1.2, idna ~= 2.0, pyasn1 ~= 0.1.7)
+  - cryptography 0.9.3-2; depends (enum34 ~= 1.0.4, six ~= 1.9.0, setuptools ~= 18.2, cffi ~= 1.1.2, idna ~= 2.0, pyasn1 ~= 0.1.7)
+  - cryptography 0.9.3-3; depends (enum34 ~= 1.0.4, cffi ~= 1.2.1, six ~= 1.9.0, setuptools ~= 18.2, idna ~= 2.0, pyasn1 ~= 0.1.7)
+  - cryptography 0.9.3-4; depends (enum34 ~= 1.0.4, pyasn1 ~= 0.1.9, cffi ~= 1.2.1, six ~= 1.9.0, setuptools ~= 18.2, idna ~= 2.0)
+  - cryptography 0.9.3-5; depends (enum34 ~= 1.0.4, pyasn1 ~= 0.1.9, cffi ~= 1.2.1, six ~= 1.9.0, setuptools ~= 18.2, idna ~= 2.0)
+  - cryptography 0.9.3-6; depends (enum34 ~= 1.0.4, pyasn1 ~= 0.1.9, six ~= 1.10.0, cffi ~= 1.2.1, setuptools ~= 18.4, idna ~= 2.0)
+  - cryptography 1.1.1-1; depends (enum34 ~= 1.0.4, pyasn1 ~= 0.1.9, six ~= 1.10.0, setuptools ~= 18.4, cffi ~= 1.3.1, idna ~= 2.0)
+  - cryptography 1.1.1-2; depends (enum34 ~= 1.0.4, pyasn1 ~= 0.1.9, six ~= 1.10.0, setuptools ~= 18.7.1, cffi ~= 1.3.1, idna ~= 2.0)
+  - cryptography 1.1.1-3; depends (pyasn1 ~= 0.1.9, six ~= 1.10.0, enum34 ~= 1.1.1, setuptools ~= 18.7.1, cffi ~= 1.3.1, idna ~= 2.0)
+  - cryptography 1.1.1-4; depends (pyasn1 ~= 0.1.9, six ~= 1.10.0, enum34 ~= 1.1.1, setuptools ~= 19.1.1, cffi ~= 1.3.1, idna ~= 2.0)
+  - cryptography_vectors 0.6.1-1
+  - cryptography_vectors 0.8.1-1
+  - cryptography_vectors 0.8.2-1
+  - cryptography_vectors 0.9.1-1
+  - cryptography_vectors 0.9.3-1
+  - cryptography_vectors 1.1.1-1
+  - cssselect 0.9.1-1
+  - curl 7.23.1-1
+  - curl 7.25.0-1
+  - curl 7.25.0-2
+  - curl 7.25.0-3
+  - curl 7.25.0-6
+  - curl 7.37.0-1
+  - curl 7.38.0-1
+  - curl 7.43.0-1
+  - cycler 0.9.0-1
+  - cycler 0.9.0-2
+  - cython 0.13-2
+  - cython 0.14-1
+  - cython 0.14.1-1
+  - cython 0.15-1
+  - cython 0.15.1-1
+  - cython 0.16-1
+  - cython 0.19.1-1
+  - cython 0.19.2-1
+  - cython 0.20.2-1
+  - cython 0.21-1
+  - cython 0.21.1-1
+  - cython 0.21.2-1
+  - cython 0.22-1
+  - cython 0.22.1-1
+  - cython 0.23.4-1
+  - cytoolz 0.7.0-1
+  - cytoolz 0.7.1-1
+  - cytoolz 0.7.2-1
+  - cytoolz 0.7.3-1
+  - cytoolz 0.7.4-1
+  - dask 0.4.0-1; depends (chest ~= 0.2.2, networkx ~= 1.9.1, psutil ~= 2.2.1, toolz ~= 0.7.1)
+  - dask 0.5.0-1; depends (chest ~= 0.2.2, networkx ~= 1.9.1, psutil ~= 2.2.1, toolz ~= 0.7.2)
+  - dask 0.5.0-2; depends (chest ~= 0.2.2, networkx ~= 1.9.1, psutil ~= 2.2.1, toolz ~= 0.7.2)
+  - dask 0.6.0-1; depends (chest ~= 0.2.2, networkx ~= 1.9.1, psutil ~= 2.2.1, toolz ~= 0.7.2)
+  - dask 0.6.0-2; depends (toolz ~= 0.7.4, chest ~= 0.2.2, networkx ~= 1.9.1, psutil ~= 2.2.1)
+  - dask 0.6.0-3; depends (toolz ~= 0.7.4, psutil ~= 2.2.1, chest ~= 0.2.3, networkx ~= 1.10)
+  - dask 0.6.0-4; depends (toolz ~= 0.7.4, psutil ~= 3.2.1, chest ~= 0.2.3, networkx ~= 1.10)
+  - dask 0.6.0-5; depends (toolz ~= 0.7.4, psutil ~= 3.2.1, chest ~= 0.2.3, networkx ~= 1.10)
+  - dask 0.7.3-1; depends (toolz ~= 0.7.4, psutil ~= 3.2.1, chest ~= 0.2.3, networkx ~= 1.10)
+  - dask 0.7.3-2; depends (toolz ~= 0.7.4, psutil ~= 3.2.1, chest ~= 0.2.3, networkx ~= 1.10)
+  - dask 0.7.3-3; depends (toolz ~= 0.7.4, psutil ~= 3.2.1, chest ~= 0.2.3, networkx ~= 1.10)
+  - dask 0.7.5-1; depends (toolz ~= 0.7.4, psutil ~= 3.2.1, chest ~= 0.2.3, networkx ~= 1.10)
+  - datashape 0.4.2-1
+  - datashape 0.4.3-1
+  - datashape 0.4.4-1
+  - datashape 0.4.4-2
+  - datashape 0.4.4-3
+  - datashape 0.4.5-1; depends (multipledispatch ~= 0.4.7, numpy ~= 1.9.2, python_dateutil ~= 2.4.2)
+  - datashape 0.4.6-1; depends (multipledispatch ~= 0.4.8, numpy ~= 1.9.2, python_dateutil ~= 2.4.2)
+  - datashape 0.4.7-1; depends (multipledispatch ~= 0.4.8, numpy ~= 1.9.2, python_dateutil ~= 2.4.2)
+  - datashape 0.4.7-2; depends (multipledispatch ~= 0.4.8, numpy ~= 1.9.2, python_dateutil ~= 2.4.2)
+  - datashape 0.4.7-3; depends (multipledispatch ~= 0.4.8, numpy ~= 1.9.2, python_dateutil ~= 2.4.2)
+  - decorator 3.4.0-1
+  - decorator 3.4.2-1
+  - decorator 4.0.2-1
+  - decorator 4.0.4-1
+  - dill 0.2.2-1
+  - dill 0.2.2-2
+  - dill 0.2.3-1
+  - dill 0.2.4-1
+  - distribute 0.6.14-2
+  - distribute 0.6.14-3
+  - distribute 0.6.15-1
+  - distribute 0.6.16-1
+  - distribute 0.6.17-1
+  - distribute 0.6.19-1
+  - distribute 0.6.24-1
+  - distribute 0.6.25-1
+  - distribute 0.6.26-1
+  - distribute 0.6.26-2
+  - distribute 0.6.49-1
+  - distribute_remove 1.0.0-2
+  - distribute_remove 1.0.0-3
+  - dnspython 1.12.0-1
+  - doclinks 7.1-1; depends (appinst)
+  - doclinks 7.1-2; depends (appinst)
+  - doclinks 7.2-1; depends (appinst)
+  - doclinks 7.2-2; depends (appinst)
+  - doclinks 7.3-1; depends (appinst)
+  - doctest_tools 1.0a3-1
+  - docutils 0.7-2
+  - docutils 0.8.1-1
+  - docutils 0.8.1-2
+  - docutils 0.11-1
+  - docutils 0.12-1
+  - drmaa 0.4b3-1
+  - dynd_python 0.6.6-1; depends (libdynd ~= 0.6.6, numpy ~= 1.8.1)
+  - dynd_python 0.6.6-2; depends (libdynd ~= 0.6.6, numpy ~= 1.9.2)
+  - dynd_python 0.6.6-3; depends (libdynd ~= 0.6.6, numpy ~= 1.9.2)
+  - ecdsa 0.11.0-1
+  - ecdsa 0.13-1
+  - enable 3.4.0-1; depends (pil ~= 1.1.7, numpy ~= 1.5.1)
+  - enable 4.0.0-1; depends (pil ~= 1.1.7, numpy ~= 1.6.0)
+  - enable 4.0.0-2; depends (pil ~= 1.1.7, numpy ~= 1.6.1)
+  - enable 4.1.0-1; depends (pil ~= 1.1.7, numpy ~= 1.6.1)
+  - enable 4.2.0-1; depends (pil ~= 1.1.7, numpy ~= 1.6.1)
+  - enable 4.3.0-1; depends (pil ~= 1.1.7, numpy ~= 1.6.1)
+  - enable 4.3.0-4; depends (pil ~= 1.1.7, numpy ~= 1.7.1)
+  - enable 4.3.0-5; depends (pil ~= 1.1.7, numpy ~= 1.7.1, traits ~= 4.3.0)
+  - enable 4.3.0-6; depends (pil ~= 1.1.7, numpy ~= 1.7.1, traits ~= 4.3.0)
+  - enable 4.3.0-7; depends (pil ~= 1.1.7, numpy ~= 1.7.1, traitsui ~= 4.3.0)
+  - enable 4.3.0-8; depends (numpy ~= 1.8.0, pil ~= 1.1.7, traitsui ~= 4.3.0)
+  - enable 4.3.0-10; depends (numpy ~= 1.8.0, pil ~= 1.1.7, traitsui ~= 4.4.0)
+  - enable 4.4.1-2; depends (numpy ~= 1.8.0, pil ~= 1.1.7, traitsui ~= 4.4.0)
+  - enable 4.4.1-3; depends (numpy ~= 1.8.0, pil ~= 1.1.7, traitsui ~= 4.4.0)
+  - enable 4.4.1-4; depends (pil ~= 1.1.7, numpy ~= 1.8.1, traitsui ~= 4.4.0)
+  - enable 4.4.1-5; depends (pil ~= 1.1.7, numpy ~= 1.8.1, traitsui ~= 4.4.0)
+  - enable 4.5.1-1; depends (traitsui ~= 4.4.0, kiwisolver ~= 0.1.3, pil ~= 1.1.7, numpy ~= 1.8.1, pyparsing ~= 2.0.3)
+  - enable 4.5.1-2; depends (traitsui ~= 4.4.0, kiwisolver ~= 0.1.3, pil ~= 1.1.7, numpy ~= 1.8.1, pyparsing ~= 2.0.3)
+  - enable 4.5.1-3; depends (traitsui ~= 4.4.0, kiwisolver ~= 0.1.3, pil ~= 1.1.7, numpy ~= 1.9.2, pyparsing ~= 2.0.3)
+  - enable 4.5.1-4; depends (traitsui ~= 4.4.0, kiwisolver ~= 0.1.3, pillow ~= 2.8.1, numpy ~= 1.9.2, pyparsing ~= 2.0.3)
+  - enable 4.5.1-5; depends (kiwisolver ~= 0.1.3, pillow ~= 2.8.1, numpy ~= 1.9.2, traitsui ~= 4.5.1, pyparsing ~= 2.0.3)
+  - enable 4.5.1-6; depends (kiwisolver ~= 0.1.3, pillow ~= 2.8.1, numpy ~= 1.9.2, traitsui ~= 4.5.1, pyparsing ~= 2.0.3)
+  - enable 4.5.1-7; depends (kiwisolver ~= 0.1.3, pillow ~= 2.9.0, numpy ~= 1.9.2, traitsui ~= 4.5.1, pyparsing ~= 2.0.3)
+  - enable 4.5.1-8; depends (kiwisolver ~= 0.1.3, pillow ~= 2.9.0, numpy ~= 1.9.2, traitsui ~= 4.5.1, pyparsing ~= 2.0.3)
+  - enable 4.5.1-9; depends (traitsui ~= 5.0.0, kiwisolver ~= 0.1.3, pillow ~= 2.9.0, numpy ~= 1.9.2, pyparsing ~= 2.0.3)
+  - enable 4.5.1-10; depends (traitsui ~= 5.0.0, kiwisolver ~= 0.1.3, pillow ~= 2.9.0, numpy ~= 1.9.2, pyparsing ~= 2.0.3)
+  - enable 4.5.1-11; depends (traitsui ~= 5.0.0, kiwisolver ~= 0.1.3, numpy ~= 1.9.2, pillow ~= 3.0.0, pyparsing ~= 2.0.3)
+  - enaml 0.1a0-1; depends (ply)
+  - enaml 0.1-1; depends (casuarius ~= 1.0b1, ply, traits ~= 4.1.0)
+  - enaml 0.2.0-1; depends (traits ~= 4.2.0, ply, casuarius ~= 1.0)
+  - enaml 0.6.8-1; depends (casuarius ~= 1.1, ply, traits ~= 4.3.0)
+  - enaml 0.6.8-2; depends (casuarius ~= 1.1, ply, traits ~= 4.3.0)
+  - enaml 0.6.8-3; depends (casuarius ~= 1.1, ply, traits ~= 4.3.0)
+  - enaml 0.6.8-5; depends (casuarius ~= 1.1, ply, traits ~= 4.4.0)
+  - enaml 0.8.9-1; depends (atom ~= 0.3.5, casuarius ~= 1.1, ply ~= 3.4)
+  - enaml 0.9.4-1; depends (atom ~= 0.3.8, ply ~= 3.4, kiwisolver ~= 0.1.2)
+  - enaml 0.9.5-1; depends (atom ~= 0.3.9, ply ~= 3.4, kiwisolver ~= 0.1.2)
+  - enaml 0.9.8-1; depends (atom ~= 0.3.9, ply ~= 3.4, kiwisolver ~= 0.1.2)
+  - enaml 0.9.8-2; depends (atom ~= 0.3.9, kiwisolver ~= 0.1.3, ply ~= 3.4)
+  - enaml 0.9.8-3; depends (atom ~= 0.3.9, kiwisolver ~= 0.1.3, ply ~= 3.6)
+  - encore 0.1-1
+  - encore 0.2-2
+  - encore 0.3-1
+  - encore 0.4.0-1
+  - encore 0.5.1-1
+  - encore 0.5.1-3
+  - encore 0.5.1-4
+  - encore 0.5.1-5
+  - encore 0.6.0-1
+  - encore 0.6.0-2
+  - encore 0.6.0-3
+  - encore 0.6.0-4
+  - encore 0.6.0-5
+  - encore 0.6.0-6
+  - encore 0.6.0-7
+  - encore 0.6.0-8
+  - encore 0.6.0-9
+  - endist 1.2.2-1; depends (cheetah, distribute)
+  - endist 1.2.3-1; depends (cheetah, distribute)
+  - enstaller 4.3.0-1
+  - enstaller 4.3.1-1
+  - enstaller 4.3.2-1
+  - enstaller 4.3.3-1
+  - enstaller 4.3.4-1
+  - enstaller 4.4.0-1
+  - enstaller 4.4.1-1
+  - enstaller 4.5.0-1
+  - enstaller 4.5.1-1
+  - enstaller 4.5.2-1
+  - enstaller 4.5.3-1
+  - enstaller 4.5.5-1
+  - enstaller 4.5.5-2
+  - enstaller 4.5.6-1
+  - enstaller 4.6.0-1
+  - enstaller 4.6.1-2
+  - enstaller 4.6.2-1
+  - enstaller 4.6.3-1
+  - enstaller 4.6.4-1
+  - enstaller 4.6.5-1
+  - enstaller 4.7.3-1
+  - enstaller 4.8.1-1
+  - enstaller 4.8.3-1
+  - enstaller 4.8.4-1
+  - enstaller 4.8.5-1
+  - enstaller 4.8.6-1
+  - enstaller 4.8.7-1
+  - enstaller 4.8.8-1
+  - enstaller 4.8.9-1
+  - enstaller 4.8.10-2
+  - enthoughtbase 3.1.0-1
+  - enum34 1.0.3-1
+  - enum34 1.0.4-1
+  - enum34 1.1.1-1
+  - envisage 4.0.0-1
+  - envisage 4.1.0-1
+  - envisage 4.2.0-1
+  - envisage 4.3.0-1
+  - envisage 4.3.0-2; depends (traits ~= 4.3.0)
+  - envisage 4.4.0-1; depends (traits ~= 4.4.0)
+  - envisage 4.4.0-2; depends (traits ~= 4.5.0)
+  - envisagecore 3.2.0-1
+  - envisageplugins 3.2.0-1; depends (enthoughtbase ~= 3.1.0, envisagecore ~= 3.2.0)
+  - epd 7.0-1; depends (biopython == 1.56-1, traitsgui == 3.6.0-1, zope.interface == 3.6.1-2, ipython == 0.10.1-2, distribute == 0.6.14-2, matplotlib == 1.0.1-1, pyparsing == 1.5.5-3, ply == 3.3-3, cloud == 2.2.0-1, traitsbackendwx == 3.6.0-1, numpy == 1.5.1-1, wxpython == 2.8.10.1-2, enable == 3.4.0-1, configobj == 4.7.2-2, pytables == 2.2.1-1, libyaml == 0.1.3-1, codetools == 3.2.0-1, appinst == 2.0.4-1, simpy == 2.1.0-2, xlrd == 0.7.1-3, scikits.image == 0.2.2-2, epydoc == 3.0.1-5, envisagecore == 3.2.0-1, sqlalchemy == 0.6.6-1, apptools == 3.4.1-1, vtk == 5.6.0-2, pyhdf == 0.8.3-4, pyzmq == 2.0.10-2, bitarray == 0.3.5-3, envisageplugins == 3.2.0-1, libxslt == 1.1.24-5, pyflakes == 0.4.0-2, pandas == 0.2-2, paramiko == 1.7.6-4, pyopengl == 3.0.1-2, pyopenssl == 0.11-2, blockcanvas == 3.2.1-1, lib_netcdf4 == 4.1.1-1, scikits.timeseries == 0.91.3-2, pygments == 1.4-1, scikits.learn == 0.6-1, coverage == 3.4-2, pil == 1.1.7-3, traits == 3.6.0-1, zeromq == 2.0.10-1, pydot == 1.0.2-5, pytz == 2010o-1, fwrap == 0.1.1-1, foolscap == 0.6.1-1, jinja2 == 2.5.5-3, reportlab == 2.5-2, sympy == 0.6.7-2, pygarrayimage == 0.0.7-4, netcdf4 == 0.9.3-2, cython == 0.14.1-1, basemap == 1.0-2, scons == 2.0.1-2, docutils == 0.7-2, etsdevtools == 3.1.1-1, graphcanvas == 3.0.0-1, pyproj == 1.8.8-2, pyserial == 2.5-2, grin == 1.2.1-2, mayavi == 3.4.1-1, traitsbackendqt == 3.6.0-1, mkl == 10.3-1, scimath == 3.0.7-1, lxml == 2.3-1, scikits.statsmodels == 0.2.0-2, chaco == 3.4.0-1, pyaudio == 0.2.4-1, pyfits == 2.4.0-1, xlwt == 0.7.2-3, pyglet == 1.1.4-2, idle == 2.7.1-1, hdf5 == 1.8.5.1-2, pycrypto == 2.3-2, enthoughtbase == 3.1.0-1, libxml2 == 2.7.3-3, swig == 1.3.40-2, sphinx == 1.0.7-1, pyyaml == 3.9-2, python_dateutil == 1.5-2, networkx == 1.4-1, h5py == 1.3.1-1, freetype == 2.4.4-1, ets == 3.6.0-1, twisted == 10.2.0-1, scipy == 0.9.0rc2-1, nose == 1.0.0-1, html5lib == 0.90-2, numexpr == 1.4.2-1, pycluster == 1.50-2)
+  - epd 7.0-2; depends (biopython == 1.56-1, traitsgui == 3.6.0-1, zope.interface == 3.6.1-2, ipython == 0.10.1-2, distribute == 0.6.14-2, matplotlib == 1.0.1-1, pyparsing == 1.5.5-3, ply == 3.3-3, cloud == 2.2.0-1, traitsbackendwx == 3.6.0-1, wxpython == 2.8.10.1-2, enable == 3.4.0-1, configobj == 4.7.2-2, pytables == 2.2.1-1, ets == 3.6.0-2, libyaml == 0.1.3-1, codetools == 3.2.0-1, appinst == 2.0.4-1, simpy == 2.1.0-2, xlrd == 0.7.1-3, scikits.image == 0.2.2-2, epydoc == 3.0.1-5, envisagecore == 3.2.0-1, sqlalchemy == 0.6.6-1, apptools == 3.4.1-1, vtk == 5.6.0-2, pyhdf == 0.8.3-4, bitarray == 0.3.5-3, envisageplugins == 3.2.0-1, libxslt == 1.1.24-5, pyflakes == 0.4.0-2, paramiko == 1.7.6-4, pyopengl == 3.0.1-2, pyopenssl == 0.11-2, blockcanvas == 3.2.1-1, lib_netcdf4 == 4.1.1-1, scikits.timeseries == 0.91.3-2, pygments == 1.4-1, scikits.learn == 0.6-1, coverage == 3.4-2, pil == 1.1.7-3, traits == 3.6.0-1, zeromq == 2.0.10-1, pydot == 1.0.2-5, pytz == 2010o-1, fwrap == 0.1.1-1, foolscap == 0.6.1-1, jinja2 == 2.5.5-3, reportlab == 2.5-2, sympy == 0.6.7-2, pygarrayimage == 0.0.7-4, pandas == 0.2-3, netcdf4 == 0.9.3-2, cython == 0.14.1-1, mayavi == 3.4.1-2, basemap == 1.0-2, scons == 2.0.1-2, docutils == 0.7-2, etsdevtools == 3.1.1-1, graphcanvas == 3.0.0-1, pyproj == 1.8.8-2, pyserial == 2.5-2, grin == 1.2.1-2, traitsbackendqt == 3.6.0-1, mkl == 10.3-1, scimath == 3.0.7-1, pyzmq == 2.0.10.1-1, lxml == 2.3-1, scikits.statsmodels == 0.2.0-2, chaco == 3.4.0-1, pyaudio == 0.2.4-1, pyfits == 2.4.0-1, xlwt == 0.7.2-3, pyglet == 1.1.4-2, idle == 2.7.1-1, hdf5 == 1.8.5.1-2, pycrypto == 2.3-2, enthoughtbase == 3.1.0-1, libxml2 == 2.7.3-3, swig == 1.3.40-2, sphinx == 1.0.7-1, pyyaml == 3.9-2, python_dateutil == 1.5-2, networkx == 1.4-1, h5py == 1.3.1-1, freetype == 2.4.4-1, twisted == 10.2.0-1, scipy == 0.9.0rc2-1, numpy == 1.5.1-2, nose == 1.0.0-1, html5lib == 0.90-2, numexpr == 1.4.2-1, pycluster == 1.50-2)
+  - epd 7.1-1; depends (scimath == 4.0.0-1, pyparsing == 1.5.6-1, pyyaml == 3.10-1, pydot == 1.0.25-1, twisted == 11.0.0-2, chaco == 4.0.0-1, fwrap == 0.1.1-2, pyzmq == 2.1.7-1, sympy == 0.7.0-1, configobj == 4.7.2-2, codetools == 4.0.0-1, scikits.timeseries == 0.91.3-3, simpy == 2.1.0-2, distribute == 0.6.19-1, qt == 4.7.3-1, epydoc == 3.0.1-5, vtk == 5.6.0-2, biopython == 1.57-2, pyface == 4.0.0-1, bitarray == 0.3.5-3, basemap == 1.0.1-1, libxslt == 1.1.24-5, doclinks == 7.1-1, pytables == 2.3b1.dev4669-1, mdp == 3.1-1, pyopengl == 3.0.1-2, lib_netcdf4 == 4.1.1-1, xlrd == 0.7.1-4, appinst == 2.1.0-1, blockcanvas == 4.0.0-1, pygments == 1.4-1, enable == 4.0.0-1, pil == 1.1.7-3, pycluster == 1.50-3, ply == 3.4-1, graphcanvas == 4.0.0-1, idle == 2.7.2-1, wxpython == 2.8.10.1-3, foolscap == 0.6.1-3, jinja2 == 2.5.5-3, reportlab == 2.5-2, pygarrayimage == 0.0.7-4, pyfits == 2.4.0-2, mayavi == 4.0.0-1, cython == 0.14.1-1, pytz == 2011g-1, scons == 2.0.1-2, numpy == 1.6.0-5, cloud == 2.2.4-1, examples == 7.1-1, docutils == 0.7-2, scikits.image == 0.2.2-3, scipy == 0.9.0-2, netcdf4 == 0.9.5-1, libyaml == 0.1.4-1, pyproj == 1.8.9-1, pyserial == 2.5-2, pyflakes == 0.4.0-3, grin == 1.2.1-2, sqlalchemy == 0.7.1-1, mkl == 10.3-1, paramiko == 1.7.7.1-1, apptools == 4.0.0-1, envisage == 4.0.0-1, lxml == 2.3-1, pyhdf == 0.8.3-5, scikits.statsmodels == 0.2.0-2, pyaudio == 0.2.4-1, scikits.learn == 0.8-1, xlwt == 0.7.2-3, pyglet == 1.1.4-2, hdf5 == 1.8.5.1-2, pandas == 0.3.0-2, pyopenssl == 0.12-1, pycrypto == 2.3-2, networkx == 1.5-1, libxml2 == 2.7.3-3, matplotlib == 1.0.1-2, swig == 1.3.40-2, nose == 1.0.0-2, sphinx == 1.0.7-1, numexpr == 1.4.2-2, python_dateutil == 1.5-2, pyside == 1.0.3-2, freetype == 2.4.4-1, coverage == 3.5-1, etsdevtools == 4.0.0-1, traits == 4.0.0-1, h5py == 1.3.1-2, etsproxy == 0.1.0-1, traitsui == 4.0.0-1, zope.interface == 3.6.3-1, html5lib == 0.90-2, ets == 4.0.0-1, ipython == 0.11rc1-1, zeromq == 2.1.7-1)
+  - epd 7.1-2; depends (sympy == 0.7.1-1, netcdf4 == 0.9.5-2, pyparsing == 1.5.6-1, pyyaml == 3.10-1, examples == 7.1-2, pydot == 1.0.25-1, twisted == 11.0.0-2, fwrap == 0.1.1-2, scikits.learn == 0.8-2, pyzmq == 2.1.7-1, configobj == 4.7.2-2, codetools == 4.0.0-1, scipy == 0.9.0-3, distribute == 0.6.19-1, simpy == 2.1.0-2, epydoc == 3.0.1-5, vtk == 5.6.0-2, pyface == 4.0.0-1, bitarray == 0.3.5-3, libxslt == 1.1.24-5, enable == 4.0.0-2, mdp == 3.1-1, pyopengl == 3.0.1-2, lib_netcdf4 == 4.1.1-1, xlrd == 0.7.1-4, appinst == 2.1.0-1, blockcanvas == 4.0.0-1, pygments == 1.4-1, scikits.image == 0.2.2-4, pytables == 2.3b1.dev4669-2, pil == 1.1.7-3, ply == 3.4-1, graphcanvas == 4.0.0-1, wxpython == 2.8.10.1-3, foolscap == 0.6.1-3, jinja2 == 2.5.5-3, reportlab == 2.5-2, doclinks == 7.1-2, pygarrayimage == 0.0.7-4, mayavi == 4.0.0-1, cython == 0.14.1-1, pytz == 2011g-1, idle == 2.7.2-2, scons == 2.0.1-2, cloud == 2.2.4-1, traits == 4.0.0-2, docutils == 0.7-2, libyaml == 0.1.4-1, pyproj == 1.8.9-1, ets == 4.0.0-2, pycluster == 1.50-4, pyserial == 2.5-2, pyflakes == 0.4.0-3, grin == 1.2.1-2, sqlalchemy == 0.7.1-1, mkl == 10.3-1, paramiko == 1.7.7.1-1, apptools == 4.0.0-1, envisage == 4.0.0-1, lxml == 2.3-1, scikits.statsmodels == 0.2.0-2, numexpr == 1.4.2-3, ipython == 0.11-1, pyaudio == 0.2.4-1, pyhdf == 0.8.3-6, xlwt == 0.7.2-3, qt == 4.7.3-2, pyglet == 1.1.4-2, hdf5 == 1.8.5.1-2, pyopenssl == 0.12-1, pycrypto == 2.3-2, networkx == 1.5-1, libxml2 == 2.7.3-3, swig == 1.3.40-2, nose == 1.0.0-2, pyfits == 2.4.0-3, sphinx == 1.0.7-1, chaco == 4.0.0-2, python_dateutil == 1.5-2, freetype == 2.4.4-1, scikits.timeseries == 0.91.3-4, matplotlib == 1.0.1-3, coverage == 3.5-1, etsdevtools == 4.0.0-1, basemap == 1.0.1-2, pyside == 1.0.5-1, numpy == 1.6.1-1, pandas == 0.3.0-3, etsproxy == 0.1.0-1, scimath == 4.0.0-2, traitsui == 4.0.0-1, zope.interface == 3.6.3-1, h5py == 2.0.0-1, html5lib == 0.90-2, biopython == 1.57-3, zeromq == 2.1.7-1)
+  - epd 7.2-1; depends (traits == 4.1.0-1, lxml == 2.3.2-1, sympy == 0.7.1-1, netcdf4 == 0.9.5-2, pyparsing == 1.5.6-1, pyyaml == 3.10-1, pydot == 1.0.25-1, networkx == 1.6-1, traitsui == 4.1.0-1, doclinks == 7.2-1, configobj == 4.7.2-2, pytables == 2.3.1-2, codetools == 4.0.0-1, libgdal == 1.8.1-1, cython == 0.15.1-1, sphinx == 1.1.2-1, matplotlib == 1.1.0-1, vtk == 5.6.0-2, blockcanvas == 4.0.1-1, cloud == 2.3.9-1, bitarray == 0.3.5-3, chaco == 4.1.0-1, libxslt == 1.1.24-5, pyopengl == 3.0.1-2, coverage == 3.5.1-1, lib_netcdf4 == 4.1.1-1, xlrd == 0.7.1-4, pyzmq == 2.1.11-1, appinst == 2.1.0-1, fwrap == 0.1.1-3, scikits.image == 0.4.2-1, apptools == 4.0.1-1, pygments == 1.4-1, gdal == 1.8.1-1, numexpr == 2.0-1, pil == 1.1.7-3, pyflakes == 0.5.0-1, ply == 3.4-1, numpy == 1.6.1-2, zope.interface == 3.8.0-1, wxpython == 2.8.10.1-3, pycrypto == 2.4.1-1, reportlab == 2.5-2, scikit_learn == 0.9-1, pygarrayimage == 0.0.7-4, pyface == 4.1.0-1, enable == 4.1.0-1, tornado == 2.1.1-1, pyfits == 3.0.3-1, simpy == 2.2-1, idle == 2.7.2-2, scons == 2.0.1-2, twisted == 11.1.0-2, epydoc == 3.0.1-6, pytz == 2011n-1, scimath == 4.0.1-1, libyaml == 0.1.4-1, bsdiff4 == 1.0.1-1, pyproj == 1.8.9-1, pycluster == 1.50-4, grin == 1.2.1-2, sqlalchemy == 0.7.1-1, mkl == 10.3-1, paramiko == 1.7.7.1-1, examples == 7.2-1, pyaudio == 0.2.4-1, biopython == 1.58-1, ipython == 0.12-1, pyhdf == 0.8.3-6, ets == 4.1.0-1, xlwt == 0.7.2-3, qt == 4.7.3-2, envisage == 4.1.0-1, mayavi == 4.1.0-1, nose == 1.1.2-1, pyglet == 1.1.4-2, graphcanvas == 4.0.0-2, hdf5 == 1.8.5.1-2, pep8 == 0.6.1-1, pyopenssl == 0.12-1, mdp == 3.2-1, scikits.statsmodels == 0.3.1-1, libxml2 == 2.7.3-3, swig == 1.3.40-2, pandas == 0.4.3-1, pyserial == 2.6-1, scipy == 0.10.0-1, python_dateutil == 1.5-2, freetype == 2.4.4-1, scikits.timeseries == 0.91.3-4, etsproxy == 0.1.1-1, etsdevtools == 4.0.0-1, pyside == 1.0.5-1, basemap == 1.0.1-3, foolscap == 0.6.2-1, jinja2 == 2.6-1, docutils == 0.8.1-1, distribute == 0.6.24-1, h5py == 2.0.0-1, html5lib == 0.90-2)
+  - epd 7.2-2; depends (traits == 4.1.0-1, lxml == 2.3.2-1, sympy == 0.7.1-1, netcdf4 == 0.9.5-2, pyparsing == 1.5.6-1, pyyaml == 3.10-1, pydot == 1.0.25-1, networkx == 1.6-1, doclinks == 7.2-2, traitsui == 4.1.0-1, configobj == 4.7.2-2, pytables == 2.3.1-2, codetools == 4.0.0-1, libgdal == 1.8.1-1, cython == 0.15.1-1, sphinx == 1.1.2-1, matplotlib == 1.1.0-1, vtk == 5.6.0-2, blockcanvas == 4.0.1-1, cloud == 2.3.9-1, bitarray == 0.3.5-3, chaco == 4.1.0-1, libxslt == 1.1.24-5, pyopengl == 3.0.1-2, coverage == 3.5.1-1, lib_netcdf4 == 4.1.1-1, xlrd == 0.7.1-4, pyzmq == 2.1.11-1, appinst == 2.1.0-1, fwrap == 0.1.1-3, scikits.image == 0.4.2-1, apptools == 4.0.1-1, pygments == 1.4-1, numexpr == 2.0-1, pil == 1.1.7-3, pyflakes == 0.5.0-1, ply == 3.4-1, numpy == 1.6.1-2, zope.interface == 3.8.0-1, wxpython == 2.8.10.1-3, pycrypto == 2.4.1-1, reportlab == 2.5-2, scikit_learn == 0.9-1, pandas == 0.6.1-1, pygarrayimage == 0.0.7-4, pyface == 4.1.0-1, enable == 4.1.0-1, tornado == 2.1.1-1, pyfits == 3.0.3-1, simpy == 2.2-1, idle == 2.7.2-2, scons == 2.0.1-2, twisted == 11.1.0-2, epydoc == 3.0.1-6, pytz == 2011n-1, scimath == 4.0.1-1, libyaml == 0.1.4-1, bsdiff4 == 1.0.1-1, pyproj == 1.8.9-1, pycluster == 1.50-4, grin == 1.2.1-2, sqlalchemy == 0.7.1-1, mkl == 10.3-1, paramiko == 1.7.7.1-1, examples == 7.2-1, pyaudio == 0.2.4-1, biopython == 1.58-1, ipython == 0.12-1, pyhdf == 0.8.3-6, ets == 4.1.0-1, xlwt == 0.7.2-3, gdal == 1.8.1-2, qt == 4.7.3-2, envisage == 4.1.0-1, mayavi == 4.1.0-1, nose == 1.1.2-1, pyglet == 1.1.4-2, graphcanvas == 4.0.0-2, hdf5 == 1.8.5.1-2, pep8 == 0.6.1-1, pyopenssl == 0.12-1, mdp == 3.2-1, scikits.statsmodels == 0.3.1-1, libxml2 == 2.7.3-3, swig == 1.3.40-2, pyserial == 2.6-1, pyside == 1.1.0-2, scipy == 0.10.0-1, python_dateutil == 1.5-2, freetype == 2.4.4-1, scikits.timeseries == 0.91.3-4, etsproxy == 0.1.1-1, etsdevtools == 4.0.0-1, basemap == 1.0.1-3, foolscap == 0.6.2-1, jinja2 == 2.6-1, docutils == 0.8.1-1, distribute == 0.6.24-1, h5py == 2.0.0-1, html5lib == 0.90-2)
+  - epd 7.3-1; depends (pytables == 2.3.1-4, sympy == 0.7.1-1, pyparsing == 1.5.6-1, pyyaml == 3.10-1, networkx == 1.6-1, traitsui == 4.2.0-1, idle == 2.7.3-1, statsmodels == 0.4.0-1, xlwt == 0.7.3-1, numexpr == 2.0.1-1, shapely == 1.2.14-1, feedparser == 5.1.1-1, basemap == 1.0.2-1, configobj == 4.7.2-2, doclinks == 7.3-1, codetools == 4.0.0-1, libgdal == 1.8.1-1, examples == 7.3-1, scikit_learn == 0.11-1, sphinx == 1.1.2-1, blist == 1.3.4-1, curl == 7.25.0-2, matplotlib == 1.1.0-1, scikits.image == 0.5.0-1, jinja2 == 2.6-2, vtk == 5.6.0-2, lib_netcdf4 == 4.2-2, blockcanvas == 4.0.1-1, enable == 4.2.0-1, pyproj == 1.9.0-1, graphcanvas == 4.0.0-3, encore == 0.2-2, pandas == 0.7.3-2, pyopengl == 3.0.1-2, coverage == 3.5.1-1, pydot == 1.0.28-1, scimath == 4.1.0-1, traits == 4.2.0-1, pyzmq == 2.1.11-1, fwrap == 0.1.1-3, lxml == 2.3.4-1, pep8 == 1.0.1-1, pygments == 1.4-1, bsdiff4 == 1.1.1-1, openpyxl == 1.5.8-1, ets == 4.2.0-1, h5py == 2.0.0-2, appinst == 2.1.1-1, pil == 1.1.7-3, pyflakes == 0.5.0-1, ply == 3.4-1, numpy == 1.6.1-2, zope.interface == 3.8.0-1, hdf5 == 1.8.9-1, wxpython == 2.8.10.1-3, pycrypto == 2.4.1-1, reportlab == 2.5-2, cloud == 2.4.6-1, libxslt == 1.1.26-1, pygarrayimage == 0.0.7-4, bitarray == 0.8.0-1, xlrd == 0.7.6-1, cython == 0.16-1, simpy == 2.2-1, scons == 2.0.1-2, biopython == 1.59-1, netcdf4 == 1.0-1, keyring == 0.9-1, epydoc == 3.0.1-6, pytz == 2011n-1, sqlalchemy == 0.7.6-1, libyaml == 0.1.4-1, pycluster == 1.50-4, ipython == 0.12.1-2, grin == 1.2.1-2, mkl == 10.3-1, paramiko == 1.7.7.1-1, scipy == 0.10.1-1, twisted == 12.0.0-1, pyaudio == 0.2.4-1, pythondoc == 2.7.3-1, apptools == 4.1.0-1, pyhdf == 0.8.3-6, gdal == 1.8.1-2, qt == 4.7.3-2, distribute == 0.6.26-1, nose == 1.1.2-1, mayavi == 4.2.0-1, pyglet == 1.1.4-2, zlib == 1.2.6-1, pyface == 4.2.0-1, pyopenssl == 0.12-1, mdp == 3.2-1, swig == 1.3.40-2, pyserial == 2.6-1, libxml2 == 2.7.8-1, python_dateutil == 1.5-2, tornado == 2.2-1, freetype == 2.4.4-1, casuarius == 1.0-1, scikits.timeseries == 0.91.3-4, etsproxy == 0.1.1-1, jsonpickle == 0.4.0-1, etsdevtools == 4.0.0-1, pyfits == 3.0.6-1, enaml == 0.2.0-1, docutils == 0.8.1-1, envisage == 4.2.0-1, chaco == 4.2.0-1, pyside == 1.1.0-3, foolscap == 0.6.3-1, html5lib == 0.90-2)
+  - epd 7.3-2; depends (pytables == 2.3.1-4, sympy == 0.7.1-1, pyparsing == 1.5.6-1, pyyaml == 3.10-1, networkx == 1.6-1, traitsui == 4.2.0-1, idle == 2.7.3-1, statsmodels == 0.4.0-1, ipython == 0.12.1-3, docutils == 0.8.1-2, numexpr == 2.0.1-1, xlwt == 0.7.3-1, shapely == 1.2.14-1, feedparser == 5.1.1-1, basemap == 1.0.2-1, configobj == 4.7.2-2, doclinks == 7.3-1, codetools == 4.0.0-1, libgdal == 1.8.1-1, examples == 7.3-1, scikit_learn == 0.11-1, sphinx == 1.1.2-1, blist == 1.3.4-1, matplotlib == 1.1.0-1, scikits.image == 0.5.0-1, jinja2 == 2.6-2, vtk == 5.6.0-2, lib_netcdf4 == 4.2-2, blockcanvas == 4.0.1-1, enable == 4.2.0-1, pyproj == 1.9.0-1, graphcanvas == 4.0.0-3, encore == 0.2-2, pandas == 0.7.3-2, pyopengl == 3.0.1-2, coverage == 3.5.1-1, pydot == 1.0.28-1, scimath == 4.1.0-1, traits == 4.2.0-1, pyzmq == 2.1.11-1, fwrap == 0.1.1-3, lxml == 2.3.4-1, pep8 == 1.0.1-1, pygments == 1.4-1, bsdiff4 == 1.1.1-1, openpyxl == 1.5.8-1, ets == 4.2.0-1, h5py == 2.0.0-2, pil == 1.1.7-3, pyflakes == 0.5.0-1, ply == 3.4-1, zope.interface == 3.8.0-1, hdf5 == 1.8.9-1, wxpython == 2.8.10.1-3, pycrypto == 2.4.1-1, reportlab == 2.5-2, cloud == 2.4.6-1, libxslt == 1.1.26-1, pygarrayimage == 0.0.7-4, bitarray == 0.8.0-1, xlrd == 0.7.6-1, cython == 0.16-1, simpy == 2.2-1, scons == 2.0.1-2, biopython == 1.59-1, netcdf4 == 1.0-1, keyring == 0.9-1, epydoc == 3.0.1-6, pytz == 2011n-1, numpy == 1.6.1-3, sqlalchemy == 0.7.6-1, libyaml == 0.1.4-1, pycluster == 1.50-4, grin == 1.2.1-2, mkl == 10.3-1, paramiko == 1.7.7.1-1, scipy == 0.10.1-1, curl == 7.25.0-3, twisted == 12.0.0-1, pyaudio == 0.2.4-1, pythondoc == 2.7.3-1, apptools == 4.1.0-1, pyhdf == 0.8.3-6, gdal == 1.8.1-2, qt == 4.7.3-2, distribute == 0.6.26-1, nose == 1.1.2-1, mayavi == 4.2.0-1, pyglet == 1.1.4-2, zlib == 1.2.6-1, pyface == 4.2.0-1, pyopenssl == 0.12-1, mdp == 3.2-1, appinst == 2.1.2-1, swig == 1.3.40-2, pyserial == 2.6-1, libxml2 == 2.7.8-1, python_dateutil == 1.5-2, tornado == 2.2-1, freetype == 2.4.4-1, casuarius == 1.0-1, scikits.timeseries == 0.91.3-4, etsproxy == 0.1.1-1, jsonpickle == 0.4.0-1, etsdevtools == 4.0.0-1, pyfits == 3.0.6-1, enaml == 0.2.0-1, envisage == 4.2.0-1, chaco == 4.2.0-1, kernmagic == 0.1.0-1, pyside == 1.1.0-3, foolscap == 0.6.3-1, html5lib == 0.90-2)
+  - epd_free 7.3-2; depends (distribute == 0.6.26-1, nose == 1.1.2-1, pyglet == 1.1.4-2, pyface == 4.2.0-1, appinst == 2.1.2-1, nomkl_numpy == 1.6.1-1, traitsui == 4.2.0-1, idle == 2.7.3-1, ipython == 0.12.1-3, traits == 4.2.0-1, pyzmq == 2.1.11-1, pytz == 2011n-1, configobj == 4.7.2-2, python_dateutil == 1.5-2, tornado == 2.2-1, pygments == 1.4-1, freetype == 2.4.4-1, casuarius == 1.0-1, examples == 7.3-1, etsproxy == 0.1.1-1, pil == 1.1.7-3, matplotlib == 1.1.0-1, ply == 3.4-1, jinja2 == 2.6-2, enaml == 0.2.0-1, nomkl_scipy == 0.10.1-1, wxpython == 2.8.10.1-3, chaco == 4.2.0-1, pyaudio == 0.2.4-1, kernmagic == 0.1.0-1, pythondoc == 2.7.3-1, apptools == 4.1.0-1, enable == 4.2.0-1, cloud == 2.4.6-1)
+  - epddocs 1.0-1
+  - epdindex 1.0-1
+  - epdindex 1.1-1
+  - epdindex 1.2-1
+  - epdtests 7.0-1
+  - epdtests 7.1-1
+  - epdtests 7.2-2
+  - epdtests 7.3-1
+  - epdtests 7.3-2
+  - epydoc 3.0.1-4; depends (docutils ~= 0.7)
+  - epydoc 3.0.1-5; depends (docutils ~= 0.7)
+  - epydoc 3.0.1-6; depends (docutils ~= 0.8.1)
+  - ets 3.6.0-1; depends (apptools == 3.4.1-1, codetools == 3.2.0-1, traitsbackendwx == 3.6.0-1, traitsgui == 3.6.0-1, chaco == 3.4.0-1, mayavi == 3.4.1-1, traitsbackendqt == 3.6.0-1, envisageplugins == 3.2.0-1, traits == 3.6.0-1, etsdevtools == 3.1.1-1, scimath == 3.0.7-1, enthoughtbase == 3.1.0-1, graphcanvas == 3.0.0-1, blockcanvas == 3.2.1-1, enable == 3.4.0-1, envisagecore == 3.2.0-1)
+  - ets 3.6.0-2; depends (apptools == 3.4.1-1, codetools == 3.2.0-1, traitsbackendwx == 3.6.0-1, traitsgui == 3.6.0-1, chaco == 3.4.0-1, traitsbackendqt == 3.6.0-1, mayavi == 3.4.1-2, envisageplugins == 3.2.0-1, traits == 3.6.0-1, etsdevtools == 3.1.1-1, scimath == 3.0.7-1, enthoughtbase == 3.1.0-1, graphcanvas == 3.0.0-1, blockcanvas == 3.2.1-1, enable == 3.4.0-1, envisagecore == 3.2.0-1)
+  - ets 4.0.0-1; depends (graphcanvas == 4.0.0-1, codetools == 4.0.0-1, scimath == 4.0.0-1, etsproxy == 0.1.0-1, mayavi == 4.0.0-1, traitsui == 4.0.0-1, enable == 4.0.0-1, etsdevtools == 4.0.0-1, pyface == 4.0.0-1, apptools == 4.0.0-1, blockcanvas == 4.0.0-1, envisage == 4.0.0-1, chaco == 4.0.0-1, traits == 4.0.0-1)
+  - ets 4.0.0-2; depends (graphcanvas == 4.0.0-1, codetools == 4.0.0-1, enable == 4.0.0-2, etsproxy == 0.1.0-1, mayavi == 4.0.0-1, scimath == 4.0.0-2, traits == 4.0.0-2, traitsui == 4.0.0-1, etsdevtools == 4.0.0-1, pyface == 4.0.0-1, apptools == 4.0.0-1, chaco == 4.0.0-2, blockcanvas == 4.0.0-1, envisage == 4.0.0-1)
+  - ets 4.1.0-1; depends (codetools == 4.0.0-1, traits == 4.1.0-1, envisage == 4.1.0-1, mayavi == 4.1.0-1, blockcanvas == 4.0.1-1, etsproxy == 0.1.1-1, pyface == 4.1.0-1, enable == 4.1.0-1, graphcanvas == 4.0.0-2, traitsui == 4.1.0-1, etsdevtools == 4.0.0-1, apptools == 4.0.1-1, chaco == 4.1.0-1, scimath == 4.0.1-1)
+  - ets 4.2.0-1; depends (codetools == 4.0.0-1, traitsui == 4.2.0-1, scimath == 4.1.0-1, envisage == 4.2.0-1, blockcanvas == 4.0.1-1, etsproxy == 0.1.1-1, chaco == 4.2.0-1, mayavi == 4.2.0-1, traits == 4.2.0-1, etsdevtools == 4.0.0-1, apptools == 4.1.0-1, enable == 4.2.0-1, pyface == 4.2.0-1, graphcanvas == 4.0.0-3, encore == 0.2-2, enaml == 0.2.0-1)
+  - ets 4.3.0-1; depends (traitsui == 4.3.0-1, graphcanvas == 4.0.2-1, codetools == 4.1.0-1, envisage == 4.3.0-1, etsdevtools == 4.0.2-1, apptools == 4.2.0-1, scimath == 4.1.2-1, encore == 0.3-1, enable == 4.3.0-1, etsproxy == 0.1.2-1, casuarius == 1.1-1, enaml == 0.6.8-1, chaco == 4.3.0-1, blockcanvas == 4.0.3-1, mayavi == 4.3.0-1, pyface == 4.3.0-1, traits == 4.3.0-1)
+  - ets 4.3.0-3; depends (graphcanvas == 4.0.2-1, etsdevtools == 4.0.2-1, enaml == 0.6.8-2, mayavi == 4.3.0-3, enable == 4.3.0-5, encore == 0.3-1, envisage == 4.3.0-2, chaco == 4.3.0-2, etsproxy == 0.1.2-1, casuarius == 1.1-1, codetools == 4.1.0-2, pyface == 4.3.0-2, scimath == 4.1.2-2, traits == 4.3.0-2, traitsui == 4.3.0-2, blockcanvas == 4.0.3-1, apptools == 4.2.0-2)
+  - ets 4.3.0-5; depends (mayavi == 4.3.0-4, traits == 4.3.0-3, casuarius == 1.1-2, enaml == 0.6.8-3, etsdevtools == 4.0.2-1, scimath == 4.1.2-3, graphcanvas == 4.0.2-2, envisage == 4.3.0-2, etsproxy == 0.1.2-1, traitsui == 4.3.0-2, codetools == 4.1.0-2, pyface == 4.3.0-2, encore == 0.4.0-1, enable == 4.3.0-8, blockcanvas == 4.0.3-1, apptools == 4.2.0-2, chaco == 4.3.0-3)
+  - ets 4.4.1-1; depends (casuarius == 1.1-3, etsdevtools == 4.0.2-1, mayavi == 4.3.0-5, scimath == 4.1.2-3, pyface == 4.4.0-1, graphcanvas == 4.0.2-2, traits == 4.4.0-1, apptools == 4.2.0-4, chaco == 4.4.1-1, envisage == 4.4.0-1, enable == 4.3.0-10, etsproxy == 0.1.2-1, enaml == 0.6.8-5, codetools == 4.2.0-1, encore == 0.4.0-1, blockcanvas == 4.0.3-1, traitsui == 4.4.0-1)
+  - ets 4.4.2-1; depends (envisage == 4.4.0-2, etsdevtools == 4.0.2-1, scimath == 4.1.2-3, graphcanvas == 4.0.2-3, apptools == 4.2.1-1, traitsui == 4.4.0-2, codetools == 4.2.0-2, encore == 0.5.1-1, etsproxy == 0.1.2-1, traits == 4.5.0-1, enable == 4.4.1-2, pyface == 4.4.0-2, mayavi == 4.3.1-1, blockcanvas == 4.0.3-1, chaco == 4.4.1-2)
+  - ets 4.4.3-1; depends (envisage == 4.4.0-2, etsdevtools == 4.0.2-1, apptools == 4.2.1-3, mayavi == 4.3.1-2, chaco == 4.5.0-1, encore == 0.5.1-4, traitsui == 4.4.0-2, codetools == 4.2.0-2, etsproxy == 0.1.2-1, traits == 4.5.0-1, pyface == 4.4.0-2, graphcanvas == 4.0.2-5, scimath == 4.1.2-4, blockcanvas == 4.0.3-1, enable == 4.4.1-5)
+  - ets 4.4.3-2; depends (envisage == 4.4.0-2, etsdevtools == 4.0.2-1, encore == 0.5.1-5, apptools == 4.2.1-3, mayavi == 4.3.1-2, chaco == 4.5.0-1, traitsui == 4.4.0-2, codetools == 4.2.0-2, etsproxy == 0.1.2-1, traits == 4.5.0-1, pyface == 4.4.0-2, graphcanvas == 4.0.2-5, scimath == 4.1.2-4, blockcanvas == 4.0.3-1, enable == 4.4.1-5)
+  - ets 4.4.4-1; depends (envisage == 4.4.0-2, etsdevtools == 4.0.2-1, apptools == 4.2.1-3, mayavi == 4.3.1-2, chaco == 4.5.0-1, traitsui == 4.4.0-2, codetools == 4.2.0-2, etsproxy == 0.1.2-1, traits == 4.5.0-1, pyface == 4.4.0-2, graphcanvas == 4.0.2-5, scimath == 4.1.2-4, encore == 0.6.0-1, blockcanvas == 4.0.3-1, enable == 4.4.1-5)
+  - ets 4.4.4-2; depends (envisage == 4.4.0-2, traitsui == 4.5.1-1, apptools == 4.3.0-3, etsdevtools == 4.0.2-1, scimath == 4.1.2-5, enable == 4.5.1-5, pyface == 4.5.0-1, codetools == 4.2.0-2, chaco == 4.5.0-3, etsproxy == 0.1.2-1, traits == 4.5.0-1, mayavi == 4.4.0-4, encore == 0.6.0-5, graphcanvas == 4.0.2-6, blockcanvas == 4.0.3-1)
+  - ets 4.4.4-3; depends (mayavi == 4.4.2-1, envisage == 4.4.0-2, traitsui == 4.5.1-1, apptools == 4.3.0-5, etsdevtools == 4.0.2-1, scimath == 4.1.2-5, enable == 4.5.1-6, encore == 0.6.0-6, pyface == 4.5.0-1, codetools == 4.2.0-2, chaco == 4.5.0-3, etsproxy == 0.1.2-1, traits == 4.5.0-1, graphcanvas == 4.0.2-6, blockcanvas == 4.0.3-1)
+  - etsdevtools 3.1.1-1
+  - etsdevtools 4.0.0-1
+  - etsdevtools 4.0.2-1
+  - etsproxy 0.1.0-1
+  - etsproxy 0.1.1-1
+  - etsproxy 0.1.2-1
+  - examples 7.1-1; depends (appinst)
+  - examples 7.1-2; depends (appinst)
+  - examples 7.2-1; depends (appinst)
+  - examples 7.3-1; depends (appinst)
+  - execnet 1.2.0-1
+  - execnet 1.4.1-1; depends (apipkg ~= 1.4, gevent ~= 1.0.2)
+  - expat 2.0.1-1
+  - expat 2.0.1-2
+  - expat 2.0.1-3
+  - fabric 1.10.0-1; depends (paramiko ~= 1.15.1)
+  - fabric 1.10.1-1; depends (paramiko ~= 1.15.2)
+  - fabric 1.10.2-1; depends (paramiko ~= 1.16.0)
+  - fastnumpy 1.0-2; depends (mkl ~= 10.3, numpy ~= 1.5.1)
+  - fastnumpy 1.0-3; depends (mkl ~= 10.3, numpy ~= 1.6.1)
+  - fastnumpy 1.0-5; depends (mkl ~= 10.3, numpy ~= 1.7.1)
+  - fastnumpy 1.0-6; depends (mkl ~= 10.3, numpy ~= 1.8.0)
+  - fastnumpy 1.0-7; depends (mkl ~= 10.3, numpy ~= 1.8.1)
+  - fastnumpy 1.0-8; depends (mkl ~= 10.3, numpy ~= 1.9.2)
+  - faulthandler 2.3-1
+  - faulthandler 2.4-1
+  - faulthandler 2.4-2
+  - feedparser 5.1-1
+  - feedparser 5.1.1-1
+  - feedparser 5.1.3-1
+  - feedparser 5.2.0-1
+  - fiona 1.0.2-1; depends (libgdal ~= 1.10.1, libpng ~= 1.2.40, six ~= 1.3.0)
+  - fiona 1.0.2-2; depends (libgdal ~= 1.10.1, libpng ~= 1.2.40, six ~= 1.4.1)
+  - fiona 1.0.3-1; depends (libgdal ~= 1.10.1, libpng ~= 1.2.40, six ~= 1.4.1)
+  - fiona 1.0.3-2; depends (libgdal ~= 1.10.1, libpng ~= 1.2.40, six ~= 1.4.1)
+  - fiona 1.0.3-3; depends (libpng ~= 1.2.40, six ~= 1.4.1, libgdal ~= 1.11.0)
+  - fiona 1.0.3-4; depends (libpng ~= 1.2.40, six ~= 1.7.2, libgdal ~= 1.11.0)
+  - fiona 1.1.5-1; depends (libpng ~= 1.2.40, six ~= 1.7.2, libgdal ~= 1.11.0)
+  - fiona 1.1.5-2; depends (libpng ~= 1.6.12, libgdal ~= 1.11.0, six ~= 1.7.2)
+  - fiona 1.1.5-3; depends (libpng ~= 1.6.12, libgdal ~= 1.11.0, six ~= 1.7.2)
+  - fiona 1.1.5-4; depends (six ~= 1.7.3, libpng ~= 1.6.12, libgdal ~= 1.11.0)
+  - fiona 1.2.0-5; depends (six ~= 1.7.3, libpng ~= 1.6.12, libgdal ~= 1.11.0)
+  - fiona 1.2.0-6; depends (six ~= 1.7.3, libpng ~= 1.6.12, libgdal ~= 1.11.0)
+  - fiona 1.2.0-7; depends (libpng ~= 1.6.12, libgdal ~= 1.11.0, six ~= 1.8.0)
+  - fiona 1.4.8-1; depends (libpng ~= 1.6.12, libgdal ~= 1.11.0, six ~= 1.8.0)
+  - fiona 1.4.8-2; depends (libpng ~= 1.6.12, libgdal ~= 1.11.0, six ~= 1.9.0)
+  - fiona 1.4.8-4; depends (libpng ~= 1.6.12, libgdal ~= 1.11.2, six ~= 1.9.0)
+  - fiona 1.4.8-5; depends (libpng ~= 1.6.12, libgdal ~= 1.11.2, six ~= 1.9.0)
+  - fiona 1.4.8-7; depends (libpng ~= 1.6.12, libgdal ~= 1.11.2, six ~= 1.10.0)
+  - fiona 1.6.2-1; depends (libpng ~= 1.6.12, libgdal ~= 2.0.1, six ~= 1.10.0)
+  - fipy 2.1-2; depends (distribute, pysparse ~= 1.2.dev213)
+  - fipy 3.1-1; depends (distribute ~= 0.6.49, pysparse ~= 1.2.dev213)
+  - fipy 3.1-2; depends (setuptools ~= 14.3.1, pysparse ~= 1.2.dev213)
+  - fipy 3.1-3; depends (setuptools ~= 15.1, pysparse ~= 1.2.dev213)
+  - fipy 3.1-4; depends (pysparse ~= 1.2.dev213, setuptools ~= 15.2)
+  - fipy 3.1-5; depends (pysparse ~= 1.2.dev213, setuptools ~= 16.0)
+  - fipy 3.1-6; depends (pysparse ~= 1.2.dev213, setuptools ~= 17.1.1)
+  - fipy 3.1-7; depends (pysparse ~= 1.2.dev213, setuptools ~= 18.2)
+  - fipy 3.1-8; depends (setuptools ~= 18.4, pysparse ~= 1.2.dev213)
+  - fipy 3.1-9; depends (setuptools ~= 18.7.1, pysparse ~= 1.2.dev213)
+  - fipy 3.1-10; depends (pysparse ~= 1.2.dev213, setuptools ~= 19.1.1)
+  - flake8 2.0.0-1; depends (mccabe ~= 0.2.1, pep8 ~= 1.4.6, pyflakes ~= 0.7.3)
+  - flake8 2.0.0-2; depends (mccabe ~= 0.2.1, pep8 ~= 1.4.6, pyflakes ~= 0.7.3)
+  - flake8 2.1.0-1; depends (mccabe ~= 0.2.1, pyflakes ~= 0.8.1, pep8 ~= 1.5.7)
+  - flake8 2.2.3-1; depends (mccabe ~= 0.2.1, pyflakes ~= 0.8.1, pep8 ~= 1.5.7)
+  - flake8 2.2.5-1; depends (mccabe ~= 0.2.1, pyflakes ~= 0.8.1, pep8 ~= 1.5.7)
+  - flake8 2.3.0-1; depends (pyflakes ~= 0.8.1, mccabe ~= 0.3, pep8 ~= 1.6.1)
+  - flake8 2.3.0-2; depends (pyflakes ~= 0.8.1, mccabe ~= 0.3, pep8 ~= 1.6.2)
+  - flake8 2.4.1-1; depends (pyflakes ~= 0.9.2, mccabe ~= 0.3, pep8 ~= 1.6.2)
+  - flake8 2.4.1-2; depends (pyflakes ~= 1.0.0, mccabe ~= 0.3, pep8 ~= 1.6.2)
+  - flake8 2.4.1-3; depends (pyflakes ~= 1.0.0, mccabe ~= 0.3, pep8 ~= 1.6.2)
+  - flask 0.10.1-1; depends (jinja2 ~= 2.6, werkzeug ~= 0.9.4, itsdangerous ~= 0.23.0)
+  - flask 0.10.1-2; depends (jinja2 ~= 2.7.1, werkzeug ~= 0.9.4, itsdangerous ~= 0.23.0)
+  - flask 0.10.1-3; depends (jinja2 ~= 2.7.3, itsdangerous ~= 0.23.0, werkzeug ~= 0.9.4)
+  - flask 0.10.1-4; depends (jinja2 ~= 2.7.3, itsdangerous ~= 0.24.0, werkzeug ~= 0.9.6)
+  - flask 0.10.1-5; depends (jinja2 ~= 2.7.3, itsdangerous ~= 0.24.0, werkzeug ~= 0.10.1)
+  - flask 0.10.1-6; depends (jinja2 ~= 2.7.3, itsdangerous ~= 0.24.0, werkzeug ~= 0.10.4)
+  - flask 0.10.1-7; depends (jinja2 ~= 2.8, itsdangerous ~= 0.24.0, werkzeug ~= 0.10.4)
+  - flask 0.10.1-8; depends (jinja2 ~= 2.8, itsdangerous ~= 0.24.0, werkzeug ~= 0.11.2)
+  - flask_babel 0.9-1; depends (jinja2 ~= 2.7.3, flask ~= 0.10.1, speaklater ~= 1.3, babel ~= 1.3)
+  - flask_babel 0.9-2; depends (jinja2 ~= 2.8, flask ~= 0.10.1, babel ~= 2.1.1, speaklater ~= 1.3)
+  - flask_compress 1.0.2-1; depends (flask ~= 0.10.1)
+  - flask_compress 1.2.0-1; depends (flask ~= 0.10.1)
+  - flask_login 0.2.11-1
+  - flask_restful 0.3.2-1; depends (flask ~= 0.10.1, six ~= 1.9.0, aniso8601 ~= 0.92, pytz ~= 2014.9.0)
+  - flask_restful 0.3.2-2; depends (six ~= 1.10.0, flask ~= 0.10.1, aniso8601 ~= 0.92, pytz ~= 2014.9.0)
+  - flask_restful_swagger 0.19-1; depends (flask_restful ~= 0.3.2)
+  - flask_restplus 0.7.1-1; depends (flask_restful ~= 0.3.2)
+  - flask_restplus 0.7.1-2; depends (flask_restful ~= 0.3.2)
+  - flask_wtf 0.11-1; depends (wtforms ~= 2.0.2, flask ~= 0.10.1)
+  - foolscap 0.5.1-3; depends (twisted ~= 10.2.0, pyopenssl ~= 0.11)
+  - foolscap 0.6.1-1; depends (twisted ~= 10.2.0, pyopenssl ~= 0.11)
+  - foolscap 0.6.1-2; depends (twisted ~= 11.0.0, pyopenssl ~= 0.11)
+  - foolscap 0.6.1-3; depends (pyopenssl ~= 0.12, twisted ~= 11.0.0)
+  - foolscap 0.6.2-1; depends (pyopenssl ~= 0.12, twisted ~= 11.1.0)
+  - foolscap 0.6.3-1; depends (twisted ~= 12.0.0, pyopenssl ~= 0.12)
+  - foolscap 0.6.3-3; depends (twisted ~= 12.0.0, pyopenssl ~= 0.13.1)
+  - foolscap 0.6.3-4; depends (twisted ~= 14.0.0, pyopenssl ~= 0.13.1)
+  - foolscap 0.7.0-1; depends (pyopenssl ~= 0.13.1, twisted ~= 14.0.2)
+  - foolscap 0.7.0-3; depends (pyopenssl ~= 0.14, twisted ~= 14.0.2)
+  - foolscap 0.7.0-4; depends (pyopenssl ~= 0.14, twisted ~= 15.1.0)
+  - foolscap 0.7.0-5; depends (twisted ~= 15.1.0, pyopenssl ~= 0.15.1)
+  - foolscap 0.7.0-6; depends (twisted ~= 15.2.1, pyopenssl ~= 0.15.1)
+  - foolscap 0.7.0-7; depends (twisted ~= 15.4.0, pyopenssl ~= 0.15.1)
+  - foolscap 0.7.0-8; depends (twisted ~= 15.5.0, pyopenssl ~= 0.15.1)
+  - freeglut 2.4.0-2
+  - freeglut 2.6.0-1
+  - freeglut 2.8.1-1
+  - freetype 2.3.7-1
+  - freetype 2.3.11-1
+  - freetype 2.4.4-1
+  - freetype 2.4.4-4
+  - freetype 2.4.4-5
+  - freetype 2.5.3-1
+  - freetype 2.5.3-2
+  - freetype 2.5.3-3; depends (libpng ~= 1.6.12)
+  - freetype 2.5.3-4; depends (libpng ~= 1.6.12)
+  - funcsigs 0.4-1
+  - future 0.13.1-1
+  - future 0.14.1-1
+  - future 0.14.2-1
+  - future 0.14.3-1
+  - future 0.15.2-1
+  - futures 2.1.4-1
+  - futures 2.1.4-2
+  - futures 2.1.6-1
+  - futures 2.2.0-1
+  - futures 3.0.3-1
+  - fwrap 0.1.1-1; depends (cython ~= 0.14.1, numpy ~= 1.5.1)
+  - fwrap 0.1.1-2; depends (cython ~= 0.14.1, numpy)
+  - fwrap 0.1.1-3; depends (cython, numpy)
+  - fwrap 0.1.1-4; depends (cython, numpy)
+  - fwrap 0.1.1-5; depends (cython, numpy)
+  - fwrap 0.1.1-6; depends (cython, numpy)
+  - fwrap 0.1.1-8; depends (cython, numpy)
+  - fwrap 0.1.1-9; depends (cython, numpy)
+  - fwrap 0.1.1-10; depends (cython, numpy)
+  - fwrap 0.1.1-11; depends (cython, numpy)
+  - fwrap 0.1.1-12; depends (cython, numpy)
+  - fwrap 0.1.1-13; depends (cython, numpy)
+  - fwrap 0.1.1-14; depends (cython, numpy)
+  - fwrap 0.1.1-15; depends (cython, numpy)
+  - fwrap 0.1.1-16; depends (cython, numpy)
+  - gdal 1.7.1-1; depends (libgdal ~= 1.7.2, numpy)
+  - gdal 1.8.1-1; depends (libgdal ~= 1.8.1, numpy ~= 1.6.1)
+  - gdal 1.8.1-2; depends (libgdal ~= 1.8.1, numpy ~= 1.6.1)
+  - gdal 1.9.0-3; depends (numpy ~= 1.7.1, libgdal ~= 1.9.0)
+  - gdal 1.10.0-1; depends (numpy ~= 1.7.1, libgdal ~= 1.10.0)
+  - gdal 1.10.0-2; depends (libgdal ~= 1.10.1, numpy ~= 1.7.1)
+  - gdal 1.10.0-3; depends (libgdal ~= 1.10.1, numpy ~= 1.8.0)
+  - gdal 1.10.0-4; depends (libgdal ~= 1.10.1, numpy ~= 1.8.0)
+  - gdal 1.10.0-5; depends (numpy ~= 1.8.0, libgdal ~= 1.11.0)
+  - gdal 1.10.0-6; depends (numpy ~= 1.8.0, libgdal ~= 1.11.0)
+  - gdal 1.11.0-1; depends (numpy ~= 1.8.0, libgdal ~= 1.11.0)
+  - gdal 1.11.0-2; depends (numpy ~= 1.8.0, libgdal ~= 1.11.0)
+  - gdal 1.11.0-3; depends (numpy ~= 1.8.1, libgdal ~= 1.11.0)
+  - gdal 1.11.0-4; depends (numpy ~= 1.8.1, libgdal ~= 1.11.0)
+  - gdal 1.11.0-5; depends (numpy ~= 1.8.1, libgdal ~= 1.11.0)
+  - gdal 1.11.1-1; depends (numpy ~= 1.8.1, libgdal ~= 1.11.0)
+  - gdal 1.11.2-1; depends (numpy ~= 1.8.1, libgdal ~= 1.11.2)
+  - gdal 1.11.2-2; depends (numpy ~= 1.9.2, libgdal ~= 1.11.2)
+  - gdal 1.11.2-4; depends (numpy ~= 1.9.2, libgdal ~= 1.11.2)
+  - gdal 2.0.1-1; depends (numpy ~= 1.9.2, libgdal ~= 2.0.1)
+  - gdata 2.0.18-1
+  - geojson 1.0.8-1
+  - geos 3.4.2-1
+  - geos 3.5.0-1
+  - gevent 0.13.8-1; depends (greenlet ~= 0.4.1, libevent ~= 2.0.21)
+  - gevent 1.0.0-1; depends (greenlet ~= 0.4.2)
+  - gevent 1.0.1-1; depends (greenlet ~= 0.4.2)
+  - gevent 1.0.1-2; depends (greenlet ~= 0.4.4)
+  - gevent 1.0.1-3; depends (greenlet ~= 0.4.4)
+  - gevent 1.0.1-4; depends (greenlet ~= 0.4.5)
+  - gevent 1.0.1-5; depends (greenlet ~= 0.4.6)
+  - gevent 1.0.2-1; depends (greenlet ~= 0.4.9)
+  - gevent_websocket 0.9.3-1
+  - gitdb 0.6.4-1; depends (smmap ~= 0.9.0)
+  - gitpython 1.0.0-1; depends (gitdb ~= 0.6.4)
+  - glib 2.36.1-1; depends (libxml2 ~= 2.7.8, libffi ~= 3.0.13)
+  - glib 2.36.1-2; depends (libxml2 ~= 2.9.2, libffi ~= 3.0.13)
+  - gmp 5.0.0-1
+  - gmp 5.0.1-1
+  - gmpy 1.11-1; depends (gmp ~= 5.0.0)
+  - gmpy 1.11-2; depends (gmp ~= 5.0.1)
+  - gmpy 1.11-3; depends (gmp ~= 5.0.1)
+  - gnureadline 6.2.5-1; depends (libncurses ~= 5.9)
+  - gnureadline 6.3.3-1; depends (libncurses ~= 5.9)
+  - googlecl 0.9.12-1
+  - graphcanvas 3.0.0-1; depends (enable ~= 3.4.0, networkx ~= 1.4)
+  - graphcanvas 4.0.0-1; depends (enable ~= 4.0.0, networkx ~= 1.5)
+  - graphcanvas 4.0.0-2; depends (networkx ~= 1.6, enable ~= 4.1.0)
+  - graphcanvas 4.0.0-3; depends (enable ~= 4.2.0, networkx ~= 1.6)
+  - graphcanvas 4.0.2-1; depends (networkx ~= 1.6, enable ~= 4.3.0)
+  - graphcanvas 4.0.2-2; depends (networkx ~= 1.8.1, enable ~= 4.3.0)
+  - graphcanvas 4.0.2-3; depends (enable ~= 4.4.1, networkx ~= 1.8.1)
+  - graphcanvas 4.0.2-4; depends (enable ~= 4.4.1, networkx ~= 1.9)
+  - graphcanvas 4.0.2-5; depends (enable ~= 4.4.1, networkx ~= 1.9.1)
+  - graphcanvas 4.0.2-6; depends (networkx ~= 1.9.1, enable ~= 4.5.1)
+  - graphcanvas 4.0.2-7; depends (enable ~= 4.5.1, networkx ~= 1.10)
+  - greenlet 0.4.1-1
+  - greenlet 0.4.2-1
+  - greenlet 0.4.4-1
+  - greenlet 0.4.4-2
+  - greenlet 0.4.5-1
+  - greenlet 0.4.6-1
+  - greenlet 0.4.9-1
+  - grib_api 1.9.9-1
+  - grin 1.2.1-2
+  - gst_plugins_base 0.10.36-2; depends (gstreamer ~= 0.10.36, libtheora ~= 1.1.1)
+  - gstreamer 0.10.36-1; depends (libxml2 ~= 2.7.8, glib ~= 2.36.1)
+  - gstreamer 0.10.36-2; depends (libxml2 ~= 2.7.8, glib ~= 2.36.1)
+  - gstreamer 0.10.36-3; depends (libxml2 ~= 2.9.2, glib ~= 2.36.1)
+  - gunicorn 18.0-1; depends (greenlet ~= 0.4.2, gevent ~= 1.0.0)
+  - gunicorn 19.1.0-1; depends (gevent ~= 1.0.1, greenlet ~= 0.4.2)
+  - gunicorn 19.1.1-1; depends (gevent ~= 1.0.1, greenlet ~= 0.4.4)
+  - gunicorn 19.1.1-3; depends (greenlet ~= 0.4.5, gevent ~= 1.0.1)
+  - gunicorn 19.3.0-1; depends (greenlet ~= 0.4.5, gevent ~= 1.0.1)
+  - gunicorn 19.3.0-2; depends (greenlet ~= 0.4.6, gevent ~= 1.0.1)
+  - gunicorn 19.3.0-3; depends (greenlet ~= 0.4.6, gevent ~= 1.0.1)
+  - gunicorn 19.3.0-4; depends (greenlet ~= 0.4.6, gevent ~= 1.0.1)
+  - gunicorn 19.4.1-1; depends (gevent ~= 1.0.2, greenlet ~= 0.4.9)
+  - h5py 1.3.1-1; depends (numpy ~= 1.5.1)
+  - h5py 1.3.1-2; depends (numpy ~= 1.6.0)
+  - h5py 2.0.0-1; depends (hdf5 ~= 1.8.5.1, numpy ~= 1.6.1)
+  - h5py 2.0.0-2; depends (hdf5 ~= 1.8.9, numpy ~= 1.6.1)
+  - h5py 2.1.3-2; depends (hdf5 ~= 1.8.9, numpy ~= 1.7.1)
+  - h5py 2.2.0-1; depends (numpy ~= 1.7.1, hdf5 ~= 1.8.11)
+  - h5py 2.2.0-2; depends (numpy ~= 1.8.0, hdf5 ~= 1.8.11)
+  - h5py 2.2.1-1; depends (numpy ~= 1.8.0, hdf5 ~= 1.8.11)
+  - h5py 2.3.0-1; depends (numpy ~= 1.8.0, hdf5 ~= 1.8.11)
+  - h5py 2.3.0-2; depends (numpy ~= 1.8.1, hdf5 ~= 1.8.11)
+  - h5py 2.3.1-1; depends (numpy ~= 1.8.1, hdf5 ~= 1.8.11)
+  - h5py 2.4.0-1; depends (numpy ~= 1.8.1, hdf5 ~= 1.8.11)
+  - h5py 2.4.0-2; depends (hdf5 ~= 1.8.14, numpy ~= 1.8.1)
+  - h5py 2.5.0-1; depends (hdf5 ~= 1.8.14, numpy ~= 1.8.1)
+  - h5py 2.5.0-2; depends (hdf5 ~= 1.8.14, numpy ~= 1.9.2)
+  - h5py 2.5.0-3; depends (hdf5 ~= 1.8.15.1, numpy ~= 1.9.2)
+  - h5py 2.5.0-4; depends (hdf5 ~= 1.8.15.1, numpy ~= 1.9.2)
+  - haas 0.6.0-1; depends (enum34 ~= 1.0.4, stevedore ~= 1.1.0)
+  - haas 0.6.0-2; depends (enum34 ~= 1.0.4, stevedore ~= 1.2.0)
+  - haas 0.6.0-3; depends (enum34 ~= 1.0.4, stevedore ~= 1.2.0, six ~= 1.9.0)
+  - haas 0.6.2-1; depends (enum34 ~= 1.0.4, stevedore ~= 1.2.0, six ~= 1.9.0)
+  - haas 0.6.2-2; depends (enum34 ~= 1.0.4, stevedore ~= 1.2.0, six ~= 1.9.0)
+  - haas 0.6.2-3; depends (enum34 ~= 1.0.4, stevedore ~= 1.2.0, six ~= 1.10.0)
+  - haas 0.6.2-4; depends (enum34 ~= 1.1.1, stevedore ~= 1.2.0, six ~= 1.10.0)
+  - hatcher 0.4.2-1; depends (click ~= 3.3, requests ~= 2.5.0, six ~= 1.8.0, okonomiyaki ~= 0.3.3, clint ~= 0.4.1, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.4.2-2; depends (click ~= 3.3, six ~= 1.8.0, okonomiyaki ~= 0.3.3, clint ~= 0.4.1, requests ~= 2.5.1, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.4.2-3; depends (click ~= 3.3, okonomiyaki ~= 0.3.3, clint ~= 0.4.1, requests ~= 2.5.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.4.2-4; depends (click ~= 3.3, okonomiyaki ~= 0.3.3, clint ~= 0.4.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3, requests ~= 2.5.3)
+  - hatcher 0.5.0-1; depends (click ~= 3.3, okonomiyaki ~= 0.3.3, clint ~= 0.4.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3, requests ~= 2.5.3)
+  - hatcher 0.5.0-2; depends (click ~= 3.3, okonomiyaki ~= 0.3.3, clint ~= 0.4.1, six ~= 1.9.0, requests ~= 2.6.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.6.0-1; depends (click ~= 3.3, okonomiyaki ~= 0.3.3, clint ~= 0.4.1, six ~= 1.9.0, requests ~= 2.6.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.6.0-2; depends (click ~= 3.3, clint ~= 0.4.1, six ~= 1.9.0, requests ~= 2.6.0, okonomiyaki ~= 0.5.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.7.0-1; depends (click ~= 3.3, clint ~= 0.4.1, six ~= 1.9.0, requests ~= 2.6.0, okonomiyaki ~= 0.5.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.7.3-1; depends (click ~= 4.0, clint ~= 0.4.1, six ~= 1.9.0, requests ~= 2.6.0, okonomiyaki ~= 0.5.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.0-1; depends (click ~= 4.0, six ~= 1.9.0, requests ~= 2.6.0, okonomiyaki ~= 0.5.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.1-1; depends (click ~= 4.0, okonomiyaki ~= 0.5.1, six ~= 1.9.0, requests ~= 2.6.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.1-2; depends (click ~= 4.0, okonomiyaki ~= 0.5.1, six ~= 1.9.0, requests ~= 2.6.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.1-3; depends (click ~= 4.0, okonomiyaki ~= 0.5.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3, requests ~= 2.6.2)
+  - hatcher 0.8.2-1; depends (click ~= 4.0, okonomiyaki ~= 0.5.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3, requests ~= 2.6.2)
+  - hatcher 0.8.2-2; depends (click ~= 4.0, requests ~= 2.7.0, okonomiyaki ~= 0.5.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.3-1; depends (click ~= 4.0, requests ~= 2.7.0, okonomiyaki ~= 0.5.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.4-1; depends (click ~= 4.0, okonomiyaki ~= 0.7.0, requests ~= 2.7.0, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.4-2; depends (click ~= 4.0, requests ~= 2.7.0, okonomiyaki ~= 0.8.0, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.5-1; depends (okonomiyaki ~= 0.9.0, click ~= 4.0, requests ~= 2.7.0, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.7-1; depends (okonomiyaki ~= 0.9.0, click ~= 4.0, requests ~= 2.7.0, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.7-2; depends (okonomiyaki ~= 0.9.0, click ~= 4.1, requests ~= 2.7.0, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.8-1; depends (okonomiyaki ~= 0.12.0, click ~= 4.1, requests ~= 2.7.0, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.8-2; depends (okonomiyaki ~= 0.13.0, click ~= 4.1, requests ~= 2.7.0, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.8.8-3; depends (click ~= 4.1, requests ~= 2.7.0, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3, okonomiyaki ~= 0.13.1)
+  - hatcher 0.8.8-4; depends (requests ~= 2.8.0, click ~= 4.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3, okonomiyaki ~= 0.13.1)
+  - hatcher 0.8.8-5; depends (requests ~= 2.8.0, click ~= 4.1, six ~= 1.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3, okonomiyaki ~= 0.13.1)
+  - hatcher 0.8.8-6; depends (requests ~= 2.8.0, six ~= 1.10.0, click ~= 4.1, pyyaml ~= 3.11, tabulate ~= 0.7.3, okonomiyaki ~= 0.13.1)
+  - hatcher 0.9.0-1; depends (requests ~= 2.8.0, six ~= 1.10.0, click ~= 4.1, pyyaml ~= 3.11, tabulate ~= 0.7.3, okonomiyaki ~= 0.13.1)
+  - hatcher 0.9.1-1; depends (requests ~= 2.8.0, six ~= 1.10.0, okonomiyaki ~= 0.14.0, click ~= 4.1, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.9.1-2; depends (six ~= 1.10.0, okonomiyaki ~= 0.14.0, requests ~= 2.9.0, click ~= 4.1, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hatcher 0.9.2-1; depends (click ~= 6.2, six ~= 1.10.0, okonomiyaki ~= 0.14.0, requests ~= 2.9.0, pyyaml ~= 3.11, tabulate ~= 0.7.3)
+  - hdf4 4.2r3-1
+  - hdf5 1.8.1-1
+  - hdf5 1.8.3-1
+  - hdf5 1.8.4-1
+  - hdf5 1.8.5.1-1
+  - hdf5 1.8.5.1-2
+  - hdf5 1.8.9-1
+  - hdf5 1.8.9-4
+  - hdf5 1.8.11-1
+  - hdf5 1.8.14-1
+  - hdf5 1.8.15.1-1
+  - heapdict 1.0.0-1
+  - heapdict 1.0.0-2
+  - hello_world 1.0-1
+  - html5lib 0.90-2
+  - html5lib 0.95-1
+  - html5lib 0.999-1
+  - htmltemplate 1.5.0-1
+  - htmltemplate 1.5.0-2
+  - httpbin 0.4.0-1; depends (decorator ~= 4.0.4, markupsafe ~= 0.23, itsdangerous ~= 0.24.0, flask ~= 0.10.1, six ~= 1.10.0)
+  - httpretty 0.8.10-1
+  - humanize 0.5.1-1
+  - hypothesis 1.12.0-1
+  - idle 2.7.1-1; depends (appinst)
+  - idle 2.7.2-1; depends (appinst)
+  - idle 2.7.2-2; depends (appinst)
+  - idle 2.7.3-1; depends (appinst)
+  - idna 2.0-1
+  - into 0.1.3-1; depends (datashape ~= 0.4.2, numpy ~= 1.8.1, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - into 0.1.4-1; depends (datashape ~= 0.4.2, numpy ~= 1.8.1, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - into 0.1.4-2; depends (datashape ~= 0.4.2, numpy ~= 1.8.1, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - into 0.2.1-1; depends (datashape ~= 0.4.2, numpy ~= 1.8.1, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - into 0.2.2-1; depends (datashape ~= 0.4.3, numpy ~= 1.8.1, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - into 0.2.2-2; depends (datashape ~= 0.4.3, numpy ~= 1.8.1, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, pandas ~= 0.15.2, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - into 0.2.2-3; depends (datashape ~= 0.4.3, numpy ~= 1.8.1, pandas ~= 0.16.0, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.8, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - into 0.2.2-4; depends (datashape ~= 0.4.3, numpy ~= 1.8.1, pandas ~= 0.16.0, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.9, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - ipaddress 1.0.7-1
+  - ipaddress 1.0.15-1
+  - ipykernel 4.0.3-2; depends (traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipython4 ~= 4.0.0)
+  - ipykernel 4.1.0-1; depends (traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipython4 ~= 4.0.0)
+  - ipykernel 4.1.0-2; depends (traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipython4 ~= 4.0.0)
+  - ipykernel 4.1.0-3; depends (traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipython4 ~= 4.0.0)
+  - ipykernel 4.1.0-4; depends (traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipython4 ~= 4.0.0)
+  - ipykernel 4.2.0-1; depends (traitlets ~= 4.0.0, jupyter_client ~= 4.1.1, ipython4 ~= 4.0.1)
+  - ipyparallel 4.0.2-1; depends (pyzmq ~= 14.7.0, ipython4 ~= 4.0.0, decorator ~= 4.0.2, ipython_genutils ~= 0.1.0, jupyter_client ~= 4.0.0, ipykernel ~= 4.1.0)
+  - ipyparallel 4.1.0-1; depends (pyzmq ~= 14.7.0, ipykernel ~= 4.2.0, decorator ~= 4.0.4, ipython_genutils ~= 0.1.0, jupyter_client ~= 4.1.1, ipython4 ~= 4.0.1)
+  - ipython 0.10.1-2; depends (appinst)
+  - ipython 0.10.2-1; depends (appinst)
+  - ipython 0.10.2-2; depends (appinst)
+  - ipython 0.11rc1-1; depends (appinst)
+  - ipython 0.11rc4-1; depends (appinst)
+  - ipython 0.11-1; depends (appinst)
+  - ipython 0.12rc1-1; depends (appinst)
+  - ipython 0.12-1; depends (appinst)
+  - ipython 0.12-2; depends (appinst)
+  - ipython 0.12.1-1; depends (appinst)
+  - ipython 0.12.1-2; depends (appinst)
+  - ipython 0.12.1-3; depends (appinst)
+  - ipython 0.13.1-1; depends (appinst)
+  - ipython 0.13.1-2; depends (appinst)
+  - ipython 1.0.0-1; depends (jinja2 ~= 2.6, appinst, pyzmq ~= 2.2.0, pygments ~= 1.6.0, tornado ~= 2.2)
+  - ipython 1.0.0-2; depends (jinja2 ~= 2.6, appinst, pyzmq ~= 2.2.0, pygments ~= 1.6.0, tornado ~= 2.2)
+  - ipython 1.1.0-1; depends (jinja2 ~= 2.6, appinst, pyzmq ~= 2.2.0, pygments ~= 1.6.0, tornado ~= 2.2)
+  - ipython 1.1.0-2; depends (jinja2 ~= 2.6, appinst, pyzmq ~= 2.2.0, pygments ~= 1.6.0, tornado ~= 3.1.1)
+  - ipython 1.1.0-3; depends (jinja2 ~= 2.7.1, appinst, pyzmq ~= 2.2.0, pygments ~= 1.6.0, tornado ~= 3.1.1)
+  - ipython 1.1.0-6; depends (jinja2 ~= 2.7.1, appinst, pyzmq ~= 2.2.0, pygments ~= 1.6.0, tornado ~= 3.1.1)
+  - ipython 1.2.1-2; depends (jinja2 ~= 2.7.1, appinst, pyzmq ~= 2.2.0, pygments ~= 1.6.0, tornado ~= 3.1.1)
+  - ipython 1.2.1-3; depends (jinja2 ~= 2.7.1, appinst, pyzmq ~= 14.1.1, pygments ~= 1.6.0, tornado ~= 3.1.1)
+  - ipython 2.0.0-1; depends (jinja2 ~= 2.7.1, appinst, pyzmq ~= 14.1.1, pygments ~= 1.6.0, tornado ~= 3.1.1)
+  - ipython 2.1.0-1; depends (jinja2 ~= 2.7.1, appinst, pyzmq ~= 14.1.1, pygments ~= 1.6.0, tornado ~= 3.1.1)
+  - ipython 2.1.0-2; depends (appinst, jinja2 ~= 2.7.3, pyzmq ~= 14.1.1, pygments ~= 1.6.0, tornado ~= 3.1.1)
+  - ipython 2.1.0-3; depends (appinst, jinja2 ~= 2.7.3, pyzmq ~= 14.1.1, tornado ~= 3.2.2, pygments ~= 1.6.0)
+  - ipython 2.1.0-6; depends (pyzmq ~= 14.3.1, appinst, jinja2 ~= 2.7.3, tornado ~= 3.2.2, pygments ~= 1.6.0)
+  - ipython 2.2.0-1; depends (pyzmq ~= 14.3.1, appinst, jinja2 ~= 2.7.3, tornado ~= 3.2.2, pygments ~= 1.6.0)
+  - ipython 2.2.0-2; depends (pyzmq ~= 14.3.1, appinst, jinja2 ~= 2.7.3, tornado ~= 4.0.1, pygments ~= 1.6.0)
+  - ipython 2.2.0-3; depends (pyzmq ~= 14.3.1, appinst, jinja2 ~= 2.7.3, pygments ~= 1.6.0, tornado ~= 4.0.2)
+  - ipython 2.3.0-1; depends (pyzmq ~= 14.3.1, appinst, jinja2 ~= 2.7.3, pygments ~= 1.6.0, tornado ~= 4.0.2)
+  - ipython 2.3.1-1; depends (pyzmq ~= 14.3.1, appinst, jinja2 ~= 2.7.3, pygments ~= 2.0.1, tornado ~= 4.0.2)
+  - ipython 2.3.1-2; depends (appinst, jinja2 ~= 2.7.3, pyzmq ~= 14.4.1, pygments ~= 2.0.1, tornado ~= 4.0.2)
+  - ipython 2.3.1-3; depends (appinst, jinja2 ~= 2.7.3, pyzmq ~= 14.4.1, pygments ~= 2.0.2, tornado ~= 4.0.2)
+  - ipython 2.3.1-4; depends (appinst, jinja2 ~= 2.7.3, pyzmq ~= 14.5.0, pygments ~= 2.0.2, tornado ~= 4.0.2)
+  - ipython 2.4.1-1; depends (appinst, jinja2 ~= 2.7.3, pyzmq ~= 14.5.0, pygments ~= 2.0.2, tornado ~= 4.1)
+  - ipython 3.0.0-1; depends (pyzmq ~= 14.5.0, mistune ~= 0.5, pygments ~= 2.0.2, jsonschema ~= 2.4.0, terminado ~= 0.5, jinja2 ~= 2.7.3, tornado ~= 4.1, appinst)
+  - ipython 3.0.0-2; depends (pyzmq ~= 14.5.0, mistune ~= 0.5, pygments ~= 2.0.2, jsonschema ~= 2.4.0, terminado ~= 0.5, jinja2 ~= 2.7.3, tornado ~= 4.1, appinst)
+  - ipython 3.0.0-3; depends (mistune ~= 0.5.1, pygments ~= 2.0.2, pyzmq ~= 14.5.0, jsonschema ~= 2.4.0, terminado ~= 0.5, jinja2 ~= 2.7.3, tornado ~= 4.1, appinst)
+  - ipython 3.1.0-1; depends (mistune ~= 0.5.1, pygments ~= 2.0.2, pyzmq ~= 14.5.0, jsonschema ~= 2.4.0, terminado ~= 0.5, jinja2 ~= 2.7.3, tornado ~= 4.1, appinst)
+  - ipython 3.1.0-2; depends (mistune ~= 0.5.1, pygments ~= 2.0.2, jsonschema ~= 2.4.0, terminado ~= 0.5, jinja2 ~= 2.7.3, tornado ~= 4.1, appinst, pyzmq ~= 14.6.0)
+  - ipython 3.2.0-1; depends (mistune ~= 0.6, tornado ~= 4.2, pygments ~= 2.0.2, jsonschema ~= 2.4.0, pyzmq ~= 14.7.0, terminado ~= 0.5, jinja2 ~= 2.7.3, appinst)
+  - ipython 3.2.1-1; depends (mistune ~= 0.6, tornado ~= 4.2, pygments ~= 2.0.2, jsonschema ~= 2.4.0, pyzmq ~= 14.7.0, terminado ~= 0.5, jinja2 ~= 2.7.3, appinst)
+  - ipython 4.0.0-2; depends (jupyter ~= 1.0.0)
+  - ipython 4.0.0-3; depends (jupyter ~= 1.0.0)
+  - ipython4 4.0.0-2; depends (simplegeneric ~= 0.8.1, decorator ~= 4.0.2, gnureadline ~= 6.2.5, appinst, pickleshare ~= 0.5, pexpect ~= 3.3, traitlets ~= 4.0.0)
+  - ipython4 4.0.0-3; depends (simplegeneric ~= 0.8.1, decorator ~= 4.0.2, gnureadline ~= 6.2.5, appinst, pickleshare ~= 0.5, traitlets ~= 4.0.0)
+  - ipython4 4.0.0-4; depends (simplegeneric ~= 0.8.1, decorator ~= 4.0.2, gnureadline ~= 6.2.5, appinst, pickleshare ~= 0.5, pexpect ~= 3.3, traitlets ~= 4.0.0)
+  - ipython4 4.0.0-5; depends (simplegeneric ~= 0.8.1, decorator ~= 4.0.2, gnureadline ~= 6.3.3, appinst, pickleshare ~= 0.5, pexpect ~= 3.3, traitlets ~= 4.0.0)
+  - ipython4 4.0.0-7; depends (simplegeneric ~= 0.8.1, decorator ~= 4.0.2, gnureadline ~= 6.3.3, appinst, pickleshare ~= 0.5, pexpect ~= 3.3, traitlets ~= 4.0.0)
+  - ipython4 4.0.0-8; depends (simplegeneric ~= 0.8.1, decorator ~= 4.0.2, gnureadline ~= 6.3.3, appinst, pickleshare ~= 0.5, pexpect ~= 3.3, traitlets ~= 4.0.0)
+  - ipython4 4.0.0-9; depends (simplegeneric ~= 0.8.1, decorator ~= 4.0.2, gnureadline ~= 6.3.3, appinst, pickleshare ~= 0.5, pexpect ~= 3.3, traitlets ~= 4.0.0)
+  - ipython4 4.0.1-1; depends (simplegeneric ~= 0.8.1, gnureadline ~= 6.3.3, appinst, decorator ~= 4.0.4, pexpect ~= 3.3, pickleshare ~= 0.5, traitlets ~= 4.0.0)
+  - ipython_genutils 0.1.0-1
+  - ipywidgets 4.0.2-2; depends (ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, notebook ~= 4.0.4, ipython4 ~= 4.0.0, ipykernel ~= 4.0.3)
+  - ipywidgets 4.0.3-1; depends (ipython_genutils ~= 0.1.0, notebook ~= 4.0.5, traitlets ~= 4.0.0, ipython4 ~= 4.0.0, ipykernel ~= 4.0.3)
+  - ipywidgets 4.0.3-2; depends (ipython_genutils ~= 0.1.0, notebook ~= 4.0.5, traitlets ~= 4.0.0, ipython4 ~= 4.0.0, ipykernel ~= 4.1.0)
+  - ipywidgets 4.1.1-1; depends (ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, notebook ~= 4.0.6, ipykernel ~= 4.2.0, ipython4 ~= 4.0.1)
+  - iris 1.6.1-1; depends (numpy ~= 1.8.0, pil ~= 1.1.7, shapely ~= 1.2.17, cartopy ~= 0.10.0, pandas ~= 0.14.0, expat ~= 2.0.1, pygrib ~= 1.9.2, scipy ~= 0.14.0, gdal ~= 1.10.0, libudunits ~= 2.2.11, matplotlib ~= 1.3.1, pyke ~= 1.1.1, netcdf4 ~= 1.0.7)
+  - iris 1.6.1-2; depends (numpy ~= 1.8.0, pil ~= 1.1.7, shapely ~= 1.2.17, netcdf4 ~= 1.1.0, cartopy ~= 0.10.0, pandas ~= 0.14.0, expat ~= 2.0.1, pygrib ~= 1.9.2, scipy ~= 0.14.0, libudunits ~= 2.2.11, matplotlib ~= 1.3.1, pyke ~= 1.1.1, gdal ~= 1.11.0)
+  - iris 1.6.1-3; depends (numpy ~= 1.8.0, pil ~= 1.1.7, shapely ~= 1.2.17, netcdf4 ~= 1.1.0, cartopy ~= 0.10.0, pandas ~= 0.14.0, expat ~= 2.0.1, scipy ~= 0.14.0, libudunits ~= 2.2.11, matplotlib ~= 1.3.1, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0)
+  - iris 1.6.1-4; depends (shapely ~= 1.3.2, numpy ~= 1.8.0, pil ~= 1.1.7, netcdf4 ~= 1.1.0, cartopy ~= 0.10.0, pandas ~= 0.14.0, expat ~= 2.0.1, scipy ~= 0.14.0, libudunits ~= 2.2.11, matplotlib ~= 1.3.1, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0)
+  - iris 1.6.1-6; depends (shapely ~= 1.3.2, numpy ~= 1.8.0, pil ~= 1.1.7, netcdf4 ~= 1.1.0, cartopy ~= 0.10.0, expat ~= 2.0.1, scipy ~= 0.14.0, libudunits ~= 2.2.11, matplotlib ~= 1.3.1, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0, pandas ~= 0.14.1)
+  - iris 1.6.1-8; depends (numpy ~= 1.8.1, shapely ~= 1.3.2, pil ~= 1.1.7, netcdf4 ~= 1.1.0, cartopy ~= 0.10.0, expat ~= 2.0.1, scipy ~= 0.14.0, libudunits ~= 2.2.11, matplotlib ~= 1.4.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0, pandas ~= 0.14.1)
+  - iris 1.6.1-9; depends (numpy ~= 1.8.1, shapely ~= 1.3.2, netcdf4 ~= 1.1.1, pil ~= 1.1.7, cartopy ~= 0.10.0, expat ~= 2.0.1, scipy ~= 0.14.0, libudunits ~= 2.2.11, matplotlib ~= 1.4.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0, pandas ~= 0.14.1)
+  - iris 1.7.1-1; depends (pandas ~= 0.14.1, numpy ~= 1.8.1, shapely ~= 1.3.2, netcdf4 ~= 1.1.1, pil ~= 1.1.7, expat ~= 2.0.1, scipy ~= 0.14.0, cartopy ~= 0.11.0, libudunits ~= 2.2.11, matplotlib ~= 1.4.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0, biggus ~= 0.7.0)
+  - iris 1.7.1-2; depends (pandas ~= 0.14.1, numpy ~= 1.8.1, netcdf4 ~= 1.1.1, pil ~= 1.1.7, expat ~= 2.0.1, scipy ~= 0.14.0, shapely ~= 1.4.1, cartopy ~= 0.11.0, libudunits ~= 2.2.11, matplotlib ~= 1.4.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0, biggus ~= 0.7.0)
+  - iris 1.7.1-3; depends (numpy ~= 1.8.1, pandas ~= 0.15.0, netcdf4 ~= 1.1.1, pil ~= 1.1.7, expat ~= 2.0.1, scipy ~= 0.14.0, shapely ~= 1.4.1, cartopy ~= 0.11.0, libudunits ~= 2.2.11, matplotlib ~= 1.4.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0, biggus ~= 0.7.0)
+  - iris 1.7.1-4; depends (numpy ~= 1.8.1, pandas ~= 0.15.0, netcdf4 ~= 1.1.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, expat ~= 2.0.1, scipy ~= 0.14.0, shapely ~= 1.4.1, cartopy ~= 0.11.0, libudunits ~= 2.2.11, pyke ~= 1.1.1, pygrib ~= 1.9.9, gdal ~= 1.11.0, biggus ~= 0.7.0)
+  - iris 1.7.1-5; depends (numpy ~= 1.8.1, pandas ~= 0.15.0, netcdf4 ~= 1.1.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, gdal ~= 1.11.1, expat ~= 2.0.1, scipy ~= 0.14.0, shapely ~= 1.4.1, cartopy ~= 0.11.0, libudunits ~= 2.2.11, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0)
+  - iris 1.7.1-7; depends (numpy ~= 1.8.1, netcdf4 ~= 1.1.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, gdal ~= 1.11.1, expat ~= 2.0.1, scipy ~= 0.14.0, cartopy ~= 0.11.0, libudunits ~= 2.2.11, pandas ~= 0.15.1, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, shapely ~= 1.5.1)
+  - iris 1.7.1-8; depends (numpy ~= 1.8.1, netcdf4 ~= 1.1.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, gdal ~= 1.11.1, expat ~= 2.0.1, scipy ~= 0.14.0, pandas ~= 0.15.2, cartopy ~= 0.11.0, libudunits ~= 2.2.11, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, shapely ~= 1.5.1)
+  - iris 1.7.3-1; depends (shapely ~= 1.5.1, numpy ~= 1.8.1, netcdf4 ~= 1.1.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, gdal ~= 1.11.1, expat ~= 2.0.1, scipy ~= 0.14.0, pandas ~= 0.15.2, cartopy ~= 0.11.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-2; depends (shapely ~= 1.5.1, numpy ~= 1.8.1, netcdf4 ~= 1.1.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, gdal ~= 1.11.1, expat ~= 2.0.1, scipy ~= 0.14.1rc1, pandas ~= 0.15.2, cartopy ~= 0.11.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-3; depends (shapely ~= 1.5.1, numpy ~= 1.8.1, netcdf4 ~= 1.1.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, gdal ~= 1.11.1, expat ~= 2.0.1, cartopy ~= 0.11.2, scipy ~= 0.14.1rc1, pandas ~= 0.15.2, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-4; depends (shapely ~= 1.5.1, numpy ~= 1.8.1, netcdf4 ~= 1.1.1, scipy ~= 0.15.1, pil ~= 1.1.7, matplotlib ~= 1.4.2, gdal ~= 1.11.1, expat ~= 2.0.1, cartopy ~= 0.11.2, pandas ~= 0.15.2, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-5; depends (shapely ~= 1.5.1, numpy ~= 1.8.1, netcdf4 ~= 1.1.1, scipy ~= 0.15.1, pil ~= 1.1.7, gdal ~= 1.11.1, expat ~= 2.0.1, cartopy ~= 0.11.2, pandas ~= 0.15.2, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-6; depends (shapely ~= 1.5.1, numpy ~= 1.8.1, netcdf4 ~= 1.1.1, scipy ~= 0.15.1, pil ~= 1.1.7, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, pandas ~= 0.15.2, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-7; depends (shapely ~= 1.5.1, numpy ~= 1.8.1, netcdf4 ~= 1.1.1, pandas ~= 0.16.0, pil ~= 1.1.7, scipy ~= 0.15.1, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-8; depends (shapely ~= 1.5.1, numpy ~= 1.8.1, scipy ~= 0.15.1, pandas ~= 0.16.0, pil ~= 1.1.7, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, netcdf4 ~= 1.1.7.1, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-9; depends (shapely ~= 1.5.1, scipy ~= 0.15.1, pandas ~= 0.16.0, pil ~= 1.1.7, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, netcdf4 ~= 1.1.7.1, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-10; depends (shapely ~= 1.5.1, pillow ~= 2.8.1, scipy ~= 0.15.1, pandas ~= 0.16.0, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, netcdf4 ~= 1.1.7.1, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-11; depends (shapely ~= 1.5.1, pillow ~= 2.8.1, scipy ~= 0.15.1, pandas ~= 0.16.0, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, netcdf4 ~= 1.1.7.1, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-12; depends (pyke ~= 1.1.1, pillow ~= 2.8.1, shapely ~= 1.5.1, scipy ~= 0.15.1, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, netcdf4 ~= 1.1.7.1, matplotlib ~= 1.4.3, pandas ~= 0.16.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-13; depends (shapely ~= 1.5.1, pillow ~= 2.8.1, scipy ~= 0.15.1, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, pandas ~= 0.16.2, netcdf4 ~= 1.1.7.1, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-14; depends (shapely ~= 1.5.1, pillow ~= 2.9.0, scipy ~= 0.15.1, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, pandas ~= 0.16.2, netcdf4 ~= 1.1.7.1, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-15; depends (shapely ~= 1.5.1, pillow ~= 2.9.0, scipy ~= 0.15.1, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, pandas ~= 0.16.2, netcdf4 ~= 1.2.0, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-16; depends (shapely ~= 1.5.1, pillow ~= 2.9.0, scipy ~= 0.16.0, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, pandas ~= 0.16.2, netcdf4 ~= 1.2.0, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-17; depends (shapely ~= 1.5.1, pillow ~= 2.9.0, scipy ~= 0.16.0, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, pandas ~= 0.16.2, netcdf4 ~= 1.2.0, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-19; depends (pandas ~= 0.17.1, shapely ~= 1.5.1, scipy ~= 0.16.1, pillow ~= 2.9.0, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, numpy ~= 1.9.2, netcdf4 ~= 1.2.0, matplotlib ~= 1.4.3, pygrib ~= 1.9.9, pyke ~= 1.1.1, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-20; depends (pandas ~= 0.17.1, shapely ~= 1.5.1, scipy ~= 0.16.1, pillow ~= 2.9.0, gdal ~= 1.11.2, expat ~= 2.0.1, cartopy ~= 0.11.2, matplotlib ~= 1.5.0, numpy ~= 1.9.2, netcdf4 ~= 1.2.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.7.3-21; depends (pandas ~= 0.17.1, shapely ~= 1.5.1, scipy ~= 0.16.1, pillow ~= 2.9.0, expat ~= 2.0.1, cartopy ~= 0.11.2, matplotlib ~= 1.5.0, gdal ~= 2.0.1, numpy ~= 1.9.2, netcdf4 ~= 1.2.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.8.1-1; depends (pandas ~= 0.17.1, scipy ~= 0.16.1, pillow ~= 2.9.0, cartopy ~= 0.13.0, shapely ~= 1.5.13, expat ~= 2.0.1, matplotlib ~= 1.5.0, gdal ~= 2.0.1, numpy ~= 1.9.2, netcdf4 ~= 1.2.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iris 1.8.1-2; depends (pandas ~= 0.17.1, pillow ~= 3.0.0, scipy ~= 0.16.1, cartopy ~= 0.13.0, shapely ~= 1.5.13, expat ~= 2.0.1, matplotlib ~= 1.5.0, gdal ~= 2.0.1, numpy ~= 1.9.2, netcdf4 ~= 1.2.0, pyke ~= 1.1.1, pygrib ~= 1.9.9, biggus ~= 0.7.0, libudunits ~= 2.2.17)
+  - iso8601 0.1.10-1
+  - isodate 0.5.1-1
+  - itsdangerous 0.23.0-1
+  - itsdangerous 0.24.0-1
+  - jasper 1.9-1
+  - jdcal 1.0.0-1
+  - jedi 0.9.0-1
+  - jedi 0.9.0-2
+  - jinja2 2.5.5-2; depends (pygments ~= 1.3.1)
+  - jinja2 2.5.5-3; depends (pygments ~= 1.4)
+  - jinja2 2.6-1; depends (pygments ~= 1.4)
+  - jinja2 2.6-2
+  - jinja2 2.7.1-1; depends (markupsafe ~= 0.18)
+  - jinja2 2.7.3-1; depends (markupsafe ~= 0.18)
+  - jinja2 2.7.3-2; depends (markupsafe ~= 0.23)
+  - jinja2 2.8-1; depends (markupsafe ~= 0.23)
+  - joblib 0.8.4-1
+  - jsonpickle 0.3.1-1
+  - jsonpickle 0.4.0-1
+  - jsonschema 2.4.0-1
+  - jupyter 1.0.0-1; depends (ipywidgets ~= 4.0.2, notebook ~= 4.0.4, nbconvert ~= 4.0.0, qtconsole ~= 4.0.1, ipykernel ~= 4.0.3, jupyter_console ~= 4.0.2)
+  - jupyter 1.0.0-3; depends (notebook ~= 4.0.5, nbconvert ~= 4.0.0, qtconsole ~= 4.0.1, ipykernel ~= 4.0.3, ipywidgets ~= 4.0.3, jupyter_console ~= 4.0.2)
+  - jupyter 1.0.0-4; depends (notebook ~= 4.0.5, nbconvert ~= 4.0.0, qtconsole ~= 4.0.1, ipywidgets ~= 4.0.3, jupyter_console ~= 4.0.2, ipykernel ~= 4.1.0)
+  - jupyter 1.0.0-5; depends (notebook ~= 4.0.5, nbconvert ~= 4.0.0, qtconsole ~= 4.0.1, ipywidgets ~= 4.0.3, jupyter_console ~= 4.0.2, ipykernel ~= 4.1.0)
+  - jupyter 1.0.0-6; depends (nbconvert ~= 4.1.0, jupyter_console ~= 4.0.3, qtconsole ~= 4.1.1, ipykernel ~= 4.2.0, ipywidgets ~= 4.1.1, notebook ~= 4.0.6)
+  - jupyter_client 4.0.0-1; depends (jupyter_core ~= 4.0.4, pyzmq ~= 14.7.0, traitlets ~= 4.0.0)
+  - jupyter_client 4.0.0-2; depends (jupyter_core ~= 4.0.6, pyzmq ~= 14.7.0, traitlets ~= 4.0.0)
+  - jupyter_client 4.1.1-1; depends (jupyter_core ~= 4.0.6, pyzmq ~= 14.7.0, traitlets ~= 4.0.0)
+  - jupyter_console 4.0.2-2; depends (jupyter_client ~= 4.0.0, ipython4 ~= 4.0.0, ipykernel ~= 4.0.3)
+  - jupyter_console 4.0.2-3; depends (jupyter_client ~= 4.0.0, ipython4 ~= 4.0.0, ipykernel ~= 4.1.0)
+  - jupyter_console 4.0.3-1; depends (jupyter_client ~= 4.1.1, ipykernel ~= 4.2.0, ipython4 ~= 4.0.1)
+  - jupyter_core 4.0.4-1; depends (traitlets ~= 4.0.0)
+  - jupyter_core 4.0.6-1; depends (traitlets ~= 4.0.0)
+  - jupyter_core 4.0.6-2; depends (traitlets ~= 4.0.0)
+  - jupyter_core 4.0.6-3; depends (traitlets ~= 4.0.0)
+  - jupyter_core 4.0.6-4; depends (traitlets ~= 4.0.0)
+  - kernmagic 0.1.0-1; depends (ipython ~= 0.12.1)
+  - kernmagic 0.2.0-1; depends (ipython ~= 0.13.1)
+  - kernmagic 0.2.0-2; depends (ipython ~= 1.0.0)
+  - kernmagic 0.2.0-4; depends (ipython ~= 3.1.0)
+  - kernmagic 0.2.0-5; depends (ipython ~= 3.2.0)
+  - kernmagic 0.2.0-6; depends (ipython ~= 3.2.1)
+  - kernmagic 0.2.0-7; depends (ipython4 ~= 4.0.0)
+  - kernmagic 0.2.0-8; depends (ipython4 ~= 4.0.1)
+  - keyring 0.5.1-1
+  - keyring 0.6.2-1
+  - keyring 0.7.1-1
+  - keyring 0.9-1
+  - keyring 0.9.2-1
+  - keyring 3.7.0-1
+  - keyring 4.0-1
+  - keyring 4.0-3
+  - keyring 4.0-4
+  - keyring 4.0-5
+  - kiwisolver 0.1.2-1
+  - kiwisolver 0.1.3-1
+  - kiwisolver 0.1.3-2
+  - kombu 3.0.21-2; depends (amqp ~= 1.4.5, anyjson ~= 0.3.3)
+  - kombu 3.0.21-3; depends (amqp ~= 1.4.5, anyjson ~= 0.3.3)
+  - larry 0.4.0-2; depends (h5py ~= 1.3.1, numpy ~= 1.5.1)
+  - larry 0.4.0-3; depends (h5py ~= 1.3.1, numpy ~= 1.6.0)
+  - larry 0.6.0-3; depends (bottleneck ~= 0.6.0, numpy ~= 1.7.1, h5py ~= 2.1.3)
+  - larry 0.6.0-4; depends (h5py ~= 2.2.0, bottleneck ~= 0.7.0, numpy ~= 1.7.1)
+  - larry 0.6.0-5; depends (h5py ~= 2.2.0, bottleneck ~= 0.7.0, numpy ~= 1.8.0)
+  - larry 0.6.0-6; depends (numpy ~= 1.8.0, bottleneck ~= 0.7.0, h5py ~= 2.2.1)
+  - larry 0.6.0-8; depends (bottleneck ~= 0.7.0, h5py ~= 2.3.0, numpy ~= 1.8.1)
+  - larry 0.6.0-9; depends (bottleneck ~= 0.7.0, numpy ~= 1.8.1, h5py ~= 2.3.1)
+  - larry 0.6.0-10; depends (bottleneck ~= 0.7.0, h5py ~= 2.4.0, numpy ~= 1.8.1)
+  - larry 0.6.0-11; depends (bottleneck ~= 0.7.0, numpy ~= 1.8.1, h5py ~= 2.5.0)
+  - larry 0.6.0-12; depends (bottleneck ~= 0.7.0, numpy ~= 1.9.2, h5py ~= 2.5.0)
+  - larry 0.6.0-13; depends (numpy ~= 1.9.2, bottleneck ~= 1.0.0, h5py ~= 2.5.0)
+  - lib_netcdf3 3.6.2-6
+  - lib_netcdf4 4.0-1
+  - lib_netcdf4 4.0-3
+  - lib_netcdf4 4.0.1-1
+  - lib_netcdf4 4.1.1-1
+  - lib_netcdf4 4.1.1-2; depends (curl ~= 7.25.0)
+  - lib_netcdf4 4.2-1; depends (hdf5 ~= 1.8.9, curl ~= 7.25.0)
+  - lib_netcdf4 4.2-2; depends (hdf5 ~= 1.8.9, curl ~= 7.25.0)
+  - lib_netcdf4 4.3.0-1; depends (hdf5 ~= 1.8.9, curl ~= 7.25.0)
+  - lib_netcdf4 4.3.0-2; depends (hdf5 ~= 1.8.9, curl ~= 7.25.0)
+  - lib_netcdf4 4.3.0-3; depends (hdf5 ~= 1.8.9, curl ~= 7.25.0)
+  - lib_netcdf4 4.3.0-4; depends (curl ~= 7.25.0, hdf5 ~= 1.8.11)
+  - lib_netcdf4 4.3.2-1; depends (curl ~= 7.37.0, hdf5 ~= 1.8.11)
+  - lib_netcdf4 4.3.2-2; depends (curl ~= 7.38.0, hdf5 ~= 1.8.11)
+  - lib_netcdf4 4.3.2-3; depends (hdf5 ~= 1.8.14, curl ~= 7.38.0)
+  - lib_netcdf4 4.3.3.1-1; depends (curl ~= 7.43.0, hdf5 ~= 1.8.15.1)
+  - libblosc 1.3.5-1
+  - libblosc 1.4.1-1
+  - libdynd 0.6.6-1
+  - libevent 2.0.21-1
+  - libffi 3.0.13-1
+  - libffi 3.0.13-2
+  - libgdal 1.7.2-1; depends (expat ~= 2.0.1)
+  - libgdal 1.8.1-1
+  - libgdal 1.9.0-2
+  - libgdal 1.10.0-1; depends (hdf5 ~= 1.8.9, curl ~= 7.25.0)
+  - libgdal 1.10.0-2; depends (libxml2 ~= 2.7.8, hdf5 ~= 1.8.9, curl ~= 7.25.0, expat ~= 2.0.1)
+  - libgdal 1.10.1-1; depends (libxml2 ~= 2.7.8, hdf5 ~= 1.8.9, curl ~= 7.25.0, expat ~= 2.0.1)
+  - libgdal 1.10.1-2; depends (hdf5 ~= 1.8.11, libxml2 ~= 2.7.8, curl ~= 7.25.0, expat ~= 2.0.1)
+  - libgdal 1.10.1-4; depends (hdf5 ~= 1.8.11, libxml2 ~= 2.7.8, curl ~= 7.25.0, expat ~= 2.0.1)
+  - libgdal 1.11.0-1; depends (hdf5 ~= 1.8.11, lib_netcdf4 ~= 4.3.0, libxml2 ~= 2.7.8, curl ~= 7.25.0, expat ~= 2.0.1)
+  - libgdal 1.11.0-2; depends (hdf5 ~= 1.8.11, lib_netcdf4 ~= 4.3.0, libxml2 ~= 2.7.8, curl ~= 7.25.0, expat ~= 2.0.1)
+  - libgdal 1.11.0-3; depends (hdf5 ~= 1.8.11, lib_netcdf4 ~= 4.3.0, libxml2 ~= 2.7.8, curl ~= 7.25.0, expat ~= 2.0.1)
+  - libgdal 1.11.0-4; depends (hdf5 ~= 1.8.11, libxml2 ~= 2.7.8, curl ~= 7.37.0, lib_netcdf4 ~= 4.3.2, expat ~= 2.0.1)
+  - libgdal 1.11.0-5; depends (hdf5 ~= 1.8.11, libxml2 ~= 2.7.8, curl ~= 7.38.0, lib_netcdf4 ~= 4.3.2, expat ~= 2.0.1)
+  - libgdal 1.11.0-6; depends (hdf5 ~= 1.8.11, libxml2 ~= 2.9.2, curl ~= 7.38.0, lib_netcdf4 ~= 4.3.2, expat ~= 2.0.1)
+  - libgdal 1.11.0-7; depends (lib_netcdf4 ~= 4.3.2, curl ~= 7.38.0, expat ~= 2.0.1, libxml2 ~= 2.9.2, hdf5 ~= 1.8.11, libpng ~= 1.6.12)
+  - libgdal 1.11.0-8; depends (lib_netcdf4 ~= 4.3.2, curl ~= 7.38.0, expat ~= 2.0.1, libxml2 ~= 2.9.2, hdf5 ~= 1.8.14, libpng ~= 1.6.12)
+  - libgdal 1.11.2-1; depends (lib_netcdf4 ~= 4.3.2, curl ~= 7.38.0, expat ~= 2.0.1, libxml2 ~= 2.9.2, hdf5 ~= 1.8.14, libpng ~= 1.6.12)
+  - libgdal 1.11.2-2; depends (hdf5 ~= 1.8.15.1, lib_netcdf4 ~= 4.3.3.1, expat ~= 2.0.1, curl ~= 7.43.0, libxml2 ~= 2.9.2, libpng ~= 1.6.12)
+  - libgdal 2.0.1-1; depends (hdf5 ~= 1.8.15.1, lib_netcdf4 ~= 4.3.3.1, expat ~= 2.0.1, curl ~= 7.43.0, libxml2 ~= 2.9.2, libpng ~= 1.6.12)
+  - libgfortran 3.0.0-1
+  - libgfortran 3.0.0-2
+  - libgnomevfs 2.0-1
+  - libjpeg 7.0-2
+  - libjpeg 7.0-3
+  - libncurses 5.9-1
+  - libopenjpeg 2.1.0-1; depends (libpng ~= 1.6.12)
+  - libopenjpeg 2.1.0-2; depends (libpng ~= 1.6.12)
+  - libpng 1.2.40-4
+  - libpng 1.2.40-5
+  - libpng 1.6.12-1
+  - libpng 1.6.12-3
+  - libproj 4.8.0-1
+  - libproj 4.8.0-2
+  - libproj 4.8.0-3
+  - libsodium 1.0.3-1
+  - libtheora 1.1.1-1
+  - libudunits 2.2.11-1; depends (expat ~= 2.0.1)
+  - libudunits 2.2.17-2; depends (expat ~= 2.0.1)
+  - libxml2 2.6.32-1
+  - libxml2 2.7.3-1
+  - libxml2 2.7.3-3
+  - libxml2 2.7.8-1; depends (zlib ~= 1.2.6)
+  - libxml2 2.7.8-3
+  - libxml2 2.7.8-4
+  - libxml2 2.9.2-1
+  - libxml2 2.9.2-2
+  - libxslt 1.1.24-1; depends (libxml2 ~= 2.6.32)
+  - libxslt 1.1.24-3; depends (libxml2 ~= 2.7.3)
+  - libxslt 1.1.24-5; depends (libxml2 ~= 2.7.3)
+  - libxslt 1.1.26-1; depends (libxml2 ~= 2.7.8)
+  - libxslt 1.1.26-3; depends (libxml2 ~= 2.7.8)
+  - libxslt 1.1.28-1; depends (libxml2 ~= 2.9.2)
+  - libxslt 1.1.28-2; depends (libxml2 ~= 2.9.2)
+  - libxslt 1.1.28-3; depends (libxml2 ~= 2.9.2)
+  - libyaml 0.1.3-1
+  - libyaml 0.1.4-1
+  - line_profiler 1.0-1
+  - linecache2 1.0.0-1
+  - llvm 3.2-1
+  - llvm 3.3-1
+  - llvm 3.5.1-1
+  - llvm 3.6.1-1
+  - llvmlite 0.2.2-1; depends (enum34 ~= 1.0.4)
+  - llvmlite 0.4.0-1; depends (enum34 ~= 1.0.4)
+  - llvmlite 0.5.0-1; depends (enum34 ~= 1.0.4)
+  - llvmlite 0.6.0-1; depends (enum34 ~= 1.0.4)
+  - llvmlite 0.7.0-1; depends (enum34 ~= 1.0.4)
+  - llvmlite 0.8.0-1; depends (enum34 ~= 1.0.4)
+  - llvmlite 0.8.0-2; depends (enum34 ~= 1.1.1)
+  - llvmmath 0.1.0-1; depends (numpy ~= 1.7.1, llvmpy ~= 0.11.3)
+  - llvmmath 0.1.1-1; depends (numpy ~= 1.7.1, llvmpy ~= 0.11.3)
+  - llvmmath 0.1.1-2; depends (llvmpy ~= 0.12.0, numpy ~= 1.7.1)
+  - llvmmath 0.1.1-3; depends (llvmpy ~= 0.12.0, numpy ~= 1.8.0)
+  - llvmmath 0.1.1-4; depends (numpy ~= 1.8.0, llvmpy ~= 0.12.1)
+  - llvmmath 0.1.1-5; depends (numpy ~= 1.8.0, llvmpy ~= 0.12.6)
+  - llvmmath 0.1.1-6; depends (llvmpy ~= 0.12.6, numpy ~= 1.8.1)
+  - llvmmath 0.1.2-1; depends (llvmpy ~= 0.12.7, numpy ~= 1.8.1)
+  - llvmpy 0.11.3-1
+  - llvmpy 0.12.0-1
+  - llvmpy 0.12.1-1
+  - llvmpy 0.12.6-1
+  - llvmpy 0.12.7-1
+  - lmfit 0.9.2-1; depends (scipy ~= 0.16.1, numpy ~= 1.9.2)
+  - locket 0.2.0-1
+  - lockfile 0.10.2-1; depends (pbr ~= 1.2.0)
+  - lockfile 0.10.2-2; depends (pbr ~= 1.8.1)
+  - logbook 0.9.0-1
+  - lxml 2.2.8-2; depends (libxml2 ~= 2.7.3, libxslt ~= 1.1.24)
+  - lxml 2.3-1; depends (libxml2 ~= 2.7.3, libxslt ~= 1.1.24)
+  - lxml 2.3.1-1; depends (libxml2 ~= 2.7.3, libxslt ~= 1.1.24)
+  - lxml 2.3.2-1; depends (libxml2 ~= 2.7.3, libxslt ~= 1.1.24)
+  - lxml 2.3.3-1; depends (libxml2 ~= 2.7.3, libxslt ~= 1.1.24)
+  - lxml 2.3.3-2; depends (libxml2 ~= 2.7.8, libxslt ~= 1.1.26)
+  - lxml 2.3.4-1; depends (libxml2 ~= 2.7.8, libxslt ~= 1.1.26)
+  - lxml 2.3.4-4; depends (libxml2 ~= 2.7.8, libxslt ~= 1.1.26)
+  - lxml 2.3.4-6; depends (libxml2 ~= 2.7.8, libxslt ~= 1.1.26)
+  - lxml 3.2.3-1; depends (libxml2 ~= 2.7.8, libxslt ~= 1.1.26)
+  - lxml 3.3.5-1; depends (libxml2 ~= 2.7.8, libxslt ~= 1.1.26)
+  - lxml 3.3.6-1; depends (libxml2 ~= 2.7.8, libxslt ~= 1.1.26)
+  - lxml 3.4.0-1; depends (libxml2 ~= 2.7.8, libxslt ~= 1.1.26)
+  - lxml 3.4.0-2; depends (libxml2 ~= 2.9.2, libxslt ~= 1.1.28)
+  - lxml 3.4.1-1; depends (libxml2 ~= 2.9.2, libxslt ~= 1.1.28)
+  - lxml 3.4.2-1; depends (libxml2 ~= 2.9.2, libxslt ~= 1.1.28)
+  - lxml 3.4.3-1; depends (libxml2 ~= 2.9.2, libxslt ~= 1.1.28)
+  - lxml 3.4.4-1; depends (libxml2 ~= 2.9.2, libxslt ~= 1.1.28)
+  - lxml 3.4.4-2; depends (libxml2 ~= 2.9.2, libxslt ~= 1.1.28)
+  - lxml 3.4.4-3; depends (libxml2 ~= 2.9.2, libxslt ~= 1.1.28)
+  - m2crypto 0.22.3-1
+  - mahotas 1.3.0-1; depends (numpy ~= 1.9.2)
+  - mahotas 1.3.0-2; depends (numpy ~= 1.9.2)
+  - mahotas 1.3.0-3; depends (numpy ~= 1.9.2)
+  - mahotas 1.3.0-4; depends (numpy ~= 1.9.2)
+  - mahotas 1.3.0-5; depends (numpy ~= 1.9.2)
+  - markupsafe 0.18-1
+  - markupsafe 0.18-2
+  - markupsafe 0.23-1
+  - matplotlib 1.0.0-2; depends (wxpython ~= 2.8.10.1, numpy ~= 1.5.1, freetype ~= 2.4.4, python_dateutil, pytz, configobj)
+  - matplotlib 1.0.1-1; depends (wxpython ~= 2.8.10.1, numpy ~= 1.5.1, freetype ~= 2.4.4, python_dateutil, pytz, configobj)
+  - matplotlib 1.0.1-2; depends (wxpython ~= 2.8.10.1, freetype ~= 2.4.4, python_dateutil, pytz, numpy ~= 1.6.0, configobj)
+  - matplotlib 1.0.1-3; depends (wxpython ~= 2.8.10.1, freetype ~= 2.4.4, python_dateutil, pytz, configobj, numpy ~= 1.6.1)
+  - matplotlib 1.1.0-1; depends (wxpython ~= 2.8.10.1, freetype ~= 2.4.4, python_dateutil, pytz, configobj, numpy ~= 1.6.1)
+  - matplotlib 1.1.0-2; depends (wxpython ~= 2.8.10.1, freetype ~= 2.4.4, python_dateutil, pytz, configobj, numpy ~= 1.6.1)
+  - matplotlib 1.2.0-4; depends (pytz, python_dateutil, wxpython ~= 2.8.10.1, configobj, numpy ~= 1.6.1)
+  - matplotlib 1.2.0-7; depends (wxpython ~= 2.8.10.1, numpy ~= 1.7.1, freetype ~= 2.4.4, python_dateutil, pytz, configobj)
+  - matplotlib 1.2.1-1; depends (wxpython ~= 2.8.10.1, numpy ~= 1.7.1, freetype ~= 2.4.4, python_dateutil, pytz, configobj)
+  - matplotlib 1.3.0-1; depends (wxpython ~= 2.8.10.1, numpy ~= 1.7.1, freetype ~= 2.4.4, python_dateutil, pytz, pyparsing ~= 1.5.6, configobj, tornado ~= 2.2)
+  - matplotlib 1.3.0-2; depends (wxpython ~= 2.8.10.1, numpy ~= 1.7.1, freetype ~= 2.4.4, python_dateutil, pytz, pyparsing ~= 1.5.6, configobj, tornado ~= 3.1.1)
+  - matplotlib 1.3.1-1; depends (wxpython ~= 2.8.10.1, numpy ~= 1.7.1, freetype ~= 2.4.4, python_dateutil, pytz, pyparsing ~= 1.5.6, configobj, tornado ~= 3.1.1)
+  - matplotlib 1.3.1-2; depends (wxpython ~= 2.8.10.1, freetype ~= 2.4.4, numpy ~= 1.8.0, python_dateutil, pytz, pyparsing ~= 1.5.6, configobj, tornado ~= 3.1.1)
+  - matplotlib 1.3.1-3; depends (wxpython ~= 2.8.10.1, pytz ~= 2013.8.0, numpy ~= 1.8.0, freetype ~= 2.4.4, python_dateutil ~= 2.2.0, pyparsing ~= 1.5.6, configobj, tornado ~= 3.1.1)
+  - matplotlib 1.3.1-4; depends (wxpython ~= 2.8.10.1, freetype ~= 2.4.4, numpy ~= 1.8.0, pyparsing ~= 2.0.2, pytz ~= 2013.8.0, configobj ~= 5.0.5, python_dateutil ~= 2.2.0, tornado ~= 3.1.1)
+  - matplotlib 1.3.1-5; depends (wxpython ~= 2.8.10.1, pytz ~= 2013.8.0, numpy ~= 1.8.0, pyparsing ~= 2.0.2, configobj ~= 5.0.5, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, tornado ~= 3.1.1)
+  - matplotlib 1.3.1-6; depends (wxpython ~= 2.8.10.1, pytz ~= 2013.8.0, numpy ~= 1.8.0, pyparsing ~= 2.0.2, configobj ~= 5.0.5, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, tornado ~= 3.1.1)
+  - matplotlib 1.3.1-7; depends (wxpython ~= 2.8.10.1, pytz ~= 2013.8.0, numpy ~= 1.8.0, pyparsing ~= 2.0.2, configobj ~= 5.0.5, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, tornado ~= 3.2.2)
+  - matplotlib 1.3.1-8; depends (wxpython ~= 2.8.10.1, pytz ~= 2013.8.0, numpy ~= 1.8.0, pyparsing ~= 2.0.2, configobj ~= 5.0.5, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, tornado ~= 3.2.2, libpng ~= 1.6.12)
+  - matplotlib 1.3.1-9; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pytz ~= 2013.8.0, pyparsing ~= 2.0.2, configobj ~= 5.0.5, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, tornado ~= 3.2.2, libpng ~= 1.6.12)
+  - matplotlib 1.4.0-1; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pytz ~= 2013.8.0, pyparsing ~= 2.0.2, configobj ~= 5.0.5, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, tornado ~= 4.0.1, libpng ~= 1.6.12)
+  - matplotlib 1.4.0-2; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pytz ~= 2013.8.0, pyparsing ~= 2.0.2, configobj ~= 5.0.6, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, tornado ~= 4.0.1, libpng ~= 1.6.12)
+  - matplotlib 1.4.0-3; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pytz ~= 2013.8.0, pyparsing ~= 2.0.2, tornado ~= 4.0.2, configobj ~= 5.0.6, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, libpng ~= 1.6.12)
+  - matplotlib 1.4.0-4; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pytz ~= 2013.8.0, pyparsing ~= 2.0.2, tornado ~= 4.0.2, configobj ~= 5.0.6, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, libpng ~= 1.6.12)
+  - matplotlib 1.4.2-1; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pytz ~= 2013.8.0, pyparsing ~= 2.0.2, tornado ~= 4.0.2, configobj ~= 5.0.6, python_dateutil ~= 2.2.0, freetype ~= 2.5.3, libpng ~= 1.6.12)
+  - matplotlib 1.4.2-2; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pyparsing ~= 2.0.2, tornado ~= 4.0.2, configobj ~= 5.0.6, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0, freetype ~= 2.5.3, libpng ~= 1.6.12)
+  - matplotlib 1.4.2-3; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pyparsing ~= 2.0.2, configobj ~= 5.0.6, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0, freetype ~= 2.5.3, tornado ~= 4.1, libpng ~= 1.6.12)
+  - matplotlib 1.4.3-1; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, pyparsing ~= 2.0.2, configobj ~= 5.0.6, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0, freetype ~= 2.5.3, tornado ~= 4.1, libpng ~= 1.6.12)
+  - matplotlib 1.4.3-2; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, configobj ~= 5.0.6, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0, freetype ~= 2.5.3, tornado ~= 4.1, libpng ~= 1.6.12, pyparsing ~= 2.0.3)
+  - matplotlib 1.4.3-3; depends (wxpython ~= 2.8.10.1, numpy ~= 1.8.1, python_dateutil ~= 2.4.2, configobj ~= 5.0.6, pytz ~= 2014.9.0, freetype ~= 2.5.3, tornado ~= 4.1, libpng ~= 1.6.12, pyparsing ~= 2.0.3)
+  - matplotlib 1.4.3-4; depends (wxpython ~= 2.8.10.1, python_dateutil ~= 2.4.2, configobj ~= 5.0.6, numpy ~= 1.9.2, pytz ~= 2014.9.0, freetype ~= 2.5.3, tornado ~= 4.1, libpng ~= 1.6.12, pyparsing ~= 2.0.3)
+  - matplotlib 1.4.3-5; depends (tornado ~= 4.2, wxpython ~= 2.8.10.1, python_dateutil ~= 2.4.2, configobj ~= 5.0.6, numpy ~= 1.9.2, pytz ~= 2014.9.0, freetype ~= 2.5.3, libpng ~= 1.6.12, pyparsing ~= 2.0.3)
+  - matplotlib 1.4.3-6; depends (tornado ~= 4.2, wxpython ~= 2.8.10.1, python_dateutil ~= 2.4.2, configobj ~= 5.0.6, numpy ~= 1.9.2, pytz ~= 2014.9.0, freetype ~= 2.5.3, libpng ~= 1.6.12, pyparsing ~= 2.0.3)
+  - matplotlib 1.4.3-7; depends (wxpython ~= 2.8.10.1, python_dateutil ~= 2.4.2, tornado ~= 4.2.1, configobj ~= 5.0.6, numpy ~= 1.9.2, pytz ~= 2014.9.0, freetype ~= 2.5.3, libpng ~= 1.6.12, pyparsing ~= 2.0.3)
+  - matplotlib 1.5.0-1; depends (cycler ~= 0.9.0, wxpython ~= 3.0.2.0, python_dateutil ~= 2.4.2, tornado ~= 4.2.1, configobj ~= 5.0.6, numpy ~= 1.9.2, pytz ~= 2014.9.0, freetype ~= 2.5.3, libpng ~= 1.6.12, pyparsing ~= 2.0.3)
+  - matplotlib 1.5.0-2; depends (cycler ~= 0.9.0, wxpython ~= 3.0.2.0, python_dateutil ~= 2.4.2, configobj ~= 5.0.6, numpy ~= 1.9.2, pytz ~= 2014.9.0, freetype ~= 2.5.3, tornado ~= 4.3, libpng ~= 1.6.12, pyparsing ~= 2.0.3)
+  - matplotlib_tests 1.5.0-1; depends (matplotlib ~= 1.5.0)
+  - mayavi 3.4.1-1; depends (traits ~= 3.6.0, vtk ~= 5.6.0, enthoughtbase ~= 3.1.0, apptools ~= 3.4.1, envisageplugins ~= 3.2.0, traitsgui ~= 3.6.0, appinst)
+  - mayavi 3.4.1-2; depends (traits ~= 3.6.0, vtk ~= 5.6.0, enthoughtbase ~= 3.1.0, apptools ~= 3.4.1, envisageplugins ~= 3.2.0, traitsgui ~= 3.6.0, appinst)
+  - mayavi 4.0.0-1; depends (traitsui ~= 4.0.0, appinst, envisage ~= 4.0.0, vtk ~= 5.6.0, apptools ~= 4.0.0)
+  - mayavi 4.1.0-1; depends (appinst, traitsui ~= 4.1.0, apptools ~= 4.0.1, envisage ~= 4.1.0, vtk ~= 5.6.0)
+  - mayavi 4.2.0-1; depends (traitsui ~= 4.2.0, appinst, vtk ~= 5.6.0, apptools ~= 4.1.0, envisage ~= 4.2.0)
+  - mayavi 4.3.0-1; depends (appinst, apptools ~= 4.2.0, envisage ~= 4.3.0, vtk ~= 5.6.0, traitsui ~= 4.3.0)
+  - mayavi 4.3.0-3; depends (appinst, apptools ~= 4.2.0, envisage ~= 4.3.0, vtk ~= 5.6.0, traitsui ~= 4.3.0)
+  - mayavi 4.3.0-4; depends (appinst, apptools ~= 4.2.0, envisage ~= 4.3.0, vtk ~= 5.6.0, traitsui ~= 4.3.0)
+  - mayavi 4.3.0-5; depends (appinst, apptools ~= 4.2.0, envisage ~= 4.4.0, vtk ~= 5.6.0, traitsui ~= 4.4.0)
+  - mayavi 4.3.1-1; depends (appinst, apptools ~= 4.2.1, vtk ~= 5.10.1, envisage ~= 4.4.0, traitsui ~= 4.4.0)
+  - mayavi 4.3.1-2; depends (appinst, apptools ~= 4.2.1, vtk ~= 5.10.1, envisage ~= 4.4.0, traitsui ~= 4.4.0)
+  - mayavi 4.4.0-1; depends (appinst, apptools ~= 4.2.1, vtk ~= 5.10.1, envisage ~= 4.4.0, traitsui ~= 4.4.0)
+  - mayavi 4.4.0-2; depends (appinst, vtk ~= 5.10.1, envisage ~= 4.4.0, apptools ~= 4.3.0, traitsui ~= 4.4.0)
+  - mayavi 4.4.0-3; depends (appinst, vtk ~= 5.10.1, envisage ~= 4.4.0, apptools ~= 4.3.0, traitsui ~= 4.4.0)
+  - mayavi 4.4.0-4; depends (appinst, vtk ~= 5.10.1, envisage ~= 4.4.0, apptools ~= 4.3.0, traitsui ~= 4.5.1)
+  - mayavi 4.4.2-1; depends (appinst, envisage ~= 4.4.0, apptools ~= 4.3.0, traitsui ~= 4.5.1, vtk ~= 6.2.0)
+  - mayavi 4.4.3-1; depends (vtk ~= 6.3.0, appinst, envisage ~= 4.4.0, apptools ~= 4.3.0, traitsui ~= 4.5.1)
+  - mayavi 4.4.3-2; depends (vtk ~= 6.3.0, appinst, envisage ~= 4.4.0, apptools ~= 4.3.0, traitsui ~= 5.0.0)
+  - mccabe 0.2.1-1
+  - mccabe 0.2.1-2
+  - mccabe 0.3-1
+  - mdp 3.1-1; depends (numpy)
+  - mdp 3.2-1; depends (numpy)
+  - mdp 3.3-1; depends (numpy ~= 1.6.1)
+  - mdp 3.3-2; depends (numpy ~= 1.7.1)
+  - mdp 3.3-3; depends (numpy ~= 1.7.1)
+  - mdp 3.3-4; depends (numpy ~= 1.8.0)
+  - mdp 3.3-6; depends (numpy ~= 1.8.1)
+  - mdp 3.3-7; depends (numpy ~= 1.8.1)
+  - mdp 3.3-8; depends (numpy ~= 1.8.1)
+  - mdp 3.3-9; depends (numpy ~= 1.8.1)
+  - mdp 3.3-10; depends (numpy ~= 1.9.2)
+  - mdp 3.3-11; depends (numpy ~= 1.9.2)
+  - meld3 0.6.10-1
+  - meld3 1.0.0-1
+  - memory_profiler 0.30-1; depends (psutil ~= 1.2.1)
+  - memory_profiler 0.31.0-1; depends (psutil ~= 2.1.1)
+  - memory_profiler 0.31.0-2; depends (psutil ~= 2.2.0)
+  - memory_profiler 0.31.0-3; depends (psutil ~= 2.2.1)
+  - memory_profiler 0.33-1; depends (psutil ~= 3.2.1)
+  - meta 0.4.2.dev-1
+  - meta 0.4.2.dev-2
+  - meta 0.4.2.dev2-1
+  - mistune 0.5-1
+  - mistune 0.5.1-1
+  - mistune 0.6-1
+  - mistune 0.6-2
+  - mistune 0.7.1-1
+  - mkl 10.2-1
+  - mkl 10.2-2
+  - mkl 10.3-1
+  - mkl 10.3-2
+  - mkl_service 1.0-1; depends (mkl ~= 10.3)
+  - mlab 1.1.4-1; depends (numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - mlab 1.1.4-2; depends (numpy ~= 1.8.1, scipy ~= 0.14.1rc1)
+  - mlab 1.1.4-3; depends (numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - mlab 1.1.4-4; depends (numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - mlab 1.1.4-5; depends (scipy ~= 0.16.0, numpy ~= 1.9.2)
+  - mlab 1.1.4-6; depends (scipy ~= 0.16.1, numpy ~= 1.9.2)
+  - mock 1.0.1-1
+  - mock 1.3.0-1; depends (pbr ~= 1.8.1, six ~= 1.9.0, funcsigs ~= 0.4)
+  - mock 1.3.0-2; depends (pbr ~= 1.8.1, six ~= 1.10.0, funcsigs ~= 0.4)
+  - mock 1.3.0-3; depends (pbr ~= 1.8.1, six ~= 1.10.0, funcsigs ~= 0.4)
+  - moto 0.4.6-1; depends (boto ~= 2.38.0, xmltodict ~= 0.9.2, httpretty ~= 0.8.10, flask ~= 0.10.1, jinja2 ~= 2.7.3, requests ~= 2.7.0, six ~= 1.9.0)
+  - moto 0.4.6-2; depends (boto ~= 2.38.0, xmltodict ~= 0.9.2, jinja2 ~= 2.8, httpretty ~= 0.8.10, flask ~= 0.10.1, requests ~= 2.7.0, six ~= 1.9.0)
+  - moto 0.4.6-3; depends (boto ~= 2.38.0, xmltodict ~= 0.9.2, requests ~= 2.8.0, jinja2 ~= 2.8, httpretty ~= 0.8.10, flask ~= 0.10.1, six ~= 1.9.0)
+  - moto 0.4.6-4; depends (boto ~= 2.38.0, xmltodict ~= 0.9.2, requests ~= 2.8.0, six ~= 1.10.0, jinja2 ~= 2.8, httpretty ~= 0.8.10, flask ~= 0.10.1)
+  - moto 0.4.6-5; depends (boto ~= 2.38.0, xmltodict ~= 0.9.2, six ~= 1.10.0, jinja2 ~= 2.8, httpretty ~= 0.8.10, flask ~= 0.10.1, requests ~= 2.9.0)
+  - mpi4py 1.2.1-2; depends (mpich2 ~= 1.1)
+  - mpi4py 1.2.2-1; depends (mpich2 ~= 1.4.1)
+  - mpich2 1.0.7-2
+  - mpich2 1.1-1
+  - mpich2 1.4.1-1
+  - msgpack 0.3.0-1
+  - msgpack 0.3.0-2
+  - msgpack 0.4.0-1
+  - msgpack 0.4.2-4
+  - msgpack_python 0.4.5-1
+  - msgpack_python 0.4.6-1
+  - msgpack_python 0.4.6-2
+  - msgpack_python 0.4.6-3
+  - msgpack_python 0.4.6-4
+  - multimethods 1.0.0-1
+  - multipledispatch 0.4.7-1
+  - multipledispatch 0.4.8-1
+  - nbconvert 4.0.0-1; depends (nbformat ~= 4.0.0, pygments ~= 2.0.2, mistune ~= 0.7.1, jinja2 ~= 2.7.3, jupyter_core ~= 4.0.4, traitlets ~= 4.0.0)
+  - nbconvert 4.0.0-2; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, pygments ~= 2.0.2, mistune ~= 0.7.1, jinja2 ~= 2.7.3, traitlets ~= 4.0.0)
+  - nbconvert 4.0.0-3; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, pygments ~= 2.0.2, mistune ~= 0.7.1, jinja2 ~= 2.7.3, traitlets ~= 4.0.0)
+  - nbconvert 4.0.0-4; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, pygments ~= 2.0.2, jinja2 ~= 2.8, mistune ~= 0.7.1, traitlets ~= 4.0.0)
+  - nbconvert 4.0.0-5; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, pygments ~= 2.0.2, jinja2 ~= 2.8, mistune ~= 0.7.1, traitlets ~= 4.0.0)
+  - nbconvert 4.1.0-1; depends (jupyter_core ~= 4.0.6, pygments ~= 2.0.2, jinja2 ~= 2.8, mistune ~= 0.7.1, traitlets ~= 4.0.0, nbformat ~= 4.0.1)
+  - nbconvert 4.1.0-2; depends (jupyter_core ~= 4.0.6, pygments ~= 2.0.2, jinja2 ~= 2.8, mistune ~= 0.7.1, traitlets ~= 4.0.0, nbformat ~= 4.0.1)
+  - nbformat 4.0.0-1; depends (ipython_genutils ~= 0.1.0, jupyter_core ~= 4.0.4, traitlets ~= 4.0.0, jsonschema ~= 2.4.0)
+  - nbformat 4.0.0-2; depends (jupyter_core ~= 4.0.6, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jsonschema ~= 2.4.0)
+  - nbformat 4.0.1-1; depends (jupyter_core ~= 4.0.6, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jsonschema ~= 2.4.0)
+  - ndg_httpsclient 0.3.2-1; depends (pyasn1 ~= 0.1.7, pyopenssl ~= 0.13.1)
+  - ndg_httpsclient 0.3.2-2; depends (pyopenssl ~= 0.14, pyasn1 ~= 0.1.7)
+  - ndg_httpsclient 0.3.3-1; depends (pyopenssl ~= 0.14, pyasn1 ~= 0.1.7)
+  - ndg_httpsclient 0.3.3-2; depends (pyasn1 ~= 0.1.7, pyopenssl ~= 0.15.1)
+  - ndg_httpsclient 0.3.3-3; depends (pyasn1 ~= 0.1.9, pyopenssl ~= 0.15.1)
+  - netcdf 3.6.2-6
+  - netcdf 4.0-1
+  - netcdf4 0.9.3-2; depends (hdf5 ~= 1.8.5.1, numpy ~= 1.5.1, lib_netcdf4 == 4.1.1-1)
+  - netcdf4 0.9.4-1; depends (hdf5 ~= 1.8.5.1, lib_netcdf4 == 4.1.1-1, numpy ~= 1.6.0)
+  - netcdf4 0.9.5-1; depends (hdf5 ~= 1.8.5.1, lib_netcdf4 == 4.1.1-1, numpy ~= 1.6.0)
+  - netcdf4 0.9.5-2; depends (hdf5 ~= 1.8.5.1, lib_netcdf4 == 4.1.1-1, numpy ~= 1.6.1)
+  - netcdf4 0.9.8-1; depends (hdf5 ~= 1.8.5.1, lib_netcdf4 == 4.1.1-1, numpy ~= 1.6.1)
+  - netcdf4 0.9.9-1; depends (hdf5 ~= 1.8.5.1, numpy ~= 1.6.1, lib_netcdf4 == 4.1.1-2)
+  - netcdf4 1.0-1; depends (hdf5 ~= 1.8.9, numpy ~= 1.6.1, lib_netcdf4 ~= 4.2)
+  - netcdf4 1.0-4; depends (hdf5 ~= 1.8.9, lib_netcdf4 ~= 4.3.0, numpy ~= 1.7.1)
+  - netcdf4 1.0.5-1; depends (lib_netcdf4 ~= 4.3.0, numpy ~= 1.7.1, hdf5 ~= 1.8.11)
+  - netcdf4 1.0.5-2; depends (numpy ~= 1.8.0, lib_netcdf4 ~= 4.3.0, hdf5 ~= 1.8.11)
+  - netcdf4 1.0.7-1; depends (numpy ~= 1.8.0, lib_netcdf4 ~= 4.3.0, hdf5 ~= 1.8.11)
+  - netcdf4 1.1.0-1; depends (numpy ~= 1.8.0, lib_netcdf4 ~= 4.3.2, hdf5 ~= 1.8.11)
+  - netcdf4 1.1.0-2; depends (lib_netcdf4 ~= 4.3.2, numpy ~= 1.8.1, hdf5 ~= 1.8.11)
+  - netcdf4 1.1.1-1; depends (lib_netcdf4 ~= 4.3.2, numpy ~= 1.8.1, hdf5 ~= 1.8.11)
+  - netcdf4 1.1.1-2; depends (lib_netcdf4 ~= 4.3.2, numpy ~= 1.8.1, hdf5 ~= 1.8.11)
+  - netcdf4 1.1.1-3; depends (hdf5 ~= 1.8.14, lib_netcdf4 ~= 4.3.2, numpy ~= 1.8.1)
+  - netcdf4 1.1.7.1-1; depends (hdf5 ~= 1.8.14, lib_netcdf4 ~= 4.3.2, numpy ~= 1.8.1)
+  - netcdf4 1.1.7.1-2; depends (hdf5 ~= 1.8.14, lib_netcdf4 ~= 4.3.2, numpy ~= 1.9.2)
+  - netcdf4 1.1.7.1-3; depends (hdf5 ~= 1.8.15.1, numpy ~= 1.9.2, lib_netcdf4 ~= 4.3.3.1)
+  - netcdf4 1.2.0-1; depends (hdf5 ~= 1.8.15.1, numpy ~= 1.9.2, lib_netcdf4 ~= 4.3.3.1)
+  - networkx 1.3-2; depends (numpy)
+  - networkx 1.4-1; depends (numpy)
+  - networkx 1.5-1; depends (numpy)
+  - networkx 1.6-1; depends (numpy)
+  - networkx 1.6-2; depends (numpy)
+  - networkx 1.8.1-1; depends (numpy)
+  - networkx 1.8.1-2; depends (numpy)
+  - networkx 1.8.1-3; depends (numpy)
+  - networkx 1.9-1; depends (decorator ~= 3.4.0, numpy)
+  - networkx 1.9.1-1; depends (decorator ~= 3.4.0, numpy ~= 1.8.1)
+  - networkx 1.9.1-2; depends (decorator ~= 3.4.2, numpy ~= 1.8.1)
+  - networkx 1.9.1-3; depends (decorator ~= 3.4.2, numpy ~= 1.9.2)
+  - networkx 1.10-1; depends (decorator ~= 4.0.2, numpy ~= 1.9.2)
+  - networkx 1.10-2; depends (decorator ~= 4.0.4, numpy ~= 1.9.2)
+  - nltk 2.0.1rc1-1; depends (pyyaml ~= 3.9)
+  - nltk 2.0.1rc1-2; depends (pyyaml)
+  - nltk 2.0.1-1; depends (numpy, pyyaml)
+  - nltk 2.0.1-2; depends (numpy, pyyaml)
+  - nltk 2.0.1-3; depends (numpy, pyyaml)
+  - nltk 2.0.1-4; depends (numpy, pyyaml)
+  - nltk 3.0.0b1-1; depends (numpy, pyyaml)
+  - nltk 3.0.0b2-2; depends (numpy, pyyaml)
+  - nltk 3.0.0-1; depends (numpy, pyyaml)
+  - nltk 3.0.1-1; depends (numpy, pyyaml)
+  - nltk 3.0.2-1; depends (numpy, pyyaml)
+  - nltk 3.0.2-2; depends (numpy, pyyaml)
+  - nltk 3.0.3-1; depends (numpy, pyyaml)
+  - nltk 3.1-1; depends (numpy, pyyaml)
+  - nose 0.11.4-2
+  - nose 1.0.0-1
+  - nose 1.0.0-2
+  - nose 1.1.2-1
+  - nose 1.2.1-1
+  - nose 1.3.0-1
+  - nose 1.3.3-1
+  - nose 1.3.4-1
+  - notebook 4.0.4-1; depends (tornado ~= 4.2, nbformat ~= 4.0.0, terminado ~= 0.5, nbconvert ~= 4.0.0, jinja2 ~= 2.7.3, jupyter_core ~= 4.0.4, ipykernel ~= 4.0.3, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0)
+  - notebook 4.0.5-2; depends (jupyter_core ~= 4.0.6, tornado ~= 4.2, nbformat ~= 4.0.0, terminado ~= 0.5, nbconvert ~= 4.0.0, jinja2 ~= 2.7.3, ipykernel ~= 4.0.3, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0)
+  - notebook 4.0.5-3; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, terminado ~= 0.5, tornado ~= 4.2.1, nbconvert ~= 4.0.0, jinja2 ~= 2.7.3, ipykernel ~= 4.0.3, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0)
+  - notebook 4.0.5-4; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, jinja2 ~= 2.8, terminado ~= 0.5, tornado ~= 4.2.1, nbconvert ~= 4.0.0, ipykernel ~= 4.0.3, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0)
+  - notebook 4.0.5-5; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, jinja2 ~= 2.8, terminado ~= 0.5, tornado ~= 4.2.1, nbconvert ~= 4.0.0, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipykernel ~= 4.1.0)
+  - notebook 4.0.5-6; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, jinja2 ~= 2.8, terminado ~= 0.5, tornado ~= 4.2.1, nbconvert ~= 4.0.0, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipykernel ~= 4.1.0)
+  - notebook 4.0.5-7; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, jinja2 ~= 2.8, terminado ~= 0.5, tornado ~= 4.2.1, nbconvert ~= 4.0.0, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipykernel ~= 4.1.0)
+  - notebook 4.0.5-8; depends (jupyter_core ~= 4.0.6, nbformat ~= 4.0.0, jinja2 ~= 2.8, terminado ~= 0.5, tornado ~= 4.2.1, nbconvert ~= 4.0.0, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, ipykernel ~= 4.1.0)
+  - notebook 4.0.6-1; depends (jupyter_core ~= 4.0.6, nbconvert ~= 4.1.0, jinja2 ~= 2.8, terminado ~= 0.5, tornado ~= 4.2.1, ipykernel ~= 4.2.0, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.1.1, nbformat ~= 4.0.1)
+  - notebook 4.0.6-2; depends (jupyter_core ~= 4.0.6, nbconvert ~= 4.1.0, jinja2 ~= 2.8, terminado ~= 0.5, ipykernel ~= 4.2.0, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.1.1, tornado ~= 4.3, nbformat ~= 4.0.1)
+  - notebook 4.0.6-3; depends (jupyter_core ~= 4.0.6, nbconvert ~= 4.1.0, jinja2 ~= 2.8, terminado ~= 0.5, ipykernel ~= 4.2.0, ipython_genutils ~= 0.1.0, traitlets ~= 4.0.0, jupyter_client ~= 4.1.1, tornado ~= 4.3, nbformat ~= 4.0.1)
+  - numba 0.9.0-1; depends (llvmmath ~= 0.1.0, meta ~= 0.4.2.dev, numpy ~= 1.7.1, llvmpy ~= 0.11.3)
+  - numba 0.9.0-2; depends (llvmmath ~= 0.1.0, meta ~= 0.4.2.dev, numpy ~= 1.7.1, llvmpy ~= 0.11.3)
+  - numba 0.10.0-1; depends (llvmmath ~= 0.1.1, meta ~= 0.4.2.dev, llvmpy ~= 0.11.3, numpy ~= 1.7.1)
+  - numba 0.10.2-1; depends (llvmpy ~= 0.12.0, llvmmath ~= 0.1.1, meta ~= 0.4.2.dev, numpy ~= 1.7.1)
+  - numba 0.10.2-3; depends (llvmpy ~= 0.12.0, numpy ~= 1.8.0, llvmmath ~= 0.1.1, meta ~= 0.4.2.dev)
+  - numba 0.11.1-1; depends (numpy ~= 1.8.0, llvmpy ~= 0.12.1, llvmmath ~= 0.1.1, meta ~= 0.4.2.dev)
+  - numba 0.13.0-1; depends (numpy ~= 1.8.0, llvmpy ~= 0.12.1, llvmmath ~= 0.1.1, meta ~= 0.4.2.dev)
+  - numba 0.13.2-1; depends (numpy ~= 1.8.0, llvmpy ~= 0.12.6, llvmmath ~= 0.1.1, meta ~= 0.4.2.dev)
+  - numba 0.13.2-4; depends (llvmpy ~= 0.12.6, llvmmath ~= 0.1.1, meta ~= 0.4.2.dev, numpy ~= 1.8.1)
+  - numba 0.13.4-1; depends (llvmmath ~= 0.1.2, llvmpy ~= 0.12.7, meta ~= 0.4.2.dev, numpy ~= 1.8.1)
+  - numba 0.14.0-1; depends (llvmmath ~= 0.1.2, llvmpy ~= 0.12.7, meta ~= 0.4.2.dev, numpy ~= 1.8.1)
+  - numba 0.14.0-2; depends (llvmmath ~= 0.1.2, llvmpy ~= 0.12.7, numpy ~= 1.8.1, meta ~= 0.4.2.dev2)
+  - numba 0.15.1-1; depends (llvmmath ~= 0.1.2, llvmpy ~= 0.12.7, numpy ~= 1.8.1, meta ~= 0.4.2.dev2)
+  - numba 0.17.0-1; depends (numpy ~= 1.8.1, llvmlite ~= 0.2.2, funcsigs ~= 0.4)
+  - numba 0.18.1-1; depends (numpy ~= 1.8.1, llvmlite ~= 0.4.0, funcsigs ~= 0.4)
+  - numba 0.18.2-1; depends (numpy ~= 1.8.1, llvmlite ~= 0.4.0, funcsigs ~= 0.4)
+  - numba 0.18.2-2; depends (numpy ~= 1.9.2, llvmlite ~= 0.4.0, funcsigs ~= 0.4)
+  - numba 0.19.2-1; depends (numpy ~= 1.9.2, llvmlite ~= 0.5.0, funcsigs ~= 0.4)
+  - numba 0.20.0-1; depends (llvmlite ~= 0.6.0, numpy ~= 1.9.2, funcsigs ~= 0.4)
+  - numba 0.21.0-1; depends (llvmlite ~= 0.7.0, singledispatch ~= 3.4.0.3, numpy ~= 1.9.2, funcsigs ~= 0.4)
+  - numba 0.21.0-2; depends (llvmlite ~= 0.7.0, singledispatch ~= 3.4.0.3, numpy ~= 1.9.2, funcsigs ~= 0.4)
+  - numba 0.22.1-1; depends (singledispatch ~= 3.4.0.3, llvmlite ~= 0.8.0, numpy ~= 1.9.2, funcsigs ~= 0.4)
+  - numexpr 1.4.1-2; depends (mkl ~= 10.3, numpy ~= 1.5.1)
+  - numexpr 1.4.2-1; depends (mkl ~= 10.3, numpy ~= 1.5.1)
+  - numexpr 1.4.2-2; depends (mkl ~= 10.3, numpy ~= 1.6.0)
+  - numexpr 1.4.2-3; depends (mkl ~= 10.3, numpy ~= 1.6.1)
+  - numexpr 2.0-1; depends (mkl ~= 10.3, numpy ~= 1.6.1)
+  - numexpr 2.0.1-1; depends (mkl ~= 10.3, numpy ~= 1.6.1)
+  - numexpr 2.0.1-3; depends (mkl ~= 10.3, numpy ~= 1.7.1)
+  - numexpr 2.2.2-1; depends (mkl ~= 10.3, numpy ~= 1.7.1)
+  - numexpr 2.2.2-2; depends (mkl ~= 10.3, numpy ~= 1.8.0)
+  - numexpr 2.2.2-4; depends (mkl ~= 10.3, numpy ~= 1.8.0)
+  - numexpr 2.4.0-1; depends (mkl ~= 10.3, numpy ~= 1.8.0)
+  - numexpr 2.4.0-2; depends (mkl ~= 10.3, numpy ~= 1.8.1)
+  - numexpr 2.4.0-3; depends (mkl ~= 10.3, numpy ~= 1.9.2)
+  - numpy 1.5.1-1; depends (mkl == 10.3-1)
+  - numpy 1.5.1-2; depends (mkl == 10.3-1)
+  - numpy 1.6.0b2-1; depends (mkl == 10.3-1)
+  - numpy 1.6.0-1; depends (mkl == 10.3-1)
+  - numpy 1.6.0-2; depends (mkl == 10.3-1)
+  - numpy 1.6.0-3; depends (mkl == 10.3-1)
+  - numpy 1.6.0-4; depends (mkl == 10.3-1)
+  - numpy 1.6.0-5; depends (mkl == 10.3-1)
+  - numpy 1.6.1-1; depends (mkl == 10.3-1)
+  - numpy 1.6.1-2; depends (mkl == 10.3-1)
+  - numpy 1.6.1-3; depends (mkl == 10.3-1)
+  - numpy 1.6.1-5; depends (mkl == 10.3-1)
+  - numpy 1.7.1-1; depends (mkl == 10.3-1)
+  - numpy 1.7.1-2; depends (mkl == 10.3-1)
+  - numpy 1.7.1-3; depends (mkl == 10.3-1)
+  - numpy 1.8.0-1; depends (mkl == 10.3-1)
+  - numpy 1.8.0-2; depends (mkl == 10.3-1)
+  - numpy 1.8.0-3; depends (mkl == 10.3-1)
+  - numpy 1.8.1-1; depends (mkl == 10.3-1)
+  - numpy 1.8.1-2; depends (mkl == 10.3-1)
+  - numpy 1.8.1-3; depends (mkl == 10.3-1, libgfortran ~= 3.0.0)
+  - numpy 1.9.2-1; depends (mkl == 10.3-1, libgfortran ~= 3.0.0)
+  - numpy 1.9.2-2; depends (mkl ~= 10.3, libgfortran ~= 3.0.0)
+  - numpydoc 0.5-1; depends (matplotlib ~= 1.4.2, numpy ~= 1.8.1, sphinx ~= 1.2.3)
+  - numpydoc 0.5-2; depends (matplotlib ~= 1.4.3, numpy ~= 1.8.1, sphinx ~= 1.2.3)
+  - numpydoc 0.5-3; depends (matplotlib ~= 1.4.3, numpy ~= 1.8.1, sphinx ~= 1.3.1)
+  - numpydoc 0.5-4; depends (matplotlib ~= 1.4.3, numpy ~= 1.9.2, sphinx ~= 1.3.1)
+  - numpydoc 0.5-5; depends (matplotlib ~= 1.5.0, numpy ~= 1.9.2, sphinx ~= 1.3.1)
+  - odo 0.3.1-1; depends (datashape ~= 0.4.4, numpy ~= 1.8.1, pandas ~= 0.16.0, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 0.9.9, python_dateutil ~= 2.2.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - odo 0.3.1-2; depends (datashape ~= 0.4.4, numpy ~= 1.8.1, python_dateutil ~= 2.4.2, pandas ~= 0.16.0, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 1.0.0, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - odo 0.3.1-3; depends (datashape ~= 0.4.4, numpy ~= 1.8.1, python_dateutil ~= 2.4.2, pandas ~= 0.16.0, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 1.0.1, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - odo 0.3.1-4; depends (datashape ~= 0.4.4, python_dateutil ~= 2.4.2, pandas ~= 0.16.0, networkx ~= 1.9.1, pytables ~= 3.1.1, sqlalchemy ~= 1.0.1, numpy ~= 1.9.2, multipledispatch ~= 0.4.7, toolz ~= 0.7.1)
+  - odo 0.3.2-1; depends (python_dateutil ~= 2.4.2, pandas ~= 0.16.0, networkx ~= 1.9.1, pytables ~= 3.1.1, numpy ~= 1.9.2, datashape ~= 0.4.5, multipledispatch ~= 0.4.7, sqlalchemy ~= 1.0.4, toolz ~= 0.7.1)
+  - odo 0.3.2-2; depends (python_dateutil ~= 2.4.2, networkx ~= 1.9.1, pytables ~= 3.1.1, numpy ~= 1.9.2, datashape ~= 0.4.5, pandas ~= 0.16.1, multipledispatch ~= 0.4.7, sqlalchemy ~= 1.0.4, toolz ~= 0.7.1)
+  - odo 0.3.2-3; depends (python_dateutil ~= 2.4.2, networkx ~= 1.9.1, pytables ~= 3.1.1, numpy ~= 1.9.2, datashape ~= 0.4.5, toolz ~= 0.7.2, pandas ~= 0.16.1, multipledispatch ~= 0.4.7, sqlalchemy ~= 1.0.4)
+  - odo 0.3.2-4; depends (python_dateutil ~= 2.4.2, networkx ~= 1.9.1, pytables ~= 3.1.1, numpy ~= 1.9.2, pandas ~= 0.16.2, datashape ~= 0.4.5, toolz ~= 0.7.2, multipledispatch ~= 0.4.7, sqlalchemy ~= 1.0.4)
+  - odo 0.3.2-5; depends (python_dateutil ~= 2.4.2, networkx ~= 1.9.1, numpy ~= 1.9.2, pandas ~= 0.16.2, datashape ~= 0.4.5, pytables ~= 3.2.0, toolz ~= 0.7.2, multipledispatch ~= 0.4.7, sqlalchemy ~= 1.0.4)
+  - odo 0.3.2-6; depends (sqlalchemy ~= 1.0.6, python_dateutil ~= 2.4.2, networkx ~= 1.9.1, numpy ~= 1.9.2, pandas ~= 0.16.2, datashape ~= 0.4.5, pytables ~= 3.2.0, toolz ~= 0.7.2, multipledispatch ~= 0.4.7)
+  - odo 0.3.2-7; depends (sqlalchemy ~= 1.0.6, python_dateutil ~= 2.4.2, networkx ~= 1.9.1, numpy ~= 1.9.2, pandas ~= 0.16.2, datashape ~= 0.4.5, pytables ~= 3.2.0, toolz ~= 0.7.2, multipledispatch ~= 0.4.7)
+  - odo 0.3.3-1; depends (toolz ~= 0.7.4, datashape ~= 0.4.6, sqlalchemy ~= 1.0.6, python_dateutil ~= 2.4.2, networkx ~= 1.9.1, multipledispatch ~= 0.4.8, numpy ~= 1.9.2, pandas ~= 0.16.2, pytables ~= 3.2.0)
+  - odo 0.3.3-2; depends (toolz ~= 0.7.4, datashape ~= 0.4.6, sqlalchemy ~= 1.0.6, networkx ~= 1.10, python_dateutil ~= 2.4.2, multipledispatch ~= 0.4.8, numpy ~= 1.9.2, pandas ~= 0.16.2, pytables ~= 3.2.0)
+  - odo 0.3.3-3; depends (toolz ~= 0.7.4, datashape ~= 0.4.6, networkx ~= 1.10, python_dateutil ~= 2.4.2, multipledispatch ~= 0.4.8, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, pandas ~= 0.16.2, pytables ~= 3.2.0)
+  - odo 0.3.4-1; depends (toolz ~= 0.7.4, datashape ~= 0.4.7, networkx ~= 1.10, python_dateutil ~= 2.4.2, multipledispatch ~= 0.4.8, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, pandas ~= 0.16.2, pytables ~= 3.2.0)
+  - odo 0.3.4-2; depends (toolz ~= 0.7.4, datashape ~= 0.4.7, networkx ~= 1.10, python_dateutil ~= 2.4.2, multipledispatch ~= 0.4.8, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, pandas ~= 0.16.2, pytables ~= 3.2.0)
+  - odo 0.3.4-3; depends (toolz ~= 0.7.4, datashape ~= 0.4.7, networkx ~= 1.10, python_dateutil ~= 2.4.2, multipledispatch ~= 0.4.8, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, pandas ~= 0.16.2, pytables ~= 3.2.0)
+  - odo 0.3.4-4; depends (toolz ~= 0.7.4, datashape ~= 0.4.7, networkx ~= 1.10, python_dateutil ~= 2.4.2, multipledispatch ~= 0.4.8, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, pytables ~= 3.2.0, pandas ~= 0.17.1)
+  - odo 0.3.4-5; depends (toolz ~= 0.7.4, datashape ~= 0.4.7, networkx ~= 1.10, python_dateutil ~= 2.4.2, multipledispatch ~= 0.4.8, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, pytables ~= 3.2.0, pandas ~= 0.17.1)
+  - odo 0.3.4-6; depends (toolz ~= 0.7.4, datashape ~= 0.4.7, networkx ~= 1.10, python_dateutil ~= 2.4.2, multipledispatch ~= 0.4.8, sqlalchemy ~= 1.0.8, numpy ~= 1.9.2, pytables ~= 3.2.2, pandas ~= 0.17.1)
+  - odo 0.3.4-7; depends (toolz ~= 0.7.4, datashape ~= 0.4.7, networkx ~= 1.10, python_dateutil ~= 2.4.2, sqlalchemy ~= 1.0.10, multipledispatch ~= 0.4.8, numpy ~= 1.9.2, pytables ~= 3.2.2, pandas ~= 0.17.1)
+  - okonomiyaki 0.2.1-1
+  - okonomiyaki 0.3.1-1
+  - okonomiyaki 0.3.2-1
+  - okonomiyaki 0.3.3-1
+  - okonomiyaki 0.3.3-2
+  - okonomiyaki 0.5.0-1
+  - okonomiyaki 0.5.0-2; depends (six ~= 1.9.0)
+  - okonomiyaki 0.5.1-1; depends (six ~= 1.9.0)
+  - okonomiyaki 0.7.0-1; depends (six ~= 1.9.0)
+  - okonomiyaki 0.7.0-2; depends (zipfile2 ~= 0.0.6, six ~= 1.9.0)
+  - okonomiyaki 0.8.0-1; depends (zipfile2 ~= 0.0.6, six ~= 1.9.0)
+  - okonomiyaki 0.8.0-2; depends (zipfile2 ~= 0.0.7, six ~= 1.9.0)
+  - okonomiyaki 0.9.0-1; depends (zipfile2 ~= 0.0.7, six ~= 1.9.0)
+  - okonomiyaki 0.9.0-3; depends (zipfile2 ~= 0.0.8, six ~= 1.9.0)
+  - okonomiyaki 0.12.0-1; depends (zipfile2 ~= 0.0.11, attrs ~= 15.1.0, six ~= 1.9.0, jsonschema ~= 2.4.0)
+  - okonomiyaki 0.13.0-1; depends (zipfile2 ~= 0.0.11, attrs ~= 15.1.0, six ~= 1.9.0, jsonschema ~= 2.4.0)
+  - okonomiyaki 0.13.1-1; depends (zipfile2 ~= 0.0.11, attrs ~= 15.1.0, six ~= 1.9.0, jsonschema ~= 2.4.0)
+  - okonomiyaki 0.13.1-2; depends (zipfile2 ~= 0.0.11, attrs ~= 15.1.0, six ~= 1.9.0, jsonschema ~= 2.4.0)
+  - okonomiyaki 0.13.1-3; depends (zipfile2 ~= 0.0.11, attrs ~= 15.1.0, six ~= 1.10.0, jsonschema ~= 2.4.0)
+  - okonomiyaki 0.13.1-4; depends (zipfile2 ~= 0.0.11, attrs ~= 15.1.0, six ~= 1.10.0, jsonschema ~= 2.4.0)
+  - okonomiyaki 0.14.0-1; depends (zipfile2 ~= 0.0.11, attrs ~= 15.1.0, six ~= 1.10.0, jsonschema ~= 2.4.0)
+  - okonomiyaki 0.14.0-2; depends (zipfile2 ~= 0.0.11, attrs ~= 15.2.0, six ~= 1.10.0, jsonschema ~= 2.4.0)
+  - opencv 2.4.5-2; depends (numpy ~= 1.7.1)
+  - opencv 2.4.5-3; depends (numpy ~= 1.8.0)
+  - opencv 2.4.5-4; depends (numpy ~= 1.8.0, libpng ~= 1.6.12)
+  - opencv 2.4.5-5; depends (numpy ~= 1.8.1, libpng ~= 1.6.12)
+  - opencv 2.4.9-1; depends (numpy ~= 1.8.1, libpng ~= 1.6.12)
+  - opencv 2.4.9-2; depends (numpy ~= 1.9.2, libpng ~= 1.6.12)
+  - openopt 0.28-2; depends (numpy)
+  - openpyxl 1.5.8-1
+  - openpyxl 1.8.5-1
+  - openpyxl 2.0.3-1; depends (jdcal ~= 1.0.0)
+  - openpyxl 2.3.0-1; depends (jdcal ~= 1.0.0)
+  - openpyxl 2.3.1-1; depends (jdcal ~= 1.0.0, lxml ~= 3.4.4)
+  - owslib 0.8.8-1; depends (lxml ~= 3.3.6, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - owslib 0.8.8-2; depends (lxml ~= 3.4.0, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - owslib 0.8.8-3; depends (lxml ~= 3.4.0, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0)
+  - owslib 0.8.8-4; depends (lxml ~= 3.4.1, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0)
+  - owslib 0.8.8-5; depends (lxml ~= 3.4.2, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0)
+  - owslib 0.8.8-6; depends (lxml ~= 3.4.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - owslib 0.8.8-7; depends (lxml ~= 3.4.3, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - owslib 0.8.8-8; depends (lxml ~= 3.4.4, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.2-2; depends (python_dateutil, numpy ~= 1.5.1, scikits.statsmodels)
+  - pandas 0.2-3; depends (python_dateutil, numpy ~= 1.5.1, scikits.statsmodels)
+  - pandas 0.3.0-1; depends (python_dateutil, numpy ~= 1.5.1, scikits.statsmodels)
+  - pandas 0.3.0-2; depends (python_dateutil, numpy ~= 1.6.0, scikits.statsmodels)
+  - pandas 0.3.0-3; depends (python_dateutil, numpy ~= 1.6.1, scikits.statsmodels)
+  - pandas 0.4.3-1; depends (python_dateutil, numpy ~= 1.6.1, scikits.statsmodels)
+  - pandas 0.6.1-1; depends (python_dateutil, numpy ~= 1.6.1, scikits.statsmodels)
+  - pandas 0.7.0-1; depends (python_dateutil, numpy ~= 1.6.1, scikits.statsmodels)
+  - pandas 0.7.1-1; depends (python_dateutil, numpy ~= 1.6.1, scikits.statsmodels)
+  - pandas 0.7.2-1; depends (python_dateutil, numpy ~= 1.6.1, scikits.statsmodels)
+  - pandas 0.7.3-1; depends (python_dateutil, numpy ~= 1.6.1, scikits.statsmodels)
+  - pandas 0.7.3-2; depends (python_dateutil, statsmodels, numpy ~= 1.6.1)
+  - pandas 0.8.0rc2-1; depends (python_dateutil, statsmodels, numpy ~= 1.6.1)
+  - pandas 0.9.0-1; depends (python_dateutil, statsmodels, numpy ~= 1.6.1)
+  - pandas 0.9.1-1; depends (python_dateutil, numpy ~= 1.6.1)
+  - pandas 0.10.0-1; depends (python_dateutil, numpy ~= 1.6.1)
+  - pandas 0.10.1-1; depends (python_dateutil, numpy ~= 1.6.1)
+  - pandas 0.11.0-1; depends (python_dateutil, numpy ~= 1.6.1)
+  - pandas 0.11.0-2; depends (python_dateutil, numpy ~= 1.7.1)
+  - pandas 0.11.0-3; depends (python_dateutil, numpy ~= 1.7.1)
+  - pandas 0.12.0-1; depends (python_dateutil, numpy ~= 1.7.1)
+  - pandas 0.12.0-2; depends (python_dateutil, pytz ~= 2011n, numpy ~= 1.7.1)
+  - pandas 0.12.0-3; depends (numpy ~= 1.8.0, python_dateutil, pytz ~= 2011n)
+  - pandas 0.12.0-4; depends (numpy ~= 1.8.0, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - pandas 0.13.1-1; depends (numpy ~= 1.8.0, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - pandas 0.14.0-1; depends (numpy ~= 1.8.0, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - pandas 0.14.1-1; depends (numpy ~= 1.8.0, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - pandas 0.14.1-2; depends (numpy ~= 1.8.1, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - pandas 0.14.1-3; depends (numpy ~= 1.8.1, distribute ~= 0.6.49, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - pandas 0.15.0-1; depends (numpy ~= 1.8.1, distribute ~= 0.6.49, python_dateutil ~= 2.2.0, pytz ~= 2013.8.0)
+  - pandas 0.15.0-2; depends (numpy ~= 1.8.1, distribute ~= 0.6.49, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0)
+  - pandas 0.15.1-1; depends (numpy ~= 1.8.1, distribute ~= 0.6.49, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0)
+  - pandas 0.15.2-1; depends (numpy ~= 1.8.1, distribute ~= 0.6.49, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0)
+  - pandas 0.15.2-2; depends (setuptools ~= 14.3.1, numpy ~= 1.8.1, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0)
+  - pandas 0.16.0-1; depends (setuptools ~= 14.3.1, numpy ~= 1.8.1, python_dateutil ~= 2.2.0, pytz ~= 2014.9.0)
+  - pandas 0.16.0-2; depends (setuptools ~= 14.3.1, numpy ~= 1.8.1, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.0-3; depends (numpy ~= 1.8.1, setuptools ~= 15.1, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.0-4; depends (numpy ~= 1.9.2, setuptools ~= 15.1, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.0-5; depends (setuptools ~= 15.2, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.1-1; depends (setuptools ~= 15.2, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.1-2; depends (setuptools ~= 16.0, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.1-3; depends (setuptools ~= 17.1.1, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.2-1; depends (setuptools ~= 17.1.1, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.2-2; depends (setuptools ~= 18.2, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.16.2-3; depends (setuptools ~= 18.4, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.17.1-1; depends (setuptools ~= 18.4, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.17.1-2; depends (setuptools ~= 18.7.1, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.17.1-3; depends (setuptools ~= 18.7.1, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.17.1-4; depends (setuptools ~= 18.7.1, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas 0.17.1-5; depends (setuptools ~= 19.1.1, numpy ~= 1.9.2, pytz ~= 2014.9.0, python_dateutil ~= 2.4.2)
+  - pandas_datareader 0.2.1-1; depends (requests ~= 2.8.0, requests_file ~= 1.4, pandas ~= 0.17.1)
+  - pandas_datareader 0.2.1-2; depends (requests_file ~= 1.4, requests ~= 2.9.0, pandas ~= 0.17.1)
+  - pandasql 0.3.1-1; depends (sqlparse ~= 0.1.8, pandas ~= 0.12.0)
+  - pandasql 0.3.1-2; depends (sqlparse ~= 0.1.8, pandas ~= 0.13.1)
+  - pandasql 0.4.3-1; depends (pandas ~= 0.14.0, sqlparse ~= 0.1.11)
+  - pandasql 0.4.3-2; depends (pandas ~= 0.14.1, sqlparse ~= 0.1.11)
+  - pandasql 0.6.1-1; depends (pandas ~= 0.14.1)
+  - pandasql 0.6.1-2; depends (pandas ~= 0.15.0)
+  - pandasql 0.6.1-3; depends (pandas ~= 0.15.1)
+  - pandasql 0.6.1-4; depends (pandas ~= 0.15.2)
+  - pandasql 0.6.1-5; depends (pandas ~= 0.16.0)
+  - pandasql 0.6.2-1; depends (pandas ~= 0.16.0)
+  - pandasql 0.6.2-2; depends (pandas ~= 0.16.1)
+  - pandasql 0.6.2-3; depends (pandas ~= 0.16.2)
+  - pandasql 0.6.3-1; depends (pandas ~= 0.16.2)
+  - pandasql 0.6.3-2; depends (pandas ~= 0.17.1)
+  - paramiko 1.7.6-4; depends (pycrypto)
+  - paramiko 1.7.7.1-1; depends (pycrypto)
+  - paramiko 1.10.1-2; depends (pycrypto ~= 2.6.1)
+  - paramiko 1.14.0-1; depends (pycrypto ~= 2.6.1, ecdsa ~= 0.11.0)
+  - paramiko 1.15.1-1; depends (pycrypto ~= 2.6.1, ecdsa ~= 0.11.0)
+  - paramiko 1.15.2-1; depends (pycrypto ~= 2.6.1, ecdsa ~= 0.11.0)
+  - paramiko 1.15.2-2; depends (pycrypto ~= 2.6.1, ecdsa ~= 0.13)
+  - paramiko 1.16.0-1; depends (pycrypto ~= 2.6.1, ecdsa ~= 0.13)
+  - partd 0.3.2-1; depends (locket ~= 0.2.0)
+  - passlib 1.6.2-1; depends (bcrypt ~= 1.0.2)
+  - paste 1.7.5.1-1
+  - pastedeploy 1.5.2-1; depends (paste ~= 1.7.5.1)
+  - patchelf 0.8-1
+  - path.py 8.1.1-1
+  - path.py 8.1.1-2
+  - patsy 0.2.0-1
+  - patsy 0.3.0-1
+  - patsy 0.4.0-1; depends (numpy ~= 1.9.2, six ~= 1.9.0)
+  - patsy 0.4.0-2; depends (numpy ~= 1.9.2, six ~= 1.10.0)
+  - pbr 0.10.0-1
+  - pbr 0.10.0-2; depends (distribute ~= 0.6.49)
+  - pbr 0.10.0-3; depends (setuptools ~= 14.3.1)
+  - pbr 0.10.0-4; depends (setuptools ~= 15.1)
+  - pbr 0.10.0-5; depends (setuptools ~= 15.2)
+  - pbr 0.10.0-6; depends (setuptools ~= 16.0)
+  - pbr 0.10.0-7; depends (setuptools ~= 17.1.1)
+  - pbr 1.2.0-1; depends (setuptools ~= 17.1.1)
+  - pbr 1.2.0-2; depends (setuptools ~= 18.2)
+  - pbr 1.8.1-1; depends (setuptools ~= 18.2)
+  - pbr 1.8.1-2; depends (setuptools ~= 18.4)
+  - pbr 1.8.1-3; depends (setuptools ~= 18.7.1)
+  - pbr 1.8.1-4; depends (setuptools ~= 19.1.1)
+  - pep8 0.6.1-1
+  - pep8 1.0.1-1
+  - pep8 1.4.6-1
+  - pep8 1.4.6-2
+  - pep8 1.5.7-1
+  - pep8 1.6.1-1
+  - pep8 1.6.2-1
+  - pexpect 3.3-1
+  - pexpect 3.3-2
+  - pickleshare 0.5-1; depends (path.py ~= 8.1.1)
+  - pil 1.1.7-3; depends (freetype ~= 2.4.4)
+  - pil 1.1.7-4; depends (libjpeg ~= 7.0, freetype ~= 2.4.4)
+  - pil 1.1.7-10; depends (libjpeg ~= 7.0, freetype ~= 2.4.4)
+  - pil 1.1.7-12; depends (libjpeg ~= 7.0, freetype ~= 2.4.4)
+  - pil 1.1.7-13; depends (libjpeg ~= 7.0, freetype ~= 2.5.3)
+  - pil 1.1.7-14; depends (libjpeg ~= 7.0, freetype ~= 2.5.3)
+  - pil_remove 1.0.0-1
+  - pil_remove 1.0.0-2
+  - pillow 2.8.1-1; depends (libjpeg ~= 7.0, pil_remove ~= 1.0.0, freetype ~= 2.5.3)
+  - pillow 2.9.0-1; depends (libjpeg ~= 7.0, pil_remove ~= 1.0.0, freetype ~= 2.5.3)
+  - pillow 2.9.0-2; depends (pil_remove ~= 1.0.0, libjpeg ~= 7.0, libopenjpeg ~= 2.1.0, freetype ~= 2.5.3)
+  - pillow 2.9.0-3; depends (pil_remove ~= 1.0.0, libjpeg ~= 7.0, libopenjpeg ~= 2.1.0, freetype ~= 2.5.3)
+  - pillow 3.0.0-1; depends (pil_remove ~= 1.0.0, libjpeg ~= 7.0, libopenjpeg ~= 2.1.0, freetype ~= 2.5.3)
+  - pip 1.5.6-1
+  - pip 6.0.6-1
+  - pip 6.0.8-1
+  - pip 6.1.1-1
+  - pip 7.0.1-1
+  - pip 7.0.3-1
+  - pip 7.1.0-1
+  - pip 7.1.2-1
+  - plotly 1.3.0-1; depends (requests ~= 2.4.3, matplotlib ~= 1.4.0, six ~= 1.8.0)
+  - plotly 1.3.0-2; depends (requests ~= 2.4.3, matplotlib ~= 1.4.2, six ~= 1.8.0)
+  - plotly 1.3.0-3; depends (matplotlib ~= 1.4.2, requests ~= 2.5.0, six ~= 1.8.0)
+  - plotly 1.4.14-1; depends (matplotlib ~= 1.4.2, requests ~= 2.5.0, six ~= 1.8.0)
+  - plotly 1.4.14-2; depends (matplotlib ~= 1.4.2, requests ~= 2.5.1, six ~= 1.8.0)
+  - plotly 1.4.14-3; depends (matplotlib ~= 1.4.2, requests ~= 2.5.1, six ~= 1.9.0)
+  - plotly 1.4.14-4; depends (matplotlib ~= 1.4.3, requests ~= 2.5.1, six ~= 1.9.0)
+  - plotly 1.4.14-5; depends (matplotlib ~= 1.4.3, requests ~= 2.5.3, six ~= 1.9.0)
+  - plotly 1.4.14-6; depends (matplotlib ~= 1.4.3, six ~= 1.9.0, requests ~= 2.6.0)
+  - plotly 1.4.14-7; depends (matplotlib ~= 1.4.3, requests ~= 2.6.2, six ~= 1.9.0)
+  - plotly 1.4.14-8; depends (requests ~= 2.7.0, matplotlib ~= 1.4.3, six ~= 1.9.0)
+  - plotly 1.4.14-9; depends (requests ~= 2.8.0, matplotlib ~= 1.4.3, six ~= 1.9.0)
+  - plotly 1.4.14-10; depends (requests ~= 2.8.0, matplotlib ~= 1.4.3, six ~= 1.10.0)
+  - plotly 1.4.14-11; depends (matplotlib ~= 1.5.0, requests ~= 2.8.0, six ~= 1.10.0)
+  - plotly 1.4.14-12; depends (matplotlib ~= 1.5.0, requests ~= 2.9.0, six ~= 1.10.0)
+  - ply 3.3-3
+  - ply 3.4-1
+  - ply 3.6-1
+  - portaudio 19-4
+  - pretend 1.0.8-1
+  - prettyplotlib 0.1.3-2; depends (matplotlib ~= 1.3.1, brewer2mpl ~= 1.3.1)
+  - prettyplotlib 0.1.7-1; depends (brewer2mpl ~= 1.4.0, matplotlib ~= 1.3.1)
+  - prettyplotlib 0.1.7-2; depends (brewer2mpl ~= 1.4.0, matplotlib ~= 1.4.0)
+  - prettyplotlib 0.1.7-3; depends (brewer2mpl ~= 1.4.0, matplotlib ~= 1.4.2)
+  - prettyplotlib 0.1.7-4; depends (brewer2mpl ~= 1.4.0, matplotlib ~= 1.4.3)
+  - prettyplotlib 0.1.7-5; depends (brewer2mpl ~= 1.4.0, matplotlib ~= 1.5.0)
+  - progressbar 2.3-1
+  - protobuf 2.4.0a0-1
+  - protobuf 2.4.1-1
+  - protobuf 2.4.1-2
+  - protobuf 2.6.1-1
+  - protobuf 2.6.1-2
+  - protobuf_python 2.4.1-1; depends (protobuf ~= 2.4.1)
+  - protobuf_python 2.6.1-1; depends (protobuf ~= 2.6.1)
+  - psutil 0.2.0-1
+  - psutil 0.2.1-1
+  - psutil 0.4.1-1
+  - psutil 1.0.1-1
+  - psutil 1.2.1-2
+  - psutil 2.1.1-1
+  - psutil 2.2.0-1
+  - psutil 2.2.1-1
+  - psutil 3.2.1-1
+  - ptyprocess 0.4-1
+  - py 1.4.14-1
+  - py 1.4.18-1
+  - py 1.4.20-1
+  - py 1.4.24-1
+  - py 1.4.25-1
+  - py 1.4.25-2
+  - py 1.4.26-1
+  - py 1.4.26-2
+  - py 1.4.30-1
+  - pyamg 2.1.0-1; depends (numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - pyamg 2.1.0-2; depends (numpy ~= 1.8.1, scipy ~= 0.14.1rc1)
+  - pyamg 2.2.0-1; depends (numpy ~= 1.8.1, scipy ~= 0.14.1rc1)
+  - pyamg 2.2.0-2; depends (numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - pyamg 2.2.1-1; depends (numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - pyamg 2.2.1-2; depends (numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - pyamg 2.2.1-3; depends (scipy ~= 0.16.0, numpy ~= 1.9.2)
+  - pyamg 2.2.1-4; depends (scipy ~= 0.16.1, numpy ~= 1.9.2)
+  - pyasn1 0.1.7-2
+  - pyasn1 0.1.9-1
+  - pyasn1_modules 0.0.8-1
+  - pyaudio 0.2.4-1
+  - pyaudio 0.2.4-3
+  - pycluster 1.50-2; depends (numpy ~= 1.5.1)
+  - pycluster 1.50-3; depends (numpy ~= 1.6.0)
+  - pycluster 1.50-4; depends (numpy ~= 1.6.1)
+  - pycluster 1.50-5; depends (numpy ~= 1.7.1)
+  - pycluster 1.50-6; depends (numpy ~= 1.8.0)
+  - pycluster 1.50-7; depends (numpy ~= 1.8.1)
+  - pycluster 1.50-8; depends (numpy ~= 1.9.2)
+  - pycparser 2.10.0-1
+  - pycparser 2.12-1
+  - pycparser 2.13-1
+  - pycparser 2.14-1
+  - pycparser 2.14-2
+  - pycrypto 2.3-2
+  - pycrypto 2.4.1-1
+  - pycrypto 2.6.1-1
+  - pycurl 7.19.5-1; depends (curl ~= 7.38.0)
+  - pycurl 7.19.5-2; depends (curl ~= 7.43.0)
+  - pydicom 0.9.9-1
+  - pydot 1.0.2-5; depends (pyparsing ~= 1.5.5)
+  - pydot 1.0.25-1; depends (pyparsing ~= 1.5.5)
+  - pydot 1.0.28-1; depends (pyparsing)
+  - pydot 1.0.28-2; depends (pyparsing ~= 2.0.2)
+  - pydot 1.0.28-3; depends (pyparsing ~= 2.0.3)
+  - pyephem 3.7.3.4-2
+  - pyephem 3.7.4.1-1
+  - pyephem 3.7.5.1-1
+  - pyephem 3.7.5.3-1
+  - pyface 4.0.0-1
+  - pyface 4.1.0-1
+  - pyface 4.2.0-1
+  - pyface 4.3.0-1
+  - pyface 4.3.0-2; depends (traits ~= 4.3.0)
+  - pyface 4.4.0-1; depends (traits ~= 4.4.0)
+  - pyface 4.4.0-2; depends (traits ~= 4.5.0)
+  - pyface 4.5.0-1; depends (traits ~= 4.5.0)
+  - pyface 4.5.2-1; depends (traits ~= 4.5.0)
+  - pyface 5.0.0-1; depends (traits ~= 4.5.0)
+  - pyfits 2.4.0-1; depends (numpy ~= 1.5.1)
+  - pyfits 2.4.0-2; depends (numpy ~= 1.6.0)
+  - pyfits 2.4.0-3; depends (numpy ~= 1.6.1)
+  - pyfits 3.0.3-1; depends (numpy ~= 1.6.1)
+  - pyfits 3.0.6-1; depends (numpy ~= 1.6.1)
+  - pyfits 3.0.6-2; depends (numpy ~= 1.7.1)
+  - pyfits 3.0.6-3; depends (numpy ~= 1.8.0)
+  - pyfits 3.0.6-4; depends (numpy ~= 1.8.1)
+  - pyfits 3.3-1; depends (numpy ~= 1.8.1)
+  - pyflakes 0.4.0-2
+  - pyflakes 0.4.0-3
+  - pyflakes 0.5.0-1
+  - pyflakes 0.7.3-1
+  - pyflakes 0.7.3-2
+  - pyflakes 0.8.1-1
+  - pyflakes 0.9.2-1
+  - pyflakes 1.0.0-1
+  - pygarrayimage 0.0.7-4; depends (pil, numpy, pyglet)
+  - pygarrayimage 0.0.7-5; depends (pil, numpy, pyglet)
+  - pygarrayimage 0.0.7-6; depends (pil, numpy, pyglet)
+  - pygarrayimage 0.0.7-7; depends (pil, numpy, pyglet)
+  - pygarrayimage 0.0.7-8; depends (pil, numpy, pyglet)
+  - pygarrayimage 0.0.7-9; depends (numpy, pillow, pyglet)
+  - pygarrayimage 0.0.7-10; depends (numpy, pillow, pyglet)
+  - pygarrayimage 0.0.7-11; depends (numpy, pillow, pyglet)
+  - pyglet 1.1.4-2
+  - pygments 1.3.1-2
+  - pygments 1.4-1
+  - pygments 1.6.0-1
+  - pygments 2.0.1-1
+  - pygments 2.0.2-1
+  - pygrib 1.9.1-1; depends (pyproj ~= 1.8.9, numpy ~= 1.6.1)
+  - pygrib 1.9.2-1; depends (pyproj ~= 1.8.9, numpy ~= 1.6.1)
+  - pygrib 1.9.2-2; depends (pyproj ~= 1.9.3, numpy ~= 1.7.1)
+  - pygrib 1.9.2-3; depends (numpy ~= 1.8.0, pyproj ~= 1.9.3)
+  - pygrib 1.9.9-1; depends (numpy ~= 1.8.0, pyproj ~= 1.9.3)
+  - pygrib 1.9.9-3; depends (pyproj ~= 1.9.3, numpy ~= 1.8.1, libpng ~= 1.6.12)
+  - pygrib 1.9.9-4; depends (pyproj ~= 1.9.3, numpy ~= 1.9.2, libpng ~= 1.6.12)
+  - pygrib 1.9.9-5; depends (pyproj ~= 1.9.4, numpy ~= 1.9.2, libpng ~= 1.6.12)
+  - pyhdf 0.8.3-4; depends (numpy ~= 1.5.1)
+  - pyhdf 0.8.3-5; depends (numpy ~= 1.6.0)
+  - pyhdf 0.8.3-6; depends (numpy ~= 1.6.1)
+  - pyhdf 0.8.3-8; depends (numpy ~= 1.7.1)
+  - pyhdf 0.8.3-11; depends (numpy ~= 1.8.0)
+  - pyhdf 0.8.3-12; depends (numpy ~= 1.8.1)
+  - pyke 1.1.1-1; depends (doctest_tools ~= 1.0a3, htmltemplate ~= 1.5.0)
+  - pylint 0.23.0-1; depends (logilab_common, logilab_astng)
+  - pylint 0.24.0-1; depends (logilab_common, logilab_astng)
+  - pylint 0.25.0-1; depends (logilab_common, logilab_astng)
+  - pylint 0.25.1-1; depends (logilab_common, logilab_astng)
+  - pymc 2.1b0-1; depends (numpy ~= 1.5.1)
+  - pymc 2.1b0-2; depends (numpy ~= 1.6.0)
+  - pymc 2.1b0-3; depends (numpy)
+  - pymc 2.2.0-2; depends (numpy ~= 1.7.1)
+  - pymc 2.2.0-3; depends (numpy ~= 1.8.0)
+  - pymc 2.3.2-1; depends (numpy ~= 1.8.0)
+  - pymc 2.3.2-3; depends (numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - pymc 2.3.3-1; depends (numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - pymc 2.3.3-2; depends (numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - pymc 2.3.3-3; depends (numpy ~= 1.8.1, scipy ~= 0.14.1rc1)
+  - pymc 2.3.3-4; depends (numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - pymc 2.3.4-1; depends (numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - pymc 2.3.4-2; depends (numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - pymc 2.3.4-3; depends (numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - pymc 2.3.4-4; depends (scipy ~= 0.16.0, numpy ~= 1.9.2)
+  - pymc 2.3.6-1; depends (scipy ~= 0.16.0, numpy ~= 1.9.2)
+  - pymc 2.3.6-2; depends (scipy ~= 0.16.1, numpy ~= 1.9.2)
+  - pymc 2.3.6-3; depends (scipy ~= 0.16.1, numpy ~= 1.9.2)
+  - pymc 2.3.6-4; depends (mkl ~= 10.3, scipy ~= 0.16.1, numpy ~= 1.9.2)
+  - pymongo 2.7.2-1
+  - pymongo 2.8-1
+  - pymysql 0.6.2-1
+  - pymysql 0.6.3-1
+  - pymysql 0.6.6-1
+  - pymysql 0.6.7-1
+  - pyodbc 2.1.8-1
+  - pyodbc 3.0.6-1
+  - pyodbc 3.0.7-1
+  - pyodbc 3.0.7-2; depends (unixodbc ~= 2.3.2)
+  - pyodbc 3.0.10-1; depends (unixodbc ~= 2.3.2)
+  - pyopengl 3.0.1-2
+  - pyopengl 3.1.0-1
+  - pyopenssl 0.11-2
+  - pyopenssl 0.12-1
+  - pyopenssl 0.13-1
+  - pyopenssl 0.13.1-1
+  - pyopenssl 0.14-1; depends (cryptography ~= 0.6.1, six ~= 1.8.0)
+  - pyopenssl 0.14-2; depends (cryptography ~= 0.6.1, six ~= 1.9.0)
+  - pyopenssl 0.14-3; depends (cryptography ~= 0.8.1, six ~= 1.9.0)
+  - pyopenssl 0.14-4; depends (six ~= 1.9.0, cryptography ~= 0.8.2)
+  - pyopenssl 0.15.1-1; depends (six ~= 1.9.0, cryptography ~= 0.8.2)
+  - pyopenssl 0.15.1-2; depends (cryptography ~= 0.9.1, six ~= 1.9.0)
+  - pyopenssl 0.15.1-3; depends (cryptography ~= 0.9.3, six ~= 1.9.0)
+  - pyopenssl 0.15.1-4; depends (cryptography ~= 0.9.3, six ~= 1.10.0)
+  - pyopenssl 0.15.1-5; depends (cryptography ~= 1.1.1, six ~= 1.10.0)
+  - pyparsing 1.5.5-3
+  - pyparsing 1.5.6-1
+  - pyparsing 2.0.2-1
+  - pyparsing 2.0.3-1
+  - pyproj 1.8.8-2
+  - pyproj 1.8.9-1
+  - pyproj 1.9.0-1
+  - pyproj 1.9.3-1
+  - pyproj 1.9.4-1
+  - pyqt 4.10.3-1; depends (qt ~= 4.8.5, sip ~= 4.15.3)
+  - pyqt 4.11.0-1; depends (sip ~= 4.16.1)
+  - pyqt 4.11.3-1; depends (sip ~= 4.16.7, qt ~= 4.8.6)
+  - pyqt 4.11.4-1; depends (sip ~= 4.17, qt ~= 4.8.6)
+  - pysal 1.7.0-1; depends (numpy ~= 1.8.0, scipy ~= 0.13.3)
+  - pysal 1.7.0-2; depends (numpy ~= 1.8.0, scipy ~= 0.14.0)
+  - pysal 1.7.0-3; depends (numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - pysal 1.7.0-4; depends (numpy ~= 1.8.1, scipy ~= 0.14.1rc1)
+  - pysal 1.7.0-5; depends (numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - pysal 1.7.0-6; depends (numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - pysal 1.7.0-7; depends (scipy ~= 0.16.0, numpy ~= 1.9.2)
+  - pysal 1.7.0-8; depends (scipy ~= 0.16.1, numpy ~= 1.9.2)
+  - pyserial 2.5-2
+  - pyserial 2.6-1
+  - pyserial 2.7-1
+  - pyshp 1.2.0-1
+  - pyside 1.0.0rc1-1; depends (qt ~= 4.7.1)
+  - pyside 1.0.2-1; depends (qt ~= 4.7.2)
+  - pyside 1.0.3-2; depends (qt ~= 4.7.3)
+  - pyside 1.0.5-1; depends (qt ~= 4.7.3)
+  - pyside 1.0.7-1; depends (qt ~= 4.7.3)
+  - pyside 1.1.0-2; depends (qt ~= 4.7.3)
+  - pyside 1.1.0-3; depends (qt ~= 4.7.3)
+  - pyside 1.2.1-1; depends (qt ~= 4.8.5, shiboken ~= 1.2.1)
+  - pyside 1.2.1-2; depends (qt ~= 4.8.5, shiboken ~= 1.2.1)
+  - pyside 1.2.2-1; depends (shiboken ~= 1.2.2, qt ~= 4.8.5)
+  - pyside 1.2.2-2; depends (shiboken ~= 1.2.2, qt ~= 4.8.6)
+  - pyside 1.2.2-5; depends (shiboken ~= 1.2.2, qt ~= 4.8.6)
+  - pyside_debug 1.2.2-5; depends (pyside == 1.2.2-5)
+  - pysparse 1.2.dev203-2; depends (mkl ~= 10.3, numpy ~= 1.5.1)
+  - pysparse 1.2.dev213-1; depends (mkl ~= 10.3, numpy ~= 1.5.1)
+  - pysparse 1.2.dev213-5; depends (mkl ~= 10.3, numpy)
+  - pysparse 1.2.dev213-6; depends (mkl ~= 10.3, numpy)
+  - pysparse 1.2.dev213-7; depends (mkl ~= 10.3, numpy)
+  - pysparse 1.2.dev213-8; depends (mkl ~= 10.3, numpy)
+  - pysparse 1.2.dev213-9; depends (mkl ~= 10.3, numpy ~= 1.9.2)
+  - pytables 2.2.1-1; depends (numexpr ~= 1.4.2, hdf5 ~= 1.8.5.1, numpy ~= 1.5.1)
+  - pytables 2.2.1-2; depends (numexpr ~= 1.4.2, hdf5 ~= 1.8.5.1, numpy ~= 1.6.0)
+  - pytables 2.3b1.dev4669-1; depends (numexpr ~= 1.4.2, hdf5 ~= 1.8.5.1, numpy ~= 1.6.0)
+  - pytables 2.3b1.dev4669-2; depends (numexpr ~= 1.4.2, hdf5 ~= 1.8.5.1, numpy ~= 1.6.1)
+  - pytables 2.3-1; depends (numexpr ~= 1.4.2, hdf5 ~= 1.8.5.1, numpy ~= 1.6.1)
+  - pytables 2.3.1-1; depends (numexpr ~= 1.4.2, hdf5 ~= 1.8.5.1, numpy ~= 1.6.1)
+  - pytables 2.3.1-2; depends (hdf5 ~= 1.8.5.1, numpy ~= 1.6.1, numexpr ~= 2.0)
+  - pytables 2.3.1-3; depends (hdf5 ~= 1.8.5.1, numexpr ~= 2.0.1, numpy ~= 1.6.1)
+  - pytables 2.3.1-4; depends (hdf5 ~= 1.8.9, numexpr ~= 2.0.1, numpy ~= 1.6.1)
+  - pytables 2.3.1-6; depends (hdf5 ~= 1.8.9, numexpr ~= 2.0.1, numpy ~= 1.7.1)
+  - pytables 2.4.0-1; depends (hdf5 ~= 1.8.9, numexpr ~= 2.0.1, numpy ~= 1.7.1)
+  - pytables 2.4.0-2; depends (hdf5 ~= 1.8.9, numexpr ~= 2.0.1, numpy ~= 1.7.1)
+  - pytables 2.4.0-3; depends (numexpr ~= 2.0.1, numpy ~= 1.7.1, hdf5 ~= 1.8.11)
+  - pytables 2.4.0-4; depends (numexpr ~= 2.2.2, numpy ~= 1.7.1, hdf5 ~= 1.8.11)
+  - pytables 2.4.0-5; depends (numpy ~= 1.8.0, numexpr ~= 2.2.2, hdf5 ~= 1.8.11)
+  - pytables 3.1.1-1; depends (numpy ~= 1.8.0, numexpr ~= 2.4.0, hdf5 ~= 1.8.11)
+  - pytables 3.1.1-3; depends (numexpr ~= 2.4.0, numpy ~= 1.8.1, hdf5 ~= 1.8.11)
+  - pytables 3.1.1-4; depends (numexpr ~= 2.4.0, numpy ~= 1.8.1, hdf5 ~= 1.8.11)
+  - pytables 3.1.1-5; depends (hdf5 ~= 1.8.14, numexpr ~= 2.4.0, numpy ~= 1.8.1)
+  - pytables 3.1.1-6; depends (hdf5 ~= 1.8.14, numexpr ~= 2.4.0, numpy ~= 1.9.2)
+  - pytables 3.1.1-7; depends (hdf5 ~= 1.8.15.1, numexpr ~= 2.4.0, numpy ~= 1.9.2)
+  - pytables 3.2.0-1; depends (hdf5 ~= 1.8.15.1, numexpr ~= 2.4.0, numpy ~= 1.9.2)
+  - pytables 3.2.0-2; depends (hdf5 ~= 1.8.15.1, numexpr ~= 2.4.0, numpy ~= 1.9.2)
+  - pytables 3.2.2-2; depends (hdf5 ~= 1.8.15.1, numexpr ~= 2.4.0, numpy ~= 1.9.2)
+  - pytest 2.3.5-1; depends (py)
+  - pytest 2.4.2-1; depends (py ~= 1.4.18)
+  - pytest 2.5.2-1; depends (py ~= 1.4.20)
+  - pytest 2.6.2-2; depends (py ~= 1.4.24)
+  - pytest 2.6.3-1; depends (py ~= 1.4.25)
+  - pytest 2.6.3-2; depends (py ~= 1.4.25)
+  - pytest 2.6.4-1; depends (py ~= 1.4.26)
+  - pytest 2.8.2-1; depends (py ~= 1.4.30)
+  - pytest_httpbin 0.2.0-1; depends (httpbin ~= 0.4.0, pytest ~= 2.8.2)
+  - python_dateutil 1.5-2
+  - python_dateutil 2.2.0-1; depends (six ~= 1.3.0)
+  - python_dateutil 2.2.0-2; depends (six ~= 1.4.1)
+  - python_dateutil 2.2.0-3; depends (six ~= 1.7.2)
+  - python_dateutil 2.2.0-4; depends (six ~= 1.7.3)
+  - python_dateutil 2.2.0-5; depends (six ~= 1.8.0)
+  - python_dateutil 2.2.0-7; depends (six ~= 1.9.0)
+  - python_dateutil 2.4.2-1; depends (six ~= 1.9.0)
+  - python_dateutil 2.4.2-2; depends (six ~= 1.10.0)
+  - python_ntlm3 1.0.2-1; depends (six ~= 1.10.0)
+  - python_pptx 0.5.7-1; depends (lxml ~= 3.4.4, pillow ~= 2.8.1, xlsxwriter ~= 0.7.2)
+  - python_pptx 0.5.7-2; depends (lxml ~= 3.4.4, pillow ~= 2.8.1, xlsxwriter ~= 0.7.3)
+  - python_pptx 0.5.7-3; depends (lxml ~= 3.4.4, pillow ~= 2.9.0, xlsxwriter ~= 0.7.3)
+  - python_pptx 0.5.7-4; depends (lxml ~= 3.4.4, pillow ~= 2.9.0, xlsxwriter ~= 0.7.6)
+  - python_pptx 0.5.7-5; depends (lxml ~= 3.4.4, pillow ~= 3.0.0, xlsxwriter ~= 0.7.6)
+  - python_pptx 0.5.8-1; depends (lxml ~= 3.4.4, xlsxwriter ~= 0.7.7, pillow ~= 3.0.0)
+  - python_sybase 0.39-1
+  - python_termstyle 0.1.10-1
+  - pythondoc 2.7.3-1; depends (appinst)
+  - pytz 2010o-1
+  - pytz 2011e-1
+  - pytz 2011g-1
+  - pytz 2011k-1
+  - pytz 2011n-1
+  - pytz 2013.8.0-1
+  - pytz 2014.9.0-1
+  - pyvisa 1.3-3
+  - pyvisa 1.6.1-1; depends (enum34 ~= 1.0.3)
+  - pyvisa 1.6.1-2; depends (enum34 ~= 1.0.4)
+  - pyvisa 1.6.1-3; depends (enum34 ~= 1.1.1)
+  - pywinrm 0.0.3-1; depends (xmltodict ~= 0.9.2, isodate ~= 0.5.1)
+  - pywinrm 0.0.3-2; depends (xmltodict ~= 0.9.2, isodate ~= 0.5.1)
+  - pywinrm 0.0.3-3; depends (xmltodict ~= 0.9.2, isodate ~= 0.5.1)
+  - pyyaml 3.9-2; depends (libyaml ~= 0.1.3)
+  - pyyaml 3.10-1; depends (libyaml ~= 0.1.4)
+  - pyyaml 3.11-1; depends (libyaml ~= 0.1.4)
+  - pyzmq 2.0.10-2; depends (zeromq ~= 2.0.10)
+  - pyzmq 2.0.10.1-1; depends (zeromq ~= 2.0.10)
+  - pyzmq 2.0.10.1-2; depends (zeromq ~= 2.0.10)
+  - pyzmq 2.1.1-1; depends (zeromq ~= 2.1.1)
+  - pyzmq 2.1.4-1; depends (zeromq ~= 2.1.4)
+  - pyzmq 2.1.7-1; depends (zeromq ~= 2.1.7)
+  - pyzmq 2.1.9-1
+  - pyzmq 2.1.10-1
+  - pyzmq 2.1.11-1
+  - pyzmq 2.2.0-1
+  - pyzmq 2.2.0-2
+  - pyzmq 2.2.0-3
+  - pyzmq 2.2.0-4
+  - pyzmq 14.1.1-1; depends (zeromq ~= 3.2.4)
+  - pyzmq 14.3.1-1; depends (zeromq ~= 4.0.4)
+  - pyzmq 14.4.1-1; depends (zeromq ~= 4.0.4)
+  - pyzmq 14.5.0-1; depends (zeromq ~= 4.0.5)
+  - pyzmq 14.6.0-1; depends (zeromq ~= 4.0.5)
+  - pyzmq 14.7.0-1; depends (zeromq ~= 4.0.5)
+  - pyzmq 14.7.0-2; depends (zeromq ~= 4.1.3)
+  - pyzmq 14.7.0-3; depends (zeromq ~= 4.1.3)
+  - qpython 1.0.0-1; depends (twisted ~= 15.2.1, numpy ~= 1.9.2, pandas ~= 0.16.2)
+  - qpython 1.0.0-2; depends (numpy ~= 1.9.2, twisted ~= 15.4.0, pandas ~= 0.16.2)
+  - qpython 1.0.0-3; depends (numpy ~= 1.9.2, twisted ~= 15.4.0, pandas ~= 0.16.2)
+  - qpython 1.0.0-4; depends (numpy ~= 1.9.2, twisted ~= 15.4.0, pandas ~= 0.17.1)
+  - qpython 1.0.0-5; depends (numpy ~= 1.9.2, twisted ~= 15.4.0, pandas ~= 0.17.1)
+  - qpython 1.0.0-6; depends (numpy ~= 1.9.2, twisted ~= 15.5.0, pandas ~= 0.17.1)
+  - qt 4.7.1-1
+  - qt 4.7.2-1
+  - qt 4.7.3-1
+  - qt 4.7.3-2
+  - qt 4.8.5-6; depends (gst_plugins_base ~= 0.10.36)
+  - qt 4.8.5-9; depends (gst_plugins_base ~= 0.10.36)
+  - qt 4.8.5-10; depends (gst_plugins_base ~= 0.10.36)
+  - qt 4.8.6-1; depends (gst_plugins_base ~= 0.10.36)
+  - qt 4.8.6-2; depends (gst_plugins_base ~= 0.10.36)
+  - qt_debug 4.8.6-2; depends (qt == 4.8.6-2)
+  - qtconsole 4.0.1-1; depends (jupyter_core ~= 4.0.4, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, pygments ~= 2.0.2, ipykernel ~= 4.0.3)
+  - qtconsole 4.0.1-2; depends (jupyter_core ~= 4.0.6, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, pygments ~= 2.0.2, ipykernel ~= 4.0.3)
+  - qtconsole 4.0.1-3; depends (jupyter_core ~= 4.0.6, traitlets ~= 4.0.0, jupyter_client ~= 4.0.0, pygments ~= 2.0.2, ipykernel ~= 4.1.0)
+  - qtconsole 4.1.1-1; depends (jupyter_core ~= 4.0.6, traitlets ~= 4.0.0, jupyter_client ~= 4.1.1, ipykernel ~= 4.2.0, pygments ~= 2.0.2)
+  - qtconsole 4.1.1-2; depends (jupyter_core ~= 4.0.6, traitlets ~= 4.0.0, jupyter_client ~= 4.1.1, ipykernel ~= 4.2.0, pygments ~= 2.0.2)
+  - quandl 2.8.5-1
+  - quandl 2.8.7-1
+  - quandl 2.8.9-1
+  - queuelib 1.2.2-1
+  - queuelib 1.4.2-1
+  - redis 2.6.16-1
+  - redis_py 2.8.0-1
+  - redis_py 2.10.3-1
+  - rednose 0.4.1-1; depends (nose ~= 1.3.4)
+  - rednose 0.4.1-2; depends (nose ~= 1.3.4, python_termstyle ~= 0.1.10)
+  - reportlab 2.5-2; depends (freetype ~= 2.4.4)
+  - reportlab 3.1.8-1; depends (freetype ~= 2.4.4)
+  - reportlab 3.1.44-1; depends (freetype ~= 2.5.3)
+  - reportlab 3.1.44-2; depends (freetype ~= 2.5.3)
+  - reportlab 3.2.0-1; depends (freetype ~= 2.5.3)
+  - reportlab 3.2.0-2; depends (freetype ~= 2.5.3)
+  - reportlab 3.2.0-3; depends (freetype ~= 2.5.3)
+  - requests 1.2.3-1
+  - requests 2.2.1-1
+  - requests 2.3.0-1
+  - requests 2.4.0-1
+  - requests 2.4.1-1
+  - requests 2.4.3-1
+  - requests 2.5.0-1
+  - requests 2.5.1-1
+  - requests 2.5.1-2
+  - requests 2.5.3-1
+  - requests 2.6.0-1
+  - requests 2.6.2-1
+  - requests 2.7.0-1
+  - requests 2.8.0-1
+  - requests 2.8.0-2
+  - requests 2.9.0-1
+  - requests_file 1.4-1; depends (requests ~= 2.8.0)
+  - requests_file 1.4-2; depends (requests ~= 2.9.0)
+  - requests_ntlm 0.2.0-1; depends (python_ntlm3 ~= 1.0.2, requests ~= 2.8.0)
+  - requests_ntlm 0.2.0-2; depends (python_ntlm3 ~= 1.0.2, requests ~= 2.9.0)
+  - responses 0.3.0-1; depends (requests ~= 2.5.0)
+  - responses 0.3.0-2; depends (requests ~= 2.5.1)
+  - responses 0.3.0-3; depends (requests ~= 2.5.3)
+  - responses 0.3.0-4; depends (requests ~= 2.6.0)
+  - responses 0.3.0-5; depends (requests ~= 2.6.2)
+  - responses 0.3.0-6; depends (requests ~= 2.7.0)
+  - responses 0.3.0-7; depends (requests ~= 2.8.0)
+  - responses 0.3.0-8; depends (requests ~= 2.9.0)
+  - rsa 3.1.2-2; depends (pyasn1 ~= 0.1.7)
+  - rsa 3.1.2-3; depends (pyasn1 ~= 0.1.9)
+  - runipy 0.1.3-1; depends (jinja2 ~= 2.7.3, ipython ~= 2.3.1, pyzmq ~= 14.5.0, pygments ~= 2.0.2)
+  - runipy 0.1.3-2; depends (ipython ~= 2.4.1, jinja2 ~= 2.7.3, pyzmq ~= 14.5.0, pygments ~= 2.0.2)
+  - runipy 0.1.3-3; depends (jinja2 ~= 2.7.3, ipython ~= 3.1.0, pygments ~= 2.0.2, pyzmq ~= 14.5.0)
+  - runipy 0.1.3-4; depends (jinja2 ~= 2.7.3, pyzmq ~= 14.6.0, ipython ~= 3.1.0, pygments ~= 2.0.2)
+  - runipy 0.1.3-5; depends (jinja2 ~= 2.7.3, ipython ~= 3.2.0, pyzmq ~= 14.7.0, pygments ~= 2.0.2)
+  - runipy 0.1.3-6; depends (jinja2 ~= 2.7.3, pyzmq ~= 14.7.0, ipython ~= 3.2.1, pygments ~= 2.0.2)
+  - sas7bdat 2.0.4-1; depends (six ~= 1.9.0)
+  - sas7bdat 2.0.4-2; depends (six ~= 1.10.0)
+  - scandir 1.1-1
+  - scientificpython 2.9.0-2; depends (numpy ~= 1.5.1, lib_netcdf3 ~= 3.6.2)
+  - scientificpython 2.9.0-3; depends (lib_netcdf3 ~= 3.6.2, numpy ~= 1.6.0)
+  - scientificpython 2.9.0-6; depends (lib_netcdf4 ~= 4.3.0, numpy ~= 1.7.1)
+  - scientificpython 2.9.0-8; depends (numpy ~= 1.8.0, lib_netcdf4 ~= 4.3.0)
+  - scientificpython 2.9.0-10; depends (lib_netcdf4 ~= 4.3.2, numpy ~= 1.8.1)
+  - scientificpython 2.9.0-11; depends (lib_netcdf4 ~= 4.3.2, numpy ~= 1.8.1)
+  - scikit_learn 0.9-1; depends (mkl ~= 10.3, numpy ~= 1.6.1, scipy)
+  - scikit_learn 0.10-1; depends (mkl ~= 10.3, numpy ~= 1.6.1, scipy)
+  - scikit_learn 0.11-1; depends (mkl ~= 10.3, numpy ~= 1.6.1, scipy)
+  - scikit_learn 0.13.1-1; depends (mkl ~= 10.3, numpy ~= 1.6.1, scipy)
+  - scikit_learn 0.13.1-4; depends (mkl ~= 10.3, numpy ~= 1.7.1, scipy)
+  - scikit_learn 0.14.1-1; depends (mkl ~= 10.3, numpy ~= 1.7.1, scipy)
+  - scikit_learn 0.14.1-2; depends (mkl ~= 10.3, scipy ~= 0.13.0, numpy ~= 1.7.1)
+  - scikit_learn 0.14.1-3; depends (mkl ~= 10.3, numpy ~= 1.8.0, scipy ~= 0.13.0)
+  - scikit_learn 0.14.1-4; depends (mkl ~= 10.3, numpy ~= 1.8.0, scipy ~= 0.13.2)
+  - scikit_learn 0.14.1-5; depends (mkl ~= 10.3, numpy ~= 1.8.0, scipy ~= 0.13.3)
+  - scikit_learn 0.14.1-6; depends (mkl ~= 10.3, numpy ~= 1.8.0, scipy ~= 0.14.0)
+  - scikit_learn 0.15.0-1; depends (mkl ~= 10.3, numpy ~= 1.8.0, scipy ~= 0.14.0)
+  - scikit_learn 0.15.0-2; depends (mkl ~= 10.3, numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - scikit_learn 0.15.1-1; depends (mkl ~= 10.3, numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - scikit_learn 0.15.2-1; depends (mkl ~= 10.3, numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - scikit_learn 0.15.2-2; depends (mkl ~= 10.3, numpy ~= 1.8.1, scipy ~= 0.14.1rc1)
+  - scikit_learn 0.15.2-3; depends (mkl ~= 10.3, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - scikit_learn 0.16.0-1; depends (mkl ~= 10.3, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - scikit_learn 0.16.1-1; depends (mkl ~= 10.3, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - scikit_learn 0.16.1-2; depends (mkl ~= 10.3, numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - scikit_learn 0.16.1-3; depends (mkl ~= 10.3, scipy ~= 0.16.0, numpy ~= 1.9.2)
+  - scikit_learn 0.17-1; depends (mkl ~= 10.3, scipy ~= 0.16.1, numpy ~= 1.9.2)
+  - scikits.image 0.2.2-2; depends (pil, numpy ~= 1.5.1)
+  - scikits.image 0.2.2-3; depends (pil, numpy ~= 1.6.0)
+  - scikits.image 0.2.2-4; depends (pil, numpy)
+  - scikits.image 0.3.1-1; depends (pil, numpy)
+  - scikits.image 0.4.2-1; depends (pil, numpy)
+  - scikits.image 0.5.0-1; depends (pil, numpy)
+  - scikits.image 0.8.2-1; depends (pil, numpy ~= 1.6.1, scipy ~= 0.12.0)
+  - scikits.image 0.8.2-2; depends (pil, numpy ~= 1.7.1, scipy ~= 0.12.0)
+  - scikits.image 0.8.2-3; depends (pil, numpy ~= 1.7.1, scipy ~= 0.12.0)
+  - scikits.image 0.8.2-4; depends (pil, scipy ~= 0.13.0, numpy ~= 1.7.1)
+  - scikits.image 0.9.3-1; depends (numpy ~= 1.8.0, pil, scipy ~= 0.13.0)
+  - scikits.image 0.9.3-3; depends (numpy ~= 1.8.0, pil, scipy ~= 0.13.2)
+  - scikits.image 0.9.3-4; depends (numpy ~= 1.8.0, pil, scipy ~= 0.13.3)
+  - scikits.image 0.9.3-5; depends (numpy ~= 1.8.0, pil, scipy ~= 0.14.0)
+  - scikits.image 0.10.0-1; depends (numpy ~= 1.8.0, pil, scipy ~= 0.14.0)
+  - scikits.image 0.10.0-3; depends (pil, numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - scikits.image 0.10.1-1; depends (pil, numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - scikits.image 0.10.1-3; depends (pil, numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - scikits.image 0.10.1-4; depends (pil, numpy ~= 1.8.1, scipy ~= 0.14.1rc1)
+  - scikits.image 0.10.1-5; depends (pil, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - scikits.image 0.10.1-6; depends (pil, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - scikits.image 0.11.2-1; depends (networkx ~= 1.9.1, pil, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - scikits.image 0.11.3-1; depends (networkx ~= 1.9.1, pil, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - scikits.image 0.11.3-2; depends (networkx ~= 1.9.1, pil, numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - scikits.image 0.11.3-3; depends (networkx ~= 1.9.1, pillow ~= 2.8.1, numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - scikits.image 0.11.3-4; depends (networkx ~= 1.9.1, pillow ~= 2.9.0, numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - scikits.image 0.11.3-5; depends (scipy ~= 0.15.1, pillow ~= 2.9.0, numpy ~= 1.9.2, networkx ~= 1.10)
+  - scikits.image 0.11.3-6; depends (scipy ~= 0.16.0, pillow ~= 2.9.0, numpy ~= 1.9.2, networkx ~= 1.10)
+  - scikits.image 0.11.3-7; depends (scipy ~= 0.16.1, pillow ~= 2.9.0, numpy ~= 1.9.2, networkx ~= 1.10)
+  - scikits.image 0.11.3-8; depends (scipy ~= 0.16.1, pillow ~= 2.9.0, numpy ~= 1.9.2, networkx ~= 1.10)
+  - scikits.image 0.11.3-9; depends (scipy ~= 0.16.1, pillow ~= 2.9.0, numpy ~= 1.9.2, networkx ~= 1.10)
+  - scikits.image 0.11.3-10; depends (scipy ~= 0.16.1, numpy ~= 1.9.2, pillow ~= 3.0.0, networkx ~= 1.10)
+  - scikits.learn 0.6-1; depends (numpy ~= 1.5.1)
+  - scikits.learn 0.7.1-1; depends (mkl ~= 10.3, numpy ~= 1.5.1)
+  - scikits.learn 0.7.1-2; depends (mkl ~= 10.3, numpy ~= 1.6.0, scipy)
+  - scikits.learn 0.8-1; depends (mkl ~= 10.3, numpy ~= 1.6.0, scipy)
+  - scikits.learn 0.8-2; depends (mkl ~= 10.3, numpy ~= 1.6.1, scipy)
+  - scikits.rsformats 0.1-6; depends (pyparsing, numpy ~= 1.5.1, pyhdf ~= 0.8.3)
+  - scikits.rsformats 0.1-7; depends (pyparsing, numpy ~= 1.6.0, pyhdf ~= 0.8.3)
+  - scikits.rsformats 0.1-9; depends (pyparsing, numpy ~= 1.7.1, pyhdf ~= 0.8.3)
+  - scikits.rsformats 0.1-10; depends (numpy ~= 1.8.0, pyparsing, pyhdf ~= 0.8.3)
+  - scikits.rsformats 0.1-11; depends (numpy ~= 1.8.0, pyparsing ~= 2.0.2, pyhdf ~= 0.8.3)
+  - scikits.rsformats 0.1-12; depends (pyparsing ~= 2.0.2, numpy ~= 1.8.1, pyhdf ~= 0.8.3)
+  - scikits.rsformats 0.1-13; depends (numpy ~= 1.8.1, pyhdf ~= 0.8.3, pyparsing ~= 2.0.3)
+  - scikits.statsmodels 0.2.0-2
+  - scikits.statsmodels 0.3.0-1
+  - scikits.statsmodels 0.3.1-1
+  - scikits.timeseries 0.91.3-2; depends (numpy ~= 1.5.1)
+  - scikits.timeseries 0.91.3-3; depends (numpy ~= 1.6.0)
+  - scikits.timeseries 0.91.3-4; depends (numpy ~= 1.6.1)
+  - scikits.timeseries 0.91.3-5; depends (numpy ~= 1.7.1)
+  - scikits.timeseries 0.91.3-6; depends (numpy ~= 1.8.0)
+  - scikits.timeseries 0.91.3-7; depends (numpy ~= 1.8.1)
+  - scikits.timeseries 0.91.3-8; depends (numpy ~= 1.9.2)
+  - scimath 3.0.7-1; depends (numpy ~= 1.5.1)
+  - scimath 4.0.0-1; depends (numpy ~= 1.6.0)
+  - scimath 4.0.0-2; depends (numpy ~= 1.6.1)
+  - scimath 4.0.1-1; depends (numpy ~= 1.6.1)
+  - scimath 4.1.0-1; depends (numpy ~= 1.6.1)
+  - scimath 4.1.2-1; depends (numpy ~= 1.6.1)
+  - scimath 4.1.2-2; depends (numpy ~= 1.7.1)
+  - scimath 4.1.2-3; depends (numpy ~= 1.8.0)
+  - scimath 4.1.2-4; depends (numpy ~= 1.8.1)
+  - scimath 4.1.2-5; depends (numpy ~= 1.9.2)
+  - scimath 4.1.2-6; depends (scipy ~= 0.16.0, traits ~= 4.5.0, numpy ~= 1.9.2)
+  - scimath 4.1.2-7; depends (scipy ~= 0.16.1, traits ~= 4.5.0, numpy ~= 1.9.2)
+  - scipy 0.9.0rc2-1; depends (numpy ~= 1.5.1)
+  - scipy 0.9.0-1; depends (numpy ~= 1.5.1)
+  - scipy 0.9.0-2; depends (numpy ~= 1.6.0)
+  - scipy 0.9.0-3; depends (numpy ~= 1.6.1)
+  - scipy 0.10.0-1; depends (numpy ~= 1.6.1)
+  - scipy 0.10.1-1; depends (numpy ~= 1.6.1)
+  - scipy 0.11.0-1; depends (numpy ~= 1.6.1)
+  - scipy 0.12.0-1; depends (numpy ~= 1.6.1)
+  - scipy 0.12.0-2; depends (numpy ~= 1.7.1)
+  - scipy 0.13.0-1; depends (numpy ~= 1.7.1, libgfortran ~= 3.0.0)
+  - scipy 0.13.0-2; depends (numpy ~= 1.8.0, libgfortran ~= 3.0.0)
+  - scipy 0.13.2-1; depends (numpy ~= 1.8.0, libgfortran ~= 3.0.0)
+  - scipy 0.13.3-1; depends (numpy ~= 1.8.0, libgfortran ~= 3.0.0)
+  - scipy 0.14.0-1; depends (numpy ~= 1.8.0, libgfortran ~= 3.0.0)
+  - scipy 0.14.0-2; depends (numpy ~= 1.8.0, libgfortran ~= 3.0.0)
+  - scipy 0.14.0-3; depends (numpy ~= 1.8.1, libgfortran ~= 3.0.0)
+  - scipy 0.14.1rc1-1; depends (mkl ~= 10.3, numpy ~= 1.8.1, libgfortran ~= 3.0.0)
+  - scipy 0.15.1-1; depends (mkl ~= 10.3, numpy ~= 1.8.1, libgfortran ~= 3.0.0)
+  - scipy 0.15.1-2; depends (mkl ~= 10.3, numpy ~= 1.9.2, libgfortran ~= 3.0.0)
+  - scipy 0.16.0-1; depends (mkl ~= 10.3, numpy ~= 1.9.2, libgfortran ~= 3.0.0)
+  - scipy 0.16.1-1; depends (mkl ~= 10.3, numpy ~= 1.9.2, libgfortran ~= 3.0.0)
+  - scons 2.0.1-2
+  - scons 2.3.3-1
+  - scrapy 0.24.4-2; depends (pyopenssl ~= 0.14, six ~= 1.8.0, queuelib ~= 1.2.2, w3lib ~= 1.10.0, twisted ~= 14.0.2, cssselect ~= 0.9.1, cffi ~= 0.8.6, lxml ~= 3.4.0)
+  - scrapy 0.24.4-3; depends (pyopenssl ~= 0.14, six ~= 1.8.0, queuelib ~= 1.2.2, w3lib ~= 1.10.0, twisted ~= 14.0.2, cssselect ~= 0.9.1, lxml ~= 3.4.1, cffi ~= 0.8.6)
+  - scrapy 0.24.4-4; depends (pyopenssl ~= 0.14, queuelib ~= 1.2.2, w3lib ~= 1.10.0, twisted ~= 14.0.2, cssselect ~= 0.9.1, lxml ~= 3.4.1, six ~= 1.9.0, cffi ~= 0.8.6)
+  - scrapy 0.24.4-5; depends (pyopenssl ~= 0.14, queuelib ~= 1.2.2, lxml ~= 3.4.2, twisted ~= 15.0.0, w3lib ~= 1.10.0, cssselect ~= 0.9.1, six ~= 1.9.0, cffi ~= 0.8.6)
+  - scrapy 0.24.4-6; depends (pyopenssl ~= 0.14, queuelib ~= 1.2.2, lxml ~= 3.4.2, twisted ~= 15.0.0, w3lib ~= 1.10.0, cssselect ~= 0.9.1, six ~= 1.9.0, cffi ~= 0.9.2)
+  - scrapy 0.24.4-7; depends (pyopenssl ~= 0.14, queuelib ~= 1.2.2, lxml ~= 3.4.2, w3lib ~= 1.10.0, cssselect ~= 0.9.1, six ~= 1.9.0, twisted ~= 15.1.0, cffi ~= 0.9.2)
+  - scrapy 0.24.4-8; depends (queuelib ~= 1.2.2, lxml ~= 3.4.3, w3lib ~= 1.10.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, six ~= 1.9.0, twisted ~= 15.1.0, cffi ~= 0.9.2)
+  - scrapy 0.24.4-9; depends (queuelib ~= 1.2.2, w3lib ~= 1.10.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, six ~= 1.9.0, twisted ~= 15.1.0, lxml ~= 3.4.4, cffi ~= 0.9.2)
+  - scrapy 0.24.4-10; depends (queuelib ~= 1.2.2, w3lib ~= 1.10.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, twisted ~= 15.2.1, six ~= 1.9.0, lxml ~= 3.4.4, cffi ~= 0.9.2)
+  - scrapy 0.24.4-11; depends (queuelib ~= 1.2.2, w3lib ~= 1.10.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, twisted ~= 15.2.1, cffi ~= 1.0.3, six ~= 1.9.0, lxml ~= 3.4.4)
+  - scrapy 0.24.4-12; depends (queuelib ~= 1.2.2, w3lib ~= 1.10.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, twisted ~= 15.2.1, six ~= 1.9.0, cffi ~= 1.1.2, lxml ~= 3.4.4)
+  - scrapy 1.0.3-1; depends (twisted ~= 15.4.0, queuelib ~= 1.2.2, w3lib ~= 1.10.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, six ~= 1.9.0, cffi ~= 1.1.2, lxml ~= 3.4.4)
+  - scrapy 1.0.3-2; depends (twisted ~= 15.4.0, queuelib ~= 1.2.2, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, w3lib ~= 1.12.0, six ~= 1.9.0, cffi ~= 1.1.2, lxml ~= 3.4.4)
+  - scrapy 1.0.3-3; depends (twisted ~= 15.4.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, queuelib ~= 1.4.2, w3lib ~= 1.12.0, six ~= 1.9.0, cffi ~= 1.1.2, lxml ~= 3.4.4)
+  - scrapy 1.0.3-4; depends (twisted ~= 15.4.0, cffi ~= 1.2.1, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, queuelib ~= 1.4.2, w3lib ~= 1.12.0, six ~= 1.9.0, lxml ~= 3.4.4)
+  - scrapy 1.0.3-5; depends (twisted ~= 15.4.0, six ~= 1.10.0, cffi ~= 1.2.1, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, queuelib ~= 1.4.2, w3lib ~= 1.12.0, lxml ~= 3.4.4)
+  - scrapy 1.0.3-6; depends (twisted ~= 15.4.0, six ~= 1.10.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, queuelib ~= 1.4.2, w3lib ~= 1.12.0, lxml ~= 3.4.4, cffi ~= 1.3.1)
+  - scrapy 1.0.3-7; depends (six ~= 1.10.0, pyopenssl ~= 0.15.1, cssselect ~= 0.9.1, queuelib ~= 1.4.2, w3lib ~= 1.12.0, lxml ~= 3.4.4, cffi ~= 1.3.1, twisted ~= 15.5.0)
+  - seaborn 0.4.0-1; depends (matplotlib ~= 1.4.2, numpy ~= 1.8.1, pandas ~= 0.15.0, scipy ~= 0.14.0)
+  - seaborn 0.5.0-1; depends (matplotlib ~= 1.4.2, numpy ~= 1.8.1, pandas ~= 0.15.0, scipy ~= 0.14.0)
+  - seaborn 0.5.0-3; depends (matplotlib ~= 1.4.2, pandas ~= 0.15.2, numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - seaborn 0.5.1-1; depends (matplotlib ~= 1.4.2, pandas ~= 0.15.2, numpy ~= 1.8.1, scipy ~= 0.14.0)
+  - seaborn 0.5.1-2; depends (matplotlib ~= 1.4.2, pandas ~= 0.15.2, numpy ~= 1.8.1, scipy ~= 0.14.1rc1)
+  - seaborn 0.5.1-3; depends (matplotlib ~= 1.4.2, pandas ~= 0.15.2, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - seaborn 0.5.1-4; depends (matplotlib ~= 1.4.3, numpy ~= 1.8.1, pandas ~= 0.15.2, scipy ~= 0.15.1)
+  - seaborn 0.5.1-5; depends (pandas ~= 0.16.0, matplotlib ~= 1.4.3, numpy ~= 1.8.1, scipy ~= 0.15.1)
+  - seaborn 0.5.1-7; depends (pandas ~= 0.16.0, matplotlib ~= 1.4.3, numpy ~= 1.9.2, scipy ~= 0.15.1)
+  - seaborn 0.5.1-8; depends (matplotlib ~= 1.4.3, numpy ~= 1.9.2, pandas ~= 0.16.1, scipy ~= 0.15.1)
+  - seaborn 0.5.1-9; depends (scipy ~= 0.15.1, matplotlib ~= 1.4.3, numpy ~= 1.9.2, pandas ~= 0.16.2)
+  - seaborn 0.6.0-1; depends (scipy ~= 0.15.1, matplotlib ~= 1.4.3, numpy ~= 1.9.2, pandas ~= 0.16.2)
+  - seaborn 0.6.0-2; depends (scipy ~= 0.16.0, matplotlib ~= 1.4.3, numpy ~= 1.9.2, pandas ~= 0.16.2)
+  - seaborn 0.6.0-4; depends (scipy ~= 0.16.1, matplotlib ~= 1.4.3, numpy ~= 1.9.2, pandas ~= 0.17.1)
+  - seaborn 0.6.0-5; depends (matplotlib ~= 1.5.0, scipy ~= 0.16.1, numpy ~= 1.9.2, pandas ~= 0.17.1)
+  - selenium 2.48.0-1
+  - setuptools 14.3.1-1; depends (_distribute_remove ~= 1.0.0)
+  - setuptools 14.3.1-2; depends (distribute_remove ~= 1.0.0)
+  - setuptools 15.1-1; depends (distribute_remove ~= 1.0.0)
+  - setuptools 15.2-2; depends (distribute_remove ~= 1.0.0)
+  - setuptools 16.0-1; depends (distribute_remove ~= 1.0.0)
+  - setuptools 17.1.1-1; depends (distribute_remove ~= 1.0.0)
+  - setuptools 18.2-1; depends (distribute_remove ~= 1.0.0)
+  - setuptools 18.4-1; depends (distribute_remove ~= 1.0.0)
+  - setuptools 18.7.1-1; depends (distribute_remove ~= 1.0.0)
+  - setuptools 19.1.1-1; depends (distribute_remove ~= 1.0.0)
+  - sfepy 2010.2-4; depends (pyparsing ~= 2.0.2)
+  - sfepy 2014.4-1; depends (numpy ~= 1.8.1, pyparsing ~= 2.0.2, matplotlib ~= 1.4.2, pytables ~= 3.1.1, scipy ~= 0.14.1rc1, sympy ~= 0.7.6, mayavi ~= 4.3.1)
+  - sfepy 2014.4-2; depends (numpy ~= 1.8.1, scipy ~= 0.15.1, pyparsing ~= 2.0.2, matplotlib ~= 1.4.2, pytables ~= 3.1.1, sympy ~= 0.7.6, mayavi ~= 4.3.1)
+  - sfepy 2014.4-3; depends (numpy ~= 1.8.1, scipy ~= 0.15.1, pyparsing ~= 2.0.2, pytables ~= 3.1.1, sympy ~= 0.7.6, matplotlib ~= 1.4.3, mayavi ~= 4.3.1)
+  - sfepy 2014.4-4; depends (numpy ~= 1.8.1, scipy ~= 0.15.1, pytables ~= 3.1.1, sympy ~= 0.7.6, matplotlib ~= 1.4.3, mayavi ~= 4.3.1, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-5; depends (numpy ~= 1.8.1, mayavi ~= 4.4.0, scipy ~= 0.15.1, pytables ~= 3.1.1, sympy ~= 0.7.6, matplotlib ~= 1.4.3, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-6; depends (mayavi ~= 4.4.0, scipy ~= 0.15.1, pytables ~= 3.1.1, numpy ~= 1.9.2, sympy ~= 0.7.6, matplotlib ~= 1.4.3, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-7; depends (scipy ~= 0.15.1, pytables ~= 3.1.1, numpy ~= 1.9.2, mayavi ~= 4.4.2, sympy ~= 0.7.6, matplotlib ~= 1.4.3, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-8; depends (scipy ~= 0.15.1, numpy ~= 1.9.2, mayavi ~= 4.4.2, sympy ~= 0.7.6, pytables ~= 3.2.0, matplotlib ~= 1.4.3, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-9; depends (scipy ~= 0.15.1, sympy ~= 0.7.6.1, numpy ~= 1.9.2, mayavi ~= 4.4.2, pytables ~= 3.2.0, matplotlib ~= 1.4.3, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-10; depends (mayavi ~= 4.4.3, scipy ~= 0.15.1, sympy ~= 0.7.6.1, numpy ~= 1.9.2, pytables ~= 3.2.0, matplotlib ~= 1.4.3, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-11; depends (mayavi ~= 4.4.3, sympy ~= 0.7.6.1, scipy ~= 0.16.0, numpy ~= 1.9.2, pytables ~= 3.2.0, matplotlib ~= 1.4.3, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-12; depends (scipy ~= 0.16.1, mayavi ~= 4.4.3, sympy ~= 0.7.6.1, numpy ~= 1.9.2, pytables ~= 3.2.0, matplotlib ~= 1.4.3, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-13; depends (scipy ~= 0.16.1, mayavi ~= 4.4.3, sympy ~= 0.7.6.1, matplotlib ~= 1.5.0, numpy ~= 1.9.2, pytables ~= 3.2.0, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-14; depends (scipy ~= 0.16.1, mayavi ~= 4.4.3, sympy ~= 0.7.6.1, matplotlib ~= 1.5.0, numpy ~= 1.9.2, pytables ~= 3.2.0, pyparsing ~= 2.0.3)
+  - sfepy 2014.4-15; depends (scipy ~= 0.16.1, mayavi ~= 4.4.3, sympy ~= 0.7.6.1, matplotlib ~= 1.5.0, numpy ~= 1.9.2, pytables ~= 3.2.2, pyparsing ~= 2.0.3)
+  - shapely 1.2.14-1; depends (basemap ~= 1.0.2)
+  - shapely 1.2.17-1; depends (basemap ~= 1.0.6)
+  - shapely 1.2.17-2; depends (basemap ~= 1.0.7)
+  - shapely 1.3.2-1; depends (basemap ~= 1.0.7)
+  - shapely 1.4.1-1; depends (geos ~= 3.4.2)
+  - shapely 1.5.1-1; depends (geos ~= 3.4.2)
+  - shapely 1.5.13-1; depends (geos ~= 3.5.0, numpy ~= 1.9.2)
+  - shiboken 1.2.1-1; depends (libxslt ~= 1.1.26, qt ~= 4.8.5)
+  - shiboken 1.2.1-3; depends (libxslt ~= 1.1.26, qt ~= 4.8.5)
+  - shiboken 1.2.2-1; depends (libxslt ~= 1.1.26, qt ~= 4.8.5)
+  - shiboken 1.2.2-2; depends (qt ~= 4.8.5, libxslt ~= 1.1.28)
+  - shiboken 1.2.2-3; depends (qt ~= 4.8.6, libxslt ~= 1.1.28)
+  - shiboken 1.2.2-5; depends (qt ~= 4.8.6, libxslt ~= 1.1.28)
+  - shiboken_debug 1.2.2-5; depends (shiboken == 1.2.2-5)
+  - simplegeneric 0.8.1-1
+  - simpy 2.1.0-2; depends (numpy)
+  - simpy 2.2-1; depends (numpy)
+  - simpy 2.2-2; depends (numpy)
+  - simpy 2.2-3; depends (numpy)
+  - simpy 3.0.2-1
+  - simpy 3.0.5-1
+  - simpy 3.0.5-2
+  - singledispatch 3.4.0.3-1
+  - sip 4.15.3-1
+  - sip 4.16.1-1
+  - sip 4.16.7-1
+  - sip 4.17-1
+  - six 1.3.0-1
+  - six 1.4.1-1
+  - six 1.7.2-1
+  - six 1.7.3-1
+  - six 1.8.0-1
+  - six 1.8.0-2
+  - six 1.9.0-1
+  - six 1.9.0-3
+  - six 1.10.0-1
+  - smart_open 1.2.1-1; depends (boto ~= 2.38.0, bz2file ~= 0.98)
+  - smart_open 1.2.1-2; depends (boto ~= 2.38.0, bz2file ~= 0.98)
+  - smmap 0.9.0-1
+  - snowballstemmer 1.2.0-1
+  - speaklater 1.3-1
+  - speaklater 1.3-2
+  - sphinx 1.0.5-1; depends (jinja2 ~= 2.5.5, docutils ~= 0.7)
+  - sphinx 1.0.7-1; depends (jinja2 ~= 2.5.5, docutils ~= 0.7)
+  - sphinx 1.1-1; depends (jinja2 ~= 2.6, docutils ~= 0.8.1)
+  - sphinx 1.1.2-1; depends (jinja2 ~= 2.6, docutils ~= 0.8.1)
+  - sphinx 1.1.2-3; depends (docutils ~= 0.11, jinja2 ~= 2.7.1)
+  - sphinx 1.1.3-1; depends (docutils ~= 0.11, jinja2 ~= 2.7.1)
+  - sphinx 1.2.2-1; depends (docutils ~= 0.11, jinja2 ~= 2.7.1)
+  - sphinx 1.2.2-2; depends (docutils ~= 0.11, jinja2 ~= 2.7.3)
+  - sphinx 1.2.2-3; depends (jinja2 ~= 2.7.3, docutils ~= 0.12)
+  - sphinx 1.2.3-1; depends (jinja2 ~= 2.7.3, docutils ~= 0.12)
+  - sphinx 1.3.1-1; depends (jinja2 ~= 2.7.3, docutils ~= 0.12)
+  - sphinx 1.3.1-2; depends (alabaster ~= 0.7.3, pygments ~= 2.0.2, docutils ~= 0.12, babel ~= 1.3, snowballstemmer ~= 1.2.0, jinja2 ~= 2.7.3, six ~= 1.9.0)
+  - sphinx 1.3.1-3; depends (alabaster ~= 0.7.3, pygments ~= 2.0.2, docutils ~= 0.12, babel ~= 1.3, snowballstemmer ~= 1.2.0, jinja2 ~= 2.7.3, six ~= 1.9.0, sphinx_rtd_theme ~= 0.1.7)
+  - sphinx 1.3.1-4; depends (alabaster ~= 0.7.6, babel ~= 2.1.1, pygments ~= 2.0.2, jinja2 ~= 2.8, docutils ~= 0.12, snowballstemmer ~= 1.2.0, six ~= 1.9.0, sphinx_rtd_theme ~= 0.1.7)
+  - sphinx 1.3.1-5; depends (alabaster ~= 0.7.6, babel ~= 2.1.1, six ~= 1.10.0, pygments ~= 2.0.2, jinja2 ~= 2.8, docutils ~= 0.12, snowballstemmer ~= 1.2.0, sphinx_rtd_theme ~= 0.1.7)
+  - sphinx_rtd_theme 0.1.7-1
+  - spyder 2.3.5.2-1; depends (pyqt ~= 4.11.3, ipython ~= 3.2.0, pyflakes ~= 0.9.2, jedi ~= 0.9.0, pygments ~= 2.0.2)
+  - spyder 2.3.5.2-2; depends (pyqt ~= 4.11.3, pyflakes ~= 0.9.2, ipython ~= 3.2.1, jedi ~= 0.9.0, pygments ~= 2.0.2)
+  - spyder 2.3.6-1; depends (pyqt ~= 4.11.3, pyflakes ~= 0.9.2, ipython ~= 3.2.1, jedi ~= 0.9.0, pygments ~= 2.0.2)
+  - spyder 2.3.6-2; depends (pyqt ~= 4.11.3, ipython ~= 4.0.0, pyflakes ~= 0.9.2, jedi ~= 0.9.0, pygments ~= 2.0.2)
+  - spyder 2.3.6-3; depends (pyflakes ~= 1.0.0, pyqt ~= 4.11.3, ipython ~= 4.0.0, jedi ~= 0.9.0, pygments ~= 2.0.2)
+  - spyder 2.3.7-1; depends (pyflakes ~= 1.0.0, pyqt ~= 4.11.3, ipython ~= 4.0.0, jedi ~= 0.9.0, pygments ~= 2.0.2)
+  - spyder 2.3.8-1; depends (pyflakes ~= 1.0.0, pyqt ~= 4.11.3, ipython ~= 4.0.0, jedi ~= 0.9.0, pygments ~= 2.0.2)
+  - spyder 2.3.8-2; depends (pyflakes ~= 1.0.0, ipython ~= 4.0.0, jedi ~= 0.9.0, pygments ~= 2.0.2, pyqt ~= 4.11.4)
+  - sqlalchemy 0.6.5-1
+  - sqlalchemy 0.6.6-1
+  - sqlalchemy 0.7.0-1
+  - sqlalchemy 0.7.1-1
+  - sqlalchemy 0.7.4-1
+  - sqlalchemy 0.7.5-1
+  - sqlalchemy 0.7.6-1
+  - sqlalchemy 0.8.2-1
+  - sqlalchemy 0.8.3-1
+  - sqlalchemy 0.9.4-1
+  - sqlalchemy 0.9.7-1
+  - sqlalchemy 0.9.8-1
+  - sqlalchemy 0.9.9-1
+  - sqlalchemy 1.0.0-1
+  - sqlalchemy 1.0.1-1
+  - sqlalchemy 1.0.4-1
+  - sqlalchemy 1.0.6-1
+  - sqlalchemy 1.0.6-2
+  - sqlalchemy 1.0.8-1
+  - sqlalchemy 1.0.8-2
+  - sqlalchemy 1.0.10-1
+  - sqlparse 0.1.8-1
+  - sqlparse 0.1.11-1
+  - sqlparse 0.1.12-1
+  - sqlparse 0.1.14-1
+  - sqlparse 0.1.15-1
+  - sqlparse 0.1.16-1
+  - sqlparse 0.1.16-2
+  - sqlparse 0.1.18-1
+  - ssl_match_hostname 3.4.0.2-1
+  - statsmodels 0.4.0-1; depends (scipy)
+  - statsmodels 0.4.3-1; depends (scipy)
+  - statsmodels 0.4.3-2; depends (scipy)
+  - statsmodels 0.4.3-3; depends (pandas ~= 0.12.0, scipy)
+  - statsmodels 0.5.0-1; depends (pandas ~= 0.12.0, patsy ~= 0.2.0, scipy)
+  - statsmodels 0.5.0-2; depends (scipy ~= 0.13.0, pandas ~= 0.12.0, patsy ~= 0.2.0)
+  - statsmodels 0.5.0-4; depends (pandas ~= 0.12.0, patsy ~= 0.2.0, scipy ~= 0.13.2)
+  - statsmodels 0.5.0-5; depends (patsy ~= 0.2.0, scipy ~= 0.13.2, pandas ~= 0.13.1)
+  - statsmodels 0.5.0-6; depends (patsy ~= 0.2.0, scipy ~= 0.13.3, pandas ~= 0.13.1)
+  - statsmodels 0.5.0-7; depends (scipy ~= 0.14.0, patsy ~= 0.2.0, pandas ~= 0.13.1)
+  - statsmodels 0.5.0-8; depends (pandas ~= 0.14.0, patsy ~= 0.2.0, scipy ~= 0.14.0)
+  - statsmodels 0.5.0-10; depends (patsy ~= 0.2.0, pandas ~= 0.14.1, scipy ~= 0.14.0)
+  - statsmodels 0.5.0-11; depends (patsy ~= 0.3.0, pandas ~= 0.14.1, scipy ~= 0.14.0)
+  - statsmodels 0.6.0rc1-1; depends (patsy ~= 0.3.0, pandas ~= 0.15.0, scipy ~= 0.14.0)
+  - statsmodels 0.6.0-1; depends (patsy ~= 0.3.0, pandas ~= 0.15.0, scipy ~= 0.14.0)
+  - statsmodels 0.6.0-2; depends (patsy ~= 0.3.0, pandas ~= 0.15.1, scipy ~= 0.14.0)
+  - statsmodels 0.6.1-1; depends (patsy ~= 0.3.0, pandas ~= 0.15.1, scipy ~= 0.14.0)
+  - statsmodels 0.6.1-2; depends (patsy ~= 0.3.0, pandas ~= 0.15.2, scipy ~= 0.14.0)
+  - statsmodels 0.6.1-3; depends (patsy ~= 0.3.0, pandas ~= 0.15.2, scipy ~= 0.14.1rc1)
+  - statsmodels 0.6.1-4; depends (patsy ~= 0.3.0, pandas ~= 0.15.2, scipy ~= 0.15.1)
+  - statsmodels 0.6.1-5; depends (pandas ~= 0.16.0, patsy ~= 0.3.0, scipy ~= 0.15.1)
+  - statsmodels 0.6.1-6; depends (patsy ~= 0.3.0, pandas ~= 0.16.1, scipy ~= 0.15.1)
+  - statsmodels 0.6.1-7; depends (patsy ~= 0.3.0, scipy ~= 0.15.1, pandas ~= 0.16.2)
+  - statsmodels 0.6.1-8; depends (scipy ~= 0.15.1, patsy ~= 0.4.0, pandas ~= 0.16.2)
+  - statsmodels 0.6.1-9; depends (scipy ~= 0.16.0, patsy ~= 0.4.0, pandas ~= 0.16.2)
+  - statsmodels 0.6.1-11; depends (scipy ~= 0.16.1, patsy ~= 0.4.0, pandas ~= 0.17.1)
+  - statsmodels 0.6.1-12; depends (scipy ~= 0.16.1, patsy ~= 0.4.0, pandas ~= 0.17.1)
+  - stevedore 1.1.0-1
+  - stevedore 1.2.0-1
+  - stevedore 1.2.0-2; depends (distribute ~= 0.6.49)
+  - stevedore 1.2.0-3; depends (setuptools ~= 14.3.1)
+  - stevedore 1.2.0-4; depends (setuptools ~= 15.1)
+  - stevedore 1.2.0-5; depends (setuptools ~= 15.2)
+  - stevedore 1.2.0-6; depends (setuptools ~= 16.0)
+  - stevedore 1.2.0-7; depends (setuptools ~= 17.1.1)
+  - stevedore 1.2.0-8; depends (setuptools ~= 17.1.1)
+  - stevedore 1.2.0-9; depends (setuptools ~= 18.2)
+  - stevedore 1.2.0-10; depends (setuptools ~= 18.2)
+  - stevedore 1.2.0-11; depends (setuptools ~= 18.4)
+  - stevedore 1.2.0-12; depends (setuptools ~= 18.7.1)
+  - stevedore 1.2.0-13; depends (setuptools ~= 19.1.1)
+  - supervisor 3.0-1; depends (meld3 ~= 0.6.10)
+  - supervisor 3.1.2-1; depends (meld3 ~= 1.0.0)
+  - supervisor 3.1.2-2; depends (meld3 ~= 1.0.0)
+  - swig 1.3.36-3
+  - swig 1.3.39-1
+  - swig 1.3.40-1
+  - swig 1.3.40-2
+  - swig 2.0.12-1
+  - swig 3.0.2-1
+  - sympy 0.6.7-2; depends (pyglet)
+  - sympy 0.7.0-1; depends (pyglet)
+  - sympy 0.7.1-1; depends (pyglet)
+  - sympy 0.7.2-1; depends (pyglet)
+  - sympy 0.7.3-1; depends (pyglet)
+  - sympy 0.7.5-1; depends (pyglet)
+  - sympy 0.7.6-1; depends (pyglet)
+  - sympy 0.7.6.1-1; depends (pyglet)
+  - tabulate 0.7.3-1
+  - tempita 0.5.1-2
+  - terminado 0.5-1; depends (ptyprocess ~= 0.4, tornado ~= 4.1)
+  - terminado 0.5-2; depends (tornado ~= 4.2, ptyprocess ~= 0.4)
+  - terminado 0.5-3; depends (tornado ~= 4.2.1, ptyprocess ~= 0.4)
+  - terminado 0.5-4; depends (tornado ~= 4.3, ptyprocess ~= 0.4)
+  - testpath 0.2-1
+  - toolz 0.7.0-1
+  - toolz 0.7.1-1
+  - toolz 0.7.2-1
+  - toolz 0.7.4-1
+  - tornado 2.1-1
+  - tornado 2.1.1-1
+  - tornado 2.2-1
+  - tornado 3.1.1-1
+  - tornado 3.2.2-1; depends (ssl_match_hostname ~= 3.4.0.2)
+  - tornado 4.0.1-1; depends (ssl_match_hostname ~= 3.4.0.2)
+  - tornado 4.0.2-1; depends (ssl_match_hostname ~= 3.4.0.2)
+  - tornado 4.0.2-2; depends (ssl_match_hostname ~= 3.4.0.2)
+  - tornado 4.1-1; depends (ssl_match_hostname ~= 3.4.0.2)
+  - tornado 4.2-1; depends (certifi ~= 14.05.14, ssl_match_hostname ~= 3.4.0.2)
+  - tornado 4.2.1-1; depends (certifi ~= 14.05.14, ssl_match_hostname ~= 3.4.0.2)
+  - tornado 4.3-1; depends (singledispatch ~= 3.4.0.3, backports_abc ~= 0.4, ssl_match_hostname ~= 3.4.0.2, certifi ~= 2015.11.20.1)
+  - traceback2 1.4.0-1; depends (linecache2 ~= 1.0.0)
+  - traitlets 4.0.0-1; depends (decorator ~= 4.0.2, ipython_genutils ~= 0.1.0)
+  - traitlets 4.0.0-2; depends (decorator ~= 4.0.4, ipython_genutils ~= 0.1.0)
+  - traits 3.6.0-1; depends (numpy ~= 1.5.1)
+  - traits 4.0.0-1; depends (numpy ~= 1.6.0)
+  - traits 4.0.0-2; depends (numpy ~= 1.6.1)
+  - traits 4.1.0-1; depends (numpy ~= 1.6.1)
+  - traits 4.2.0-1; depends (numpy ~= 1.6.1)
+  - traits 4.3.0-1; depends (numpy ~= 1.6.1)
+  - traits 4.3.0-2; depends (numpy ~= 1.7.1)
+  - traits 4.3.0-3; depends (numpy ~= 1.8.0)
+  - traits 4.4.0-1; depends (numpy ~= 1.8.0)
+  - traits 4.4.0-2
+  - traits 4.5.0-1
+  - traits_enaml 0.2.0-1; depends (enaml ~= 0.8.9, traitsui ~= 4.4.0)
+  - traits_enaml 0.2.1-1; depends (enaml ~= 0.9.4, traitsui ~= 4.4.0)
+  - traits_enaml 0.2.1-2; depends (enaml ~= 0.9.5, traitsui ~= 4.4.0)
+  - traits_enaml 0.2.1-3; depends (enaml ~= 0.9.5, traitsui ~= 4.4.0)
+  - traits_enaml 0.2.1-4; depends (enaml ~= 0.9.8, traitsui ~= 4.4.0)
+  - traits_enaml 0.2.1-5; depends (enaml ~= 0.9.8, traitsui ~= 4.4.0)
+  - traits_enaml 0.2.1-6; depends (enaml ~= 0.9.8, traitsui ~= 4.4.0)
+  - traits_enaml 0.2.1-7; depends (enaml ~= 0.9.8, traitsui ~= 4.4.0)
+  - traits_enaml 0.2.1-8; depends (enaml ~= 0.9.8, traitsui ~= 4.5.1)
+  - traits_enaml 0.2.1-9; depends (enaml ~= 0.9.8, traitsui ~= 4.5.1)
+  - traits_enaml 0.2.1-10; depends (enaml ~= 0.9.8, traitsui ~= 4.5.1)
+  - traits_enaml 0.2.1-11; depends (enaml ~= 0.9.8, traitsui ~= 4.5.1)
+  - traits_enaml 0.2.1-12; depends (enaml ~= 0.9.8, traitsui ~= 5.0.0)
+  - traits_enaml 0.2.1-13; depends (enaml ~= 0.9.8, traitsui ~= 5.0.0)
+  - traits_enaml 0.2.1-14; depends (enaml ~= 0.9.8, traitsui ~= 5.0.0)
+  - traitsbackendqt 3.6.0-1
+  - traitsbackendwx 3.6.0-1; depends (traits ~= 3.6.0, wxpython ~= 2.8.10.1)
+  - traitsgui 3.6.0-1
+  - traitsui 4.0.0-1
+  - traitsui 4.1.0-1
+  - traitsui 4.2.0-1
+  - traitsui 4.3.0-1
+  - traitsui 4.3.0-2; depends (traits ~= 4.3.0, pyface ~= 4.3.0)
+  - traitsui 4.4.0-1; depends (traits ~= 4.4.0, pyface ~= 4.4.0)
+  - traitsui 4.4.0-2; depends (traits ~= 4.5.0, pyface ~= 4.4.0)
+  - traitsui 4.4.0-3; depends (pyface ~= 4.5.0, traits ~= 4.5.0)
+  - traitsui 4.5.1-1; depends (pyface ~= 4.5.0, traits ~= 4.5.0)
+  - traitsui 4.5.1-2; depends (traits ~= 4.5.0, pyface ~= 4.5.2)
+  - traitsui 5.0.0-1; depends (pyface ~= 5.0.0, traits ~= 4.5.0)
+  - twisted 10.2.0-1; depends (pyopenssl ~= 0.11, zope.interface ~= 3.6.1)
+  - twisted 11.0.0-1; depends (pyopenssl ~= 0.11, zope.interface ~= 3.6.1)
+  - twisted 11.0.0-2; depends (pyopenssl ~= 0.12, zope.interface ~= 3.6.3)
+  - twisted 11.1.0-2; depends (pyopenssl ~= 0.12, zope.interface ~= 3.8.0)
+  - twisted 12.0.0-1; depends (pyopenssl ~= 0.12, zope.interface ~= 3.8.0)
+  - twisted 12.0.0-3; depends (pyopenssl ~= 0.13.1, zope.interface ~= 3.8.0)
+  - twisted 14.0.0-1; depends (pyopenssl ~= 0.13.1, zope.interface ~= 4.1.1)
+  - twisted 14.0.2-1; depends (pyopenssl ~= 0.13.1, zope.interface ~= 4.1.1)
+  - twisted 14.0.2-3; depends (pyopenssl ~= 0.14, zope.interface ~= 4.1.1)
+  - twisted 14.0.2-4; depends (pyopenssl ~= 0.14, zope.interface ~= 4.1.2)
+  - twisted 15.0.0-1; depends (pyopenssl ~= 0.14, zope.interface ~= 4.1.2)
+  - twisted 15.1.0-1; depends (pyopenssl ~= 0.14, zope.interface ~= 4.1.2)
+  - twisted 15.1.0-2; depends (zope.interface ~= 4.1.2, pyopenssl ~= 0.15.1)
+  - twisted 15.2.1-1; depends (zope.interface ~= 4.1.2, pyopenssl ~= 0.15.1)
+  - twisted 15.4.0-1; depends (zope.interface ~= 4.1.2, pyopenssl ~= 0.15.1)
+  - twisted 15.4.0-2; depends (zope.interface ~= 4.1.3, pyopenssl ~= 0.15.1)
+  - twisted 15.5.0-1; depends (zope.interface ~= 4.1.3, pyopenssl ~= 0.15.1)
+  - ujson 1.33.0-1
+  - ujson 1.33.0-2
+  - unittest2 0.8.0-1
+  - unittest2 1.1.0-1; depends (traceback2 ~= 1.4.0)
+  - unixodbc 2.3.0-1
+  - unixodbc 2.3.2-1
+  - unixodbc 2.3.2-2
+  - venusian 1.0-1
+  - vtk 5.6.0-2
+  - vtk 5.6.0-6
+  - vtk 5.10.1-1
+  - vtk 5.10.1-2
+  - vtk 5.10.1-3
+  - vtk 6.2.0-1
+  - vtk 6.3.0-1
+  - vtk 6.3.0-3
+  - w3lib 1.10.0-1; depends (six ~= 1.8.0)
+  - w3lib 1.10.0-2; depends (six ~= 1.9.0)
+  - w3lib 1.12.0-1; depends (six ~= 1.9.0)
+  - w3lib 1.12.0-2; depends (six ~= 1.10.0)
+  - werkzeug 0.9.4-1
+  - werkzeug 0.9.6-1
+  - werkzeug 0.10.1-1
+  - werkzeug 0.10.4-1
+  - werkzeug 0.10.4-2
+  - werkzeug 0.11.2-1
+  - whoosh 1.6.2-1
+  - whoosh 2.5.6-1
+  - whoosh 2.5.7-1
+  - whoosh 2.7.0-1
+  - whooshdoc 1.0-6; depends (epydoc ~= 3.0.1, whoosh ~= 1.6.2, epdindex ~= 1.2, pyparsing ~= 1.5.5)
+  - whooshdoc 1.0-7
+  - wtforms 2.0.2-1
+  - wxpython 2.8.10.1-2
+  - wxpython 2.8.10.1-3
+  - wxpython 2.8.10.1-7
+  - wxpython 3.0.2.0-1; depends (gstreamer ~= 0.10.36, gst_plugins_base ~= 0.10.36)
+  - x13as 1.1.19-1
+  - xlrd 0.7.1-3
+  - xlrd 0.7.1-4
+  - xlrd 0.7.2-1
+  - xlrd 0.7.3-1
+  - xlrd 0.7.6-1
+  - xlrd 0.7.9-1
+  - xlrd 0.9.2-1
+  - xlrd 0.9.3-1
+  - xlrd 0.9.4-1
+  - xlsxwriter 0.5.5-1
+  - xlsxwriter 0.5.7-1
+  - xlsxwriter 0.6.4-1
+  - xlsxwriter 0.6.5-1
+  - xlsxwriter 0.6.6-1
+  - xlsxwriter 0.6.7-1
+  - xlsxwriter 0.7.2-1
+  - xlsxwriter 0.7.3-1
+  - xlsxwriter 0.7.6-1
+  - xlsxwriter 0.7.7-1
+  - xlutils 1.7.1-1; depends (xlwt ~= 0.7.5, xlrd ~= 0.9.3)
+  - xlutils 1.7.1-2; depends (xlrd ~= 0.9.3, xlwt ~= 1.0.0)
+  - xlutils 1.7.1-3; depends (xlrd ~= 0.9.4, xlwt ~= 1.0.0)
+  - xlwings 0.2.3-2; depends (pandas ~= 0.15.1, numpy ~= 1.8.1)
+  - xlwt 0.7.2-3
+  - xlwt 0.7.3-1
+  - xlwt 0.7.4-1
+  - xlwt 0.7.5-1
+  - xlwt 1.0.0-1
+  - xmltodict 0.9.2-1
+  - xray 0.6.1-1; depends (numpy ~= 1.9.2, pandas ~= 0.17.1)
+  - xz 5.2.2-1
+  - zeromq 2.0.7-1
+  - zeromq 2.0.8-1
+  - zeromq 2.0.10-1
+  - zeromq 2.1.1-1
+  - zeromq 2.1.4-1
+  - zeromq 2.1.7-1
+  - zeromq 2.1.9-1
+  - zeromq 2.1.10-1
+  - zeromq 2.1.11-1
+  - zeromq 3.2.0-1
+  - zeromq 3.2.4-1
+  - zeromq 4.0.4-1
+  - zeromq 4.0.5-1
+  - zeromq 4.1.3-1; depends (libsodium ~= 1.0.3)
+  - zipfile2 0.0.6-1
+  - zipfile2 0.0.7-1
+  - zipfile2 0.0.8-2
+  - zipfile2 0.0.11-1
+  - zipline 0.7.0-1; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.15.1, patsy ~= 0.3.0, pandas ~= 0.15.2, requests ~= 2.5.3)
+  - zipline 0.7.0-2; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.15.1, patsy ~= 0.3.0, pandas ~= 0.15.2, requests ~= 2.6.0)
+  - zipline 0.7.0-3; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.15.1, pandas ~= 0.16.0, patsy ~= 0.3.0, requests ~= 2.6.0)
+  - zipline 0.7.0-4; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.15.1, pandas ~= 0.16.0, patsy ~= 0.3.0, requests ~= 2.6.2)
+  - zipline 0.7.0-5; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.15.1, pandas ~= 0.16.0, patsy ~= 0.3.0, requests ~= 2.7.0)
+  - zipline 0.7.0-6; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.15.1, patsy ~= 0.3.0, requests ~= 2.7.0, pandas ~= 0.16.1)
+  - zipline 0.7.0-7; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.15.1, patsy ~= 0.3.0, requests ~= 2.7.0, pandas ~= 0.16.2)
+  - zipline 0.7.0-8; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.15.1, requests ~= 2.7.0, patsy ~= 0.4.0, pandas ~= 0.16.2)
+  - zipline 0.7.0-9; depends (statsmodels ~= 0.6.1, logbook ~= 0.9.0, scipy ~= 0.16.0, requests ~= 2.7.0, patsy ~= 0.4.0, pandas ~= 0.16.2)
+  - zipline 0.7.0-10; depends (statsmodels ~= 0.6.1, requests ~= 2.8.0, logbook ~= 0.9.0, scipy ~= 0.16.0, patsy ~= 0.4.0, pandas ~= 0.16.2)
+  - zipline 0.7.0-11; depends (statsmodels ~= 0.6.1, requests ~= 2.8.0, logbook ~= 0.9.0, scipy ~= 0.16.0, patsy ~= 0.4.0, pandas ~= 0.16.2)
+  - zipline 0.7.0-12; depends (statsmodels ~= 0.6.1, requests ~= 2.8.0, logbook ~= 0.9.0, scipy ~= 0.16.0, patsy ~= 0.4.0, pandas ~= 0.16.2)
+  - zipline 0.7.0-14; depends (statsmodels ~= 0.6.1, requests ~= 2.8.0, scipy ~= 0.16.1, logbook ~= 0.9.0, patsy ~= 0.4.0, pandas ~= 0.17.1)
+  - zipline 0.7.0-15; depends (statsmodels ~= 0.6.1, scipy ~= 0.16.1, logbook ~= 0.9.0, requests ~= 2.9.0, patsy ~= 0.4.0, pandas ~= 0.17.1)
+  - zlib 1.2.6-1
+  - zope.deprecation 4.1.1-1
+  - zope.deprecation 4.1.2-1
+  - zope.deprecation 4.1.2-2
+  - zope.deprecation 4.1.2-3
+  - zope.deprecation 4.1.2-4
+  - zope.deprecation 4.1.2-5
+  - zope.deprecation 4.1.2-6
+  - zope.deprecation 4.1.2-7
+  - zope.deprecation 4.1.2-8
+  - zope.deprecation 4.1.2-9
+  - zope.deprecation 4.1.2-10
+  - zope.interface 3.6.1-2
+  - zope.interface 3.6.3-1
+  - zope.interface 3.8.0-1
+  - zope.interface 4.1.1-1
+  - zope.interface 4.1.2-1
+  - zope.interface 4.1.2-2; depends (setuptools ~= 14.3.1)
+  - zope.interface 4.1.2-3; depends (setuptools ~= 15.1)
+  - zope.interface 4.1.2-4; depends (setuptools ~= 15.2)
+  - zope.interface 4.1.2-5; depends (setuptools ~= 16.0)
+  - zope.interface 4.1.2-6; depends (setuptools ~= 17.1.1)
+  - zope.interface 4.1.2-7; depends (setuptools ~= 18.2)
+  - zope.interface 4.1.3-1; depends (setuptools ~= 18.2)
+  - zope.interface 4.1.3-2; depends (setuptools ~= 18.4)
+  - zope.interface 4.1.3-3; depends (setuptools ~= 18.7.1)
+  - zope.interface 4.1.3-4; depends (setuptools ~= 19.1.1)
+
+installed:
+  - geos 3.5.0-1
+  - libgfortran 3.0.0-2
+  - mkl 10.3-2
+  - numpy 1.9.2-2
+  - shapely 1.5.13-1
+
+marked:
+  - shapely
+
+request:
+  - operation: "update_all"
+
+transaction: []


### PR DESCRIPTION
Without this check we get stuck in infinite `update-all` loops.

It would probably be nice to refactor this somehow and remove the redundancy, but since the rule generation is currently independent from policy initialization, it won't be a superficial change.