### PR TITLE
Move package metadata enstaller

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 setuptools>=18.4
 PyYAML
-git+https://github.com/enthought/enstaller@ff0bd6140c4efd46c48fcaf182042de9810021d3#egg=enstaller
+#git+https://github.com/enthought/enstaller@ff0bd6140c4efd46c48fcaf182042de9810021d3#egg=enstaller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 setuptools>=18.4
 PyYAML
-#git+https://github.com/enthought/enstaller@ff0bd6140c4efd46c48fcaf182042de9810021d3#egg=enstaller

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
     description='Simple SAT solvers for use in Enstaller',
     packages=PACKAGES,
     package_data=PACKAGE_DATA,
-    install_requires=["attrs >= 15.1.0", "six >= 1.9.0"],
+    install_requires=["attrs >= 15.2.0", "okonomiyaki == 0.14.0", "six >= 1.9.0"],
 )

--- a/simplesat/constraints/package_parser.py
+++ b/simplesat/constraints/package_parser.py
@@ -2,10 +2,9 @@ import re
 
 from okonomiyaki.versions import EnpkgVersion
 
-from enstaller.package import PackageMetadata
-
-from simplesat.constraints.kinds import Any, EnpkgUpstreamMatch, Equal
-from simplesat.constraints.parser import _RawRequirementParser
+from simplesat.package import PackageMetadata
+from .kinds import Any, EnpkgUpstreamMatch, Equal
+from .parser import _RawRequirementParser
 
 
 DEPENDS_RE = re.compile("depends\s*\((.*)\)")
@@ -66,7 +65,7 @@ class PrettyPackageStringParser(object):
         return (name, version_factory(version_string),
                 constraints.get("dependencies", {}))
 
-    def parse_to_package(self, package_string, python):
+    def parse_to_package(self, package_string):
         """ Parse the given pretty package string.
 
         Parameters
@@ -74,8 +73,6 @@ class PrettyPackageStringParser(object):
         package_string : str
             The pretty package string, e.g.
             "numpy 1.8.1-1; depends (MKL == 10.3, nose ~= 1.3.4)"
-        python : PythonImplementation
-            The python implementation.
 
         Returns
         -------
@@ -83,8 +80,7 @@ class PrettyPackageStringParser(object):
         """
         name, version, dependencies = \
             self.parse_to_legacy_constraints(package_string)
