### PR TITLE
ENH: don't wrap long lines in yaml output

### DIFF
--- a/scripts/index_to_yaml.py
+++ b/scripts/index_to_yaml.py
@@ -60,7 +60,7 @@ def main(argv=None):
 
     data = dict(data)
     yaml.safe_dump(data, sys.stdout, allow_unicode=True,
-                   default_flow_style=False)
+                   width=100000, default_flow_style=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Have hard-wrapped lines makes it annoying to manipulate the output in an editor. This prevents the wrapping of the lines.

I wasn't sure how to achieve this in a nice way so just used a very large value. If you know how, do tell.