### PR TITLE
BUG: AssignmentSet may not have seen a package_id

### DIFF
--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -190,7 +190,7 @@ class UndeterminedClausePolicy(IPolicy):
                     assignments
                 )
 
-        assert assignments.get(candidate_id) is None, \
+        assert assignments.value(candidate_id) is None, \
             "Trying to assign to a variable which is already assigned."
 
         if not self.prefer_installed:
@@ -203,7 +203,7 @@ class UndeterminedClausePolicy(IPolicy):
     def _without_assigned(self, package_ids, assignments):
         return set(
             pkg_id for pkg_id in package_ids
-            if assignments.get(pkg_id) is None
+            if assignments.value(pkg_id) is None
         )
 
     def _best_candidate(self, package_ids, assignments):

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -190,7 +190,7 @@ class UndeterminedClausePolicy(IPolicy):
                     assignments
                 )
 
-        assert assignments[candidate_id] is None, \
+        assert assignments.get(candidate_id) is None, \
             "Trying to assign to a variable which is already assigned."
 
         if not self.prefer_installed:
@@ -203,7 +203,7 @@ class UndeterminedClausePolicy(IPolicy):
     def _without_assigned(self, package_ids, assignments):
         return set(
             pkg_id for pkg_id in package_ids
-            if assignments[pkg_id] is None
+            if assignments.get(pkg_id) is None
         )
 
     def _best_candidate(self, package_ids, assignments):

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -264,7 +264,6 @@ class UndeterminedClausePolicy(IPolicy):
             return None
 
 
-
 def LoggedUndeterminedClausePolicy(pool, installed_repository,
                                    *args, **kwargs):
     policy = UndeterminedClausePolicy(

--- a/simplesat/sat/policy.py
+++ b/simplesat/sat/policy.py
@@ -190,7 +190,7 @@ class UndeterminedClausePolicy(IPolicy):
                     assignments
                 )
 
-        assert assignments.value(candidate_id) is None, \
+        assert assignments.get(candidate_id) is None, \
             "Trying to assign to a variable which is already assigned."
 
         if not self.prefer_installed:
@@ -203,7 +203,7 @@ class UndeterminedClausePolicy(IPolicy):
     def _without_assigned(self, package_ids, assignments):
         return set(
             pkg_id for pkg_id in package_ids
-            if assignments.value(pkg_id) is None
+            if assignments.get(pkg_id) is None
         )
 
     def _best_candidate(self, package_ids, assignments):

--- a/simplesat/sat/tests/test_assignment_set.py
+++ b/simplesat/sat/tests/test_assignment_set.py
@@ -122,6 +122,25 @@ class TestAssignmentSet(unittest.TestCase):
         self.assertIs(AS.value(3), None)
         self.assertIs(AS.value(-3), None)
 
+    def test_getitem(self):
+        AS = AssignmentSet()
+
+        AS[1] = False
+        AS[2] = True
+        AS[3] = None
+
+        self.assertFalse(AS[1])
+        self.assertTrue(AS[2])
+        self.assertIs(AS[3], None)
+
+        with self.assertRaises(KeyError):
+            AS[4]
+
+        self.assertFalse(AS.get(1))
+        self.assertTrue(AS.get(2))
+        self.assertIs(AS.get(3), None)
+        self.assertIs(AS.get(4), None)
+
     def test_changelog(self):
 
         AS = AssignmentSet()


### PR DESCRIPTION
The package_ids we consider come from the Clause literals,
but we look them up in the AssignmentSet. If the
AssignmentSet has never seen that particular id before, it
crashes. This fixes that.