-        key = "{0}-{1}.egg".format(name, version)
-        return PackageMetadata(key, name, version, dependencies, python)
+        return PackageMetadata(name, version, dependencies)
 
     def parse_to_legacy_constraints(self, package_string):
         """ Parse the given package string into a name, version and a set of
@@ -111,7 +107,7 @@ class PrettyPackageStringParser(object):
                                      str(constraint.version.upstream))
             legacy_constraints.append(legacy_constraint)
 
-        return name, version, legacy_constraints
+        return name, version, tuple(legacy_constraints)
 
 
 def constraints_to_pretty_string(constraints):

--- a/simplesat/constraints/tests/test_package_parser.py
+++ b/simplesat/constraints/tests/test_package_parser.py
@@ -6,14 +6,13 @@ import six
 from okonomiyaki.platforms import PythonImplementation
 from okonomiyaki.versions import EnpkgVersion
 
-from enstaller.package import PackageMetadata
-
 from simplesat.constraints.kinds import Equal
 from simplesat.constraints.package_parser import (
     PrettyPackageStringParser, legacy_dependencies_to_pretty_string,
     package_to_pretty_string
 )
 from simplesat.errors import SolverException
+from simplesat.package import PackageMetadata
 
 
 RUNNING_PYTHON = PythonImplementation(
@@ -96,7 +95,7 @@ class TestPrettyPackageStringParser(unittest.TestCase):
         # Then
         self.assertEqual(name, "numpy")
         self.assertEqual(version, V("1.8.0-1"))
-        self.assertEqual(constraints, ["nose 1.3.4-1"])
+        self.assertEqual(constraints, ("nose 1.3.4-1",))
 
         # Given
         package_string = "numpy 1.8.0-1; depends (nose ~= 1.3.4)"
@@ -107,7 +106,7 @@ class TestPrettyPackageStringParser(unittest.TestCase):
         # Then
         self.assertEqual(name, "numpy")
         self.assertEqual(version, V("1.8.0-1"))
-        self.assertEqual(constraints, ["nose 1.3.4"])
+        self.assertEqual(constraints, ("nose 1.3.4",))
 
         # Given
         package_string = "numpy 1.8.0-1; depends (nose)"
@@ -118,7 +117,7 @@ class TestPrettyPackageStringParser(unittest.TestCase):
         # Then
         self.assertEqual(name, "numpy")
         self.assertEqual(version, V("1.8.0-1"))
-        self.assertEqual(constraints, ["nose"])
+        self.assertEqual(constraints, ("nose",))
 
 
 class TestLegacyDependenciesToPrettyString(unittest.TestCase):
@@ -137,12 +136,9 @@ class TestLegacyDependenciesToPrettyString(unittest.TestCase):
 class TestPackagePrettyString(unittest.TestCase):
     def test_simple(self):
         # Given
-        key = "numpy-1.8.1-1.egg"
-        python = RUNNING_PYTHON
-        package = PackageMetadata(key, "numpy", V("1.8.1-1"), ("MKL 10.3-1",),
-                                  python)
+        package = PackageMetadata(u"numpy", V("1.8.1-1"), ("MKL 10.3-1",))
 
-        r_pretty_string = "numpy 1.8.1-1; depends (MKL == 10.3-1)"
+        r_pretty_string = u"numpy 1.8.1-1; depends (MKL == 10.3-1)"
 
         # When
         pretty_string = package_to_pretty_string(package)
@@ -152,8 +148,7 @@ class TestPackagePrettyString(unittest.TestCase):
 
         # Given
         key = "numpy-1.8.1-1.egg"
-        package = PackageMetadata(key, "numpy", V("1.8.1-1"), ("nose",),
-                                  RUNNING_PYTHON)
+        package = PackageMetadata(u"numpy", V("1.8.1-1"), ("nose",))
 
         r_pretty_string = "numpy 1.8.1-1; depends (nose)"
 
@@ -167,13 +162,12 @@ class TestPackagePrettyString(unittest.TestCase):
 class TestToPackage(unittest.TestCase):
     def test_simple(self):
         # Given
-        s = "numpy 1.8.1; depends (MKL ~= 10.3)"
+        s = u"numpy 1.8.1; depends (MKL ~= 10.3)"
         parser = PrettyPackageStringParser(EnpkgVersion.from_string)
-        python = PythonImplementation.from_string("cp27")
 
         # When
-        package = parser.parse_to_package(s, python)
+        package = parser.parse_to_package(s)
 
         # Then
         self.assertEqual(package.name, "numpy")
-        self.assertEqual(package.dependencies, frozenset(["MKL 10.3"]))
+        self.assertEqual(package.dependencies, ("MKL 10.3",))

--- a/simplesat/package.py
+++ b/simplesat/package.py
@@ -1,0 +1,53 @@
+import six
+
+from attr import attr, attributes
+from attr.validators import instance_of
+
+from okonomiyaki.versions import EnpkgVersion
+
+
+@attributes
+class RepositoryInfo(object):
+    name = attr(validator=instance_of(six.text_type))
+
+
+@attributes
+class PackageMetadata(object):
+    name = attr(validator=instance_of(six.text_type))
+    version = attr(validator=instance_of(EnpkgVersion))
+
+    dependencies = attr(validator=instance_of(tuple))
+
+    @classmethod
+    def _from_pretty_string(cls, s):
+        """ Create an instance from a pretty string.
+
+        A pretty string looks as follows::
+
+            'numpy 1.8.1-1; depends (MKL ~= 10.3)'
+
+        Note
+        ----
+        Don't use this in production code, only meant to be used for testing.
+        """
+        # FIXME: local import to workaround circular imports
+        from .constraints import PrettyPackageStringParser
+        parser = PrettyPackageStringParser(EnpkgVersion.from_string)
+        return parser.parse_to_package(s)
+
+
+@attributes
+class RepositoryPackageMetadata(PackageMetadata):
+    repository_info = attr(validator=instance_of(RepositoryInfo))
+
+    @classmethod
+    def from_package(cls, package, repository_info):
+        return cls(
+            package.name, package.version, package.dependencies,
+            repository_info
+        )
+
+    @classmethod
+    def _from_pretty_string(cls, s, repository_info):
+        package = PackageMetadata._from_pretty_string(s) 
+        return cls.from_package(package, repository_info)

--- a/simplesat/package.py
+++ b/simplesat/package.py
@@ -1,6 +1,6 @@
 import six
 
-from attr import attr, attributes
+from attr import Factory, attr, attributes
 from attr.validators import instance_of
 
 from okonomiyaki.versions import EnpkgVersion
@@ -16,7 +16,10 @@ class PackageMetadata(object):
     name = attr(validator=instance_of(six.text_type))
     version = attr(validator=instance_of(EnpkgVersion))
 
-    dependencies = attr(validator=instance_of(tuple))
+    dependencies = attr(
+        validator=instance_of(tuple),
+        default=Factory(tuple),
+    )
 
     @classmethod
     def _from_pretty_string(cls, s):
@@ -37,17 +40,28 @@ class PackageMetadata(object):
 
 
 @attributes
-class RepositoryPackageMetadata(PackageMetadata):
+class RepositoryPackageMetadata(object):
     repository_info = attr(validator=instance_of(RepositoryInfo))
+
+    _package = attr(validator=instance_of(PackageMetadata))
 
     @classmethod
     def from_package(cls, package, repository_info):
-        return cls(
-            package.name, package.version, package.dependencies,
-            repository_info
-        )
+        return cls(repository_info, package)
 
     @classmethod
     def _from_pretty_string(cls, s, repository_info):
         package = PackageMetadata._from_pretty_string(s) 
         return cls.from_package(package, repository_info)
+
+    @property
+    def name(self):
+        return self._package.name
+
+    @property
+    def version(self):
+        return self._package.version
+
+    @property
+    def dependencies(self):
+        return self._package.dependencies

--- a/simplesat/pool.py
+++ b/simplesat/pool.py
@@ -66,9 +66,8 @@ class Pool(object):
         Convert a package id to a nice string representation.
         """
         package = self._id_to_package[abs(package_id)]
