### PR TITLE
Add pretty string for new PackageMetadata

### DIFF
--- a/simplesat/package.py
+++ b/simplesat/package.py
@@ -88,7 +88,7 @@ class PackageMetadata(object):
 class RepositoryPackageMetadata(object):
     @classmethod
     def _from_pretty_string(cls, s, repository_info):
-        package = PackageMetadata._from_pretty_string(s) 
+        package = PackageMetadata._from_pretty_string(s)
         return cls(package, repository_info)
 
     def __init__(self, package, repository_info):

--- a/simplesat/package.py
+++ b/simplesat/package.py
@@ -29,6 +29,9 @@ class RepositoryInfo(IRepositoryInfo):
     def __ne__(self, other):
         return self._key != other._key
 
+    def __repr__(self):
+        return "Repository(<{0.name}>)".format(self)
+
 
 class PackageMetadata(object):
     @classmethod
@@ -68,6 +71,10 @@ class PackageMetadata(object):
     def dependencies(self):
         return self._dependencies
 
+    def __repr__(self):
+        return "PackageMetadata('{0}-{1}', key={2!r})".format(
+            self._name, self._version, self._key)
+
     def __hash__(self):
         return self._hash
 
@@ -106,6 +113,12 @@ class RepositoryPackageMetadata(object):
     @property
     def repository_info(self):
         return self._repository_info
+
+    def __repr__(self):
+        return (
+            "RepositoryPackageMetadata('{pkg._name}-{pkg._version}'"
+            ", repo={repository_info!r}".format(
+                pkg=self._package, repository_info=self._repository_info))
 
     def __hash__(self):
         return self._hash

--- a/simplesat/package.py
+++ b/simplesat/package.py
@@ -116,7 +116,7 @@ class RepositoryPackageMetadata(object):
     def __repr__(self):
         return (
             "RepositoryPackageMetadata('{pkg._name}-{pkg._version}'"
-            ", repo={repository_info!r}".format(
+            ", repo={repository_info!r})".format(
                 pkg=self._package, repository_info=self._repository_info))
 
     def __hash__(self):

--- a/simplesat/package.py
+++ b/simplesat/package.py
@@ -72,8 +72,7 @@ class PackageMetadata(object):
         return self._dependencies
 
     def __repr__(self):
-        return "PackageMetadata('{0}-{1}', key={2!r})".format(
-            self._name, self._version, self._key)
+        return "PackageMetadata('{0}-{1}')".format(self._name, self._version)
 
     def __hash__(self):
         return self._hash


### PR DESCRIPTION
The new classes don't have a nice representation, which makes the output of `scripts/solve.py` pretty unreadable. This just implements `__repr__` on those classes in a way similar to the original.