-        package_string = package.name + "-" + package.full_version
+        package_string = package.name + "-" + str(package.version)
         if package_id > 0:
             return "+" + package_string
         else:
             return "-" + package_string
-

--- a/simplesat/test_utils.py
+++ b/simplesat/test_utils.py
@@ -4,13 +4,11 @@ import os
 import six
 import yaml
 
-from enstaller.package import RepositoryPackageMetadata
-from enstaller.repository_info import BroodRepositoryInfo
-
 from okonomiyaki.platforms import PythonImplementation
 from okonomiyaki.versions import EnpkgVersion
 
 from simplesat.constraints import PrettyPackageStringParser, Requirement
+from simplesat.package import RepositoryInfo, RepositoryPackageMetadata
 from simplesat.repository import Repository
 from simplesat.request import Request
 from simplesat.rules_generator import RulesGenerator
@@ -56,11 +54,10 @@ def parse_package_list(packages):
         'numpy 1.8.1-1; depends (MKL ~= 10.3)').
     """
     parser = PrettyPackageStringParser(EnpkgVersion.from_string)
-    python = PythonImplementation.from_running_python()
 
     for package_str in packages:
-        package = parser.parse_to_package(package_str, python)
-        full_name = "{0} {1}".format(package.name, package.full_version)
+        package = parser.parse_to_package(package_str)
+        full_name = "{0} {1}".format(package.name, str(package.version))
         yield full_name, package
 
 
@@ -74,13 +71,13 @@ def repository_factory(package_names, repository_info, reference_packages):
 
 
 def remote_repository(yaml_data, packages):
-    repository_info = BroodRepositoryInfo("http://acme.come", "remote")
+    repository_info = RepositoryInfo(u"remote")
     package_names = yaml_data.get("remote", packages.keys())
     return repository_factory(package_names, repository_info, packages)
 
 
 def installed_repository(yaml_data, packages):
-    repository_info = BroodRepositoryInfo("http://acme.come", "installed")
+    repository_info = RepositoryInfo(u"installed")
     package_names = yaml_data.get("installed", [])
     return repository_factory(package_names, repository_info, packages)
 
@@ -91,9 +88,9 @@ class Scenario(object):
     def from_yaml(cls, file_or_filename):
         if isinstance(file_or_filename, six.string_types):
             with open(file_or_filename) as fp:
-                data = yaml.load(fp)
+                data = yaml.load(fp, Loader=_UnicodeLoader)
         else:
-            data = yaml.load(file_or_filename)
+            data = yaml.load(file_or_filename, Loader=_UnicodeLoader)
 
         packages = collections.OrderedDict(
             parse_package_list(data.get("packages", []))
@@ -169,3 +166,16 @@ class Scenario(object):
             package = pool._id_to_package[package_id]
             print("{}: {} {}".format(package_id, package.name,
                                      package.full_version))
+
+
+def construct_yaml_str(self, node):
+    # Override the default string handling function to always
+    # return unicode objects
+    return self.construct_scalar(node)
+
+
+class _UnicodeLoader(yaml.Loader):
+    pass
+
+
+_UnicodeLoader.add_constructor(u'tag:yaml.org,2002:str', construct_yaml_str)

--- a/simplesat/test_utils.py
+++ b/simplesat/test_utils.py
@@ -65,7 +65,7 @@ def repository_factory(package_names, repository_info, reference_packages):
     repository = Repository()
     for package_name in package_names:
         package = reference_packages[package_name]
-        package = RepositoryPackageMetadata.from_package(package, repository_info)
+        package = RepositoryPackageMetadata(package, repository_info)
         repository.add_package(package)
     return repository
 

--- a/simplesat/tests/test_pool.py
+++ b/simplesat/tests/test_pool.py
@@ -14,7 +14,7 @@ from ..pool import Pool
 V = EnpkgVersion.from_string
 
 
-NUMPY_PACKAGES = """\
+NUMPY_PACKAGES = u"""\
 mkl 10.2-1
 mkl 10.2-2
 mkl 10.3-1
@@ -50,11 +50,10 @@ numpy 1.8.1-1; depends (MKL == 10.3-1)
 
 class TestPool(unittest.TestCase):
     def packages_from_definition(self, packages_definition):
-        python_implementation = PythonImplementation.from_running_python()
         parser = PrettyPackageStringParser(EnpkgVersion.from_string)
 
         return [
-            parser.parse_to_package(line, python_implementation)
+            parser.parse_to_package(line)
             for line in packages_definition.splitlines()
         ]
 
@@ -69,7 +68,7 @@ class TestPool(unittest.TestCase):
 
         # Then
         self.assertEqual(len(candidates), 1)
-        self.assertEqual(candidates[0].full_version, "1.8.1-1")
+        self.assertEqual(candidates[0].version, V("1.8.1-1"))
 
     def test_what_provides_casing(self):
         # Given
@@ -79,7 +78,7 @@ class TestPool(unittest.TestCase):
         # When
         pool = Pool([repository])
         candidates = pool.what_provides(requirement)
-        versions = [candidate.full_version for candidate in candidates]
+        versions = [str(candidate.version) for candidate in candidates]
 
         # Then
         six.assertCountEqual(self, versions, ["10.2-1", "10.2-2"])
@@ -92,7 +91,7 @@ class TestPool(unittest.TestCase):
         # When
         pool = Pool([repository])
         candidates = pool.what_provides(requirement)
-        versions = [candidate.full_version for candidate in candidates]
+        versions = [str(candidate.version) for candidate in candidates]
 
         # Then
         six.assertCountEqual(
@@ -107,7 +106,7 @@ class TestPool(unittest.TestCase):
         # When
         pool = Pool([repository])
         candidates = pool.what_provides(requirement)
-        versions = [candidate.full_version for candidate in candidates]
+        versions = [str(candidate.version) for candidate in candidates]
 
         # Then
         six.assertCountEqual(

--- a/simplesat/tests/test_repository.py
+++ b/simplesat/tests/test_repository.py
@@ -14,17 +14,16 @@ V = EnpkgVersion.from_string
 
 class TestRepository(unittest.TestCase):
     def packages_from_definition(self, packages_definition):
-        python_implementation = PythonImplementation.from_running_python()
         parser = PrettyPackageStringParser(EnpkgVersion.from_string)
 
         return [
-            parser.parse_to_package(line, python_implementation)
+            parser.parse_to_package(line)
             for line in packages_definition.splitlines()
         ]
 
     def test_simple(self):
         # Given
-        packages_definition = textwrap.dedent("""\
+        packages_definition = textwrap.dedent(u"""\
         dummy 1.0.1-1
         dummy_with_appinst 1.0.0-1
         dummy_with_entry_points 1.0.0-1
@@ -59,7 +58,7 @@ class TestRepository(unittest.TestCase):
 
     def test_update(self):
         # Given
-        packages_definition = textwrap.dedent("""\
+        packages_definition = textwrap.dedent(u"""\
         dummy 1.0.1-1
         dummy_with_appinst 1.0.0-1
         dummy_with_entry_points 1.0.0-1
@@ -87,7 +86,7 @@ class TestRepository(unittest.TestCase):
 
     def test_find_package(self):
         # Given
-        packages_definition = textwrap.dedent("""\
+        packages_definition = textwrap.dedent(u"""\
         dummy 1.0.1-1
         dummy_with_appinst 1.0.0-1
         dummy_with_entry_points 1.0.0-1
@@ -105,11 +104,12 @@ class TestRepository(unittest.TestCase):
         package = repository.find_package("nose", V("1.3.0-1"))
 
         # Then
-        self.assertEqual(package.key, "nose-1.3.0-1.egg")
+        self.assertEqual(package.name, "nose")
+        self.assertEqual(package.version, V("1.3.0-1"))
 
     def test_find_unavailable_package(self):
         # Given
-        packages_definition = textwrap.dedent("""\
+        packages_definition = textwrap.dedent(u"""\
         dummy 1.0.1-1
         dummy_with_appinst 1.0.0-1
         dummy_with_entry_points 1.0.0-1
@@ -133,7 +133,7 @@ class TestRepository(unittest.TestCase):
 
     def test_find_packages(self):
         # Given
-        packages_definition = textwrap.dedent("""\
+        packages_definition = textwrap.dedent(u"""\
         dummy 1.0.1-1
         dummy_with_appinst 1.0.0-1
         dummy_with_entry_points 1.0.0-1

--- a/simplesat/tests/test_solver.py
+++ b/simplesat/tests/test_solver.py
@@ -22,10 +22,9 @@ class TestSolver(unittest.TestCase):
         self._package_parser = PrettyPackageStringParser(
             EnpkgVersion.from_string
         )
-        self._python = PythonImplementation("cp", 2, 7)
 
     def package_factory(self, s):
-        return self._package_parser.parse_to_package(s, self._python)
+        return self._package_parser.parse_to_package(s)
 
     def resolve(self, request):
         pool = Pool([self.repository, self.installed_repository])
@@ -39,7 +38,7 @@ class TestSolver(unittest.TestCase):
 
     def test_simple_install(self):
         # Given
-        mkl = self.package_factory("mkl 10.3-1")
+        mkl = self.package_factory(u"mkl 10.3-1")
         self.repository.add_package(mkl)
 
         r_operations = [InstallOperation(mkl)]
@@ -55,8 +54,8 @@ class TestSolver(unittest.TestCase):
 
     def test_multiple_installs(self):
         # Given
-        mkl = self.package_factory("mkl 10.3-1")
-        libgfortran = self.package_factory("libgfortran 3.0.0-2")
+        mkl = self.package_factory(u"mkl 10.3-1")
+        libgfortran = self.package_factory(u"libgfortran 3.0.0-2")
 
         r_operations = [
             InstallOperation(mkl),
@@ -78,10 +77,10 @@ class TestSolver(unittest.TestCase):
 
     def test_simple_dependency(self):
         # Given
-        mkl = self.package_factory("mkl 10.3-1")
-        libgfortran = self.package_factory("libgfortran 3.0.0-2")
+        mkl = self.package_factory(u"mkl 10.3-1")
+        libgfortran = self.package_factory(u"libgfortran 3.0.0-2")
         numpy = self.package_factory(
-            "numpy 1.9.2-1; depends (mkl == 10.3-1, libgfortran ~= 3.0.0)"
+            u"numpy 1.9.2-1; depends (mkl == 10.3-1, libgfortran ~= 3.0.0)"
         )
 
         r_operations = [
@@ -105,8 +104,8 @@ class TestSolver(unittest.TestCase):
 
     def test_already_installed(self):
         # Given
-        mkl1 = self.package_factory("mkl 10.3-1")
-        mkl2 = self.package_factory("mkl 10.3-2")
+        mkl1 = self.package_factory(u"mkl 10.3-1")
+        mkl2 = self.package_factory(u"mkl 10.3-2")
 
         r_operations = []
 

--- a/simplesat/tests/test_test_utils.py
+++ b/simplesat/tests/test_test_utils.py
@@ -4,12 +4,10 @@ import textwrap
 
 import six
 
-from enstaller.package import RepositoryPackageMetadata
-from enstaller.repository_info import BroodRepositoryInfo
-
 from okonomiyaki.platforms import PythonImplementation
 
 from ..constraints import Requirement
+from ..package import RepositoryInfo, RepositoryPackageMetadata
 from ..request import _Job, JobType
 from ..test_utils import Scenario, parse_package_list, repository_factory
 from ..utils import mkdtemp
@@ -27,18 +25,17 @@ class TestRepositoryFactory(unittest.TestCase):
     def test_simple(self):
         # Given
         package_strings = [
-            "MKL 10.3-1",
-            "numpy 1.8.1-1; depends (MKL ~= 10.3)",
-            "numpy 1.8.1-2; depends (MKL ~= 10.3)",
+            u"MKL 10.3-1",
+            u"numpy 1.8.1-1; depends (MKL ~= 10.3)",
+            u"numpy 1.8.1-2; depends (MKL ~= 10.3)",
         ]
         repository_packages = [
             "MKL 10.3-1",
             "numpy 1.8.1-2",
         ]
-        repository_info = BroodRepositoryInfo("https://acme.com", "acme/loony")
+        repository_info = RepositoryInfo(u"acme/loony")
         r_numpy = P(
-            "numpy 1.8.1-2; depends (MKL ~= 10.3)", repository_info,
-            PythonImplementation.from_running_python()
+            u"numpy 1.8.1-2; depends (MKL ~= 10.3)", repository_info,
         )
 
         # When
@@ -51,7 +48,7 @@ class TestRepositoryFactory(unittest.TestCase):
         self.assertEqual(len(repository.find_packages("numpy")), 1)
 
         numpy = repository.find_packages("numpy")[0]
-        self.assertEqual(numpy._comp_key, r_numpy._comp_key)
+        self.assertEqual(numpy, r_numpy)
 
 
 class TestScenario(unittest.TestCase):


### PR DESCRIPTION
With this PR, `sat-solver` does not depend on `enstaller` anymore.