### PR TITLE
Fix requirement inconsistency

### DIFF
--- a/simplesat/constraints/multi.py
+++ b/simplesat/constraints/multi.py
@@ -30,9 +30,9 @@ class MultiConstraints(object):
 
     def __init__(self, constraints=None):
         if constraints is None:
-            self._constraints = frozenset()
+            self._constraints = tuple()
         else:
-            self._constraints = frozenset(constraints)
+            self._constraints = tuple(constraints)
 
     def matches(self, version_candidate):
         """ Returns True if the given version matches this set of

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -186,7 +186,7 @@ class _RawRequirementParser(object):
             elif len(requirement_block) == 1:
                 name = requirement_block[0].value
                 # Force name to exist in constraints
-                constraints[name].add(Any())
+                _ = constraints[name]
             else:
                 msg = ("Invalid requirement block: {0!r}".
                        format(requirement_block))

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -129,17 +129,21 @@ def _spec_factory(comparison_token):
 
 
 def _tokenize(scanner, requirement_string):
-    tokens = []
+    requirement_string = requirement_string.strip()
 
-    parts = requirement_string.split(",")
-    for part in parts:
-        scanned, remaining = scanner.scan(part.strip())
-        if len(remaining) > 0:
-            msg = "Invalid requirement string: {0!r}"
-            raise SolverException(msg.format(requirement_string))
-        elif len(scanned) > 0:
-            tokens.append(scanned)
-    return tokens
+    if len(requirement_string) == 0:
+        return [[AnyToken()]]
+    else:
+        tokens = []
+
+        for part in requirement_string.split(","):
+            scanned, remaining = scanner.scan(part.strip())
+            if len(remaining) > 0:
+                msg = "Invalid requirement string: {0!r}"
+                raise SolverException(msg.format(requirement_string))
+            elif len(scanned) > 0:
+                tokens.append(scanned)
+        return tokens
 
 
 def _operator_factory(operator, version, version_factory):
@@ -158,6 +162,9 @@ class _RawConstraintsParser(object):
             if len(requirement_block) == 2:
                 operator, version = requirement_block
                 return _operator_factory(operator, version, version_factory)
+            elif len(requirement_block) == 1:
+                assert isinstance(requirement_block[0], AnyToken)
+                return Any()
             else:
                 msg = ("Invalid requirement string: {0!r}".
                        format(requirement_string))
@@ -187,7 +194,7 @@ class _RawRequirementParser(object):
                 )
             elif len(requirement_block) == 1:
                 name = requirement_block[0].value
-                return name, tuple()
+                return name, tuple([Any()])
             else:
                 msg = ("Invalid requirement block: {0!r}".
                        format(requirement_block))

--- a/simplesat/constraints/requirement.py
+++ b/simplesat/constraints/requirement.py
@@ -75,7 +75,7 @@ class Requirement(object):
 
         parse = _RawConstraintsParser().parse
 
-        constraints = set(
+        constraints = tuple(
             constraint
             for conjunction in disjunction
             for constraint_str in conjunction
@@ -115,7 +115,7 @@ class Requirement(object):
         """
         name, version_string = parse_package_full_name(package_string)
         version = version_factory(version_string)
-        return cls(name, [Equal(version)])
+        return cls(name, (Equal(version),))
 
     def __init__(self, name, constraints=None):
         self.name = name

--- a/simplesat/constraints/requirement.py
+++ b/simplesat/constraints/requirement.py
@@ -75,10 +75,13 @@ class Requirement(object):
 
         parse = _RawConstraintsParser().parse
 
+        def insert_star(conjunction):
+            return conjunction if len(conjunction) > 0 else ("*",)
+
         constraints = tuple(
             constraint
             for conjunction in disjunction
-            for constraint_str in conjunction
+            for constraint_str in insert_star(conjunction)
             for constraint in parse(constraint_str, EnpkgVersion.from_string))
 
         return cls(name, constraints)

--- a/simplesat/constraints/requirement.py
+++ b/simplesat/constraints/requirement.py
@@ -154,6 +154,9 @@ class Requirement(object):
         else:
             return self.name + " " + ", ".join(parts)
 
+    def __repr__(self):
+        return "Requirement('" + str(self) + "')"
+
     @property
     def has_any_version_constraint(self):
         """ True if there is any version constraint."""

--- a/simplesat/constraints/tests/test_multi.py
+++ b/simplesat/constraints/tests/test_multi.py
@@ -200,6 +200,14 @@ class TestMultiConstraints(unittest.TestCase):
 
     def test_comparison(self):
         # Given
+        versions = (
+            V("1.2-3"),
+            V("1.3.0"),
+            V("1.3.0-1"),
+            V("1.3.0-3"),
+            V("1.4.0-1"),
+            V("2.0-1")
+        )
         constraints_string1 = ">= 1.3, < 2.0"
         constraints_string2 = "< 2.0, >= 1.3"
 
@@ -208,5 +216,7 @@ class TestMultiConstraints(unittest.TestCase):
         constraints2 = MultiConstraints._from_string(constraints_string2)
 
         # Then
-        self.assertEqual(constraints1, constraints2)
-        self.assertFalse(constraints1 != constraints2)
+        for version in versions:
+            self.assertEqual(
+                constraints1.matches(version), constraints2.matches(version)
+            )

--- a/simplesat/constraints/tests/test_parser.py
+++ b/simplesat/constraints/tests/test_parser.py
@@ -30,7 +30,7 @@ class Test_RawConstraintsParser(unittest.TestCase):
         constraints = self._parse(constraints_string)
 
         # Then
-        self.assertEqual(constraints, ())
+        self.assertEqual(constraints, (Any(),))
 
     def test_simple(self):
         # Given
@@ -149,7 +149,7 @@ class Test_RawRequirementParser(unittest.TestCase):
     def test_no_version(self):
         # Given
         requirement_string = "numpy"
-        r_constraints = {"numpy": tuple()}
+        r_constraints = {"numpy": tuple([Any()])}
 
         # When
         constraints = self._parse(requirement_string)
@@ -159,7 +159,7 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "MKL == 10.3-1, numpy"
-        r_constraints = {"numpy": tuple(),
+        r_constraints = {"numpy": tuple([Any()]),
                          "MKL": tuple([Equal(V("10.3-1"))])}
 
         # When
@@ -170,7 +170,7 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "scikits.statsmodels"
-        r_constraints = {"scikits.statsmodels": tuple()}
+        r_constraints = {"scikits.statsmodels": tuple([Any()])}
 
         # When
         constraints = self._parse(requirement_string)
@@ -180,7 +180,7 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "special_package.123"
-        r_constraints = {"special_package.123": tuple()}
+        r_constraints = {"special_package.123": tuple([Any()])}
 
         # When
         constraints = self._parse(requirement_string)

--- a/simplesat/constraints/tests/test_parser.py
+++ b/simplesat/constraints/tests/test_parser.py
@@ -149,7 +149,7 @@ class Test_RawRequirementParser(unittest.TestCase):
     def test_no_version(self):
         # Given
         requirement_string = "numpy"
-        r_constraints = {"numpy": set([Any()])}
+        r_constraints = {"numpy": set()}
 
         # When
         constraints = self._parse(requirement_string)
@@ -159,7 +159,7 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "MKL == 10.3-1, numpy"
-        r_constraints = {"numpy": set([Any()]),
+        r_constraints = {"numpy": set(),
                          "MKL": set([Equal(V("10.3-1"))])}
 
         # When
@@ -170,7 +170,7 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "scikits.statsmodels"
-        r_constraints = {"scikits.statsmodels": set([Any()])}
+        r_constraints = {"scikits.statsmodels": set()}
 
         # When
         constraints = self._parse(requirement_string)
@@ -180,7 +180,7 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "special_package.123"
-        r_constraints = {"special_package.123": set([Any()])}
+        r_constraints = {"special_package.123": set()}
 
         # When
         constraints = self._parse(requirement_string)

--- a/simplesat/constraints/tests/test_parser.py
+++ b/simplesat/constraints/tests/test_parser.py
@@ -30,12 +30,12 @@ class Test_RawConstraintsParser(unittest.TestCase):
         constraints = self._parse(constraints_string)
 
         # Then
-        self.assertEqual(constraints, set())
+        self.assertEqual(constraints, ())
 
     def test_simple(self):
         # Given
         constraints_string = "> 1.2.0-1"
-        r_constraints = set([GT(V("1.2.0-1"))])
+        r_constraints = (GT(V("1.2.0-1")),)
 
         # When
         constraints = self._parse(constraints_string)
@@ -45,7 +45,7 @@ class Test_RawConstraintsParser(unittest.TestCase):
 
         # Given
         constraints_string = ">= 1.2.0-1"
-        r_constraints = set([GEQ(V("1.2.0-1"))])
+        r_constraints = (GEQ(V("1.2.0-1")),)
 
         # When
         constraints = self._parse(constraints_string)
@@ -55,7 +55,7 @@ class Test_RawConstraintsParser(unittest.TestCase):
 
         # Given
         constraints_string = "<= 1.2.0-1"
-        r_constraints = set([LEQ(V("1.2.0-1"))])
+        r_constraints = (LEQ(V("1.2.0-1")),)
 
         # When
         constraints = self._parse(constraints_string)
@@ -65,7 +65,7 @@ class Test_RawConstraintsParser(unittest.TestCase):
 
         # Given
         constraints_string = "< 1.2.0-1"
-        r_constraints = set([LT(V("1.2.0-1"))])
+        r_constraints = (LT(V("1.2.0-1")),)
 
         # When
         constraints = self._parse(constraints_string)
@@ -75,7 +75,7 @@ class Test_RawConstraintsParser(unittest.TestCase):
 
         # Given
         constraints_string = "^= 1.2.0-1"
-        r_constraints = set([EnpkgUpstreamMatch(V("1.2.0-1"))])
+        r_constraints = (EnpkgUpstreamMatch(V("1.2.0-1")),)
 
         # When
         constraints = self._parse(constraints_string)
@@ -86,8 +86,9 @@ class Test_RawConstraintsParser(unittest.TestCase):
     def test_multiple(self):
         # Given
         constraints_string = ">= 1.2.0-1, < 1.4, != 1.3.8-1"
-        r_constraints = set([GEQ(V("1.2.0-1")), LT(V("1.4")),
-                             Not(V("1.3.8-1"))])
+        r_constraints = (
+            GEQ(V("1.2.0-1")), LT(V("1.4")), Not(V("1.3.8-1"))
+        )
 
         # When
         constraints = self._parse(constraints_string)
@@ -114,7 +115,7 @@ class Test_RawRequirementParser(unittest.TestCase):
     def test_simple(self):
         # Given
         requirement_string = "numpy == 1.8.1-1"
-        r_constraints = {"numpy": set([Equal(V("1.8.1-1"))])}
+        r_constraints = {"numpy": tuple([Equal(V("1.8.1-1"))])}
 
         # When
         constraints = self._parse(requirement_string)
@@ -125,8 +126,7 @@ class Test_RawRequirementParser(unittest.TestCase):
     def test_multiple(self):
         # Given
         requirement_string = "numpy >= 1.8.1, numpy < 1.9.0"
-        r_constraints = {"numpy": set([GEQ(V("1.8.1-0")),
-                                       LT(V("1.9.0"))])}
+        r_constraints = {"numpy": (GEQ(V("1.8.1-0")), LT(V("1.9.0")))}
 
         # When
         constraints = self._parse(requirement_string)
@@ -137,8 +137,8 @@ class Test_RawRequirementParser(unittest.TestCase):
     def test_multiple_names(self):
         # Given
         requirement_string = "numpy >= 1.8.1, scipy >= 0.14.0"
-        r_constraints = {"numpy": set([GEQ(V("1.8.1-0"))]),
-                         "scipy": set([GEQ(V("0.14.0"))])}
+        r_constraints = {"numpy": (GEQ(V("1.8.1-0")),),
+                         "scipy": (GEQ(V("0.14.0")),)}
 
         # When
         constraints = self._parse(requirement_string)
@@ -149,7 +149,7 @@ class Test_RawRequirementParser(unittest.TestCase):
     def test_no_version(self):
         # Given
         requirement_string = "numpy"
-        r_constraints = {"numpy": set()}
+        r_constraints = {"numpy": tuple()}
 
         # When
         constraints = self._parse(requirement_string)
@@ -159,8 +159,8 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "MKL == 10.3-1, numpy"
-        r_constraints = {"numpy": set(),
-                         "MKL": set([Equal(V("10.3-1"))])}
+        r_constraints = {"numpy": tuple(),
+                         "MKL": tuple([Equal(V("10.3-1"))])}
 
         # When
         constraints = self._parse(requirement_string)
@@ -170,7 +170,7 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "scikits.statsmodels"
-        r_constraints = {"scikits.statsmodels": set()}
+        r_constraints = {"scikits.statsmodels": tuple()}
 
         # When
         constraints = self._parse(requirement_string)
@@ -180,7 +180,7 @@ class Test_RawRequirementParser(unittest.TestCase):
 
         # Given
         requirement_string = "special_package.123"
-        r_constraints = {"special_package.123": set()}
+        r_constraints = {"special_package.123": tuple()}
 
         # When
         constraints = self._parse(requirement_string)

--- a/simplesat/constraints/tests/test_requirement.py
+++ b/simplesat/constraints/tests/test_requirement.py
@@ -51,6 +51,10 @@ class TestRequirementFromConstraint(unittest.TestCase):
         self.assertTrue(requirement.matches(V("1.8.1-3")))
         self.assertTrue(requirement.matches(V("1.8.2-1")))
         self.assertTrue(requirement.matches(V("1.9.0-1")))
+        self.assertEqual(
+            requirement,
+            Requirement.from_constraints(("numpy", (("*"),)))
+        )
 
     def test_simple(self):
         # Given
@@ -127,6 +131,8 @@ class TestRequirementFromString(unittest.TestCase):
     def test_any(self):
         # Given
         requirement_string = "numpy"
+        r_requirement = Requirement.from_constraints(("numpy", (("*"),)))
+        r_requirement_empty = Requirement.from_constraints(("numpy", ((),)))
 
         # When
         requirement = Requirement._from_string(requirement_string)
@@ -136,6 +142,9 @@ class TestRequirementFromString(unittest.TestCase):
         self.assertTrue(requirement.matches(V("1.8.1-3")))
         self.assertTrue(requirement.matches(V("1.8.2-1")))
         self.assertTrue(requirement.matches(V("1.9.0-1")))
+        self.assertEqual(requirement, r_requirement)
+        self.assertEqual(requirement, r_requirement_empty)
+        self.assertEqual(requirement, r_requirement_empty)
 
     def test_simple(self):
         # Given

--- a/simplesat/constraints/tests/test_requirement.py
+++ b/simplesat/constraints/tests/test_requirement.py
@@ -206,3 +206,42 @@ class TestParsePackageFullName(unittest.TestCase):
         # When/Then
         with self.assertRaises(SolverException):
             parse_package_full_name(package_s)
+
+
+class TestRequirement(unittest.TestCase):
+    def test_repr(self):
+        # Given
+        constraints = (
+            "numpy", (("^= 1.8.0",),)
+        )
+        r_repr = "Requirement('numpy ^= 1.8.0')"
+
+        # When
+        requirement = Requirement.from_constraints(constraints)
+
+        # Then
+        self.assertMultiLineEqual(repr(requirement), r_repr)
+
+        # Given
+        constraints = (
+            "numpy", ((">= 1.8.0", "< 1.10.0"),)
+        )
+        r_repr = "Requirement('numpy >= 1.8.0-0, < 1.10.0-0')"
+
+        # When
+        requirement = Requirement.from_constraints(constraints)
+
+        # Then
+        self.assertMultiLineEqual(repr(requirement), r_repr)
+
+        # Given
+        constraints = (
+            "numpy", ((">= 1.8.0-0", "< 1.10.0-0"),)
+        )
+        r_repr = "Requirement('numpy >= 1.8.0-0, < 1.10.0-0')"
+
+        # When
+        requirement = Requirement.from_constraints(constraints)
+
+        # Then
+        self.assertMultiLineEqual(repr(requirement), r_repr)


### PR DESCRIPTION
This fixes an inconsistency when creating `Requirement` instances in the case of no version constraint. Depending on which ctor we were using, we would get either an empty set (`from_constraints`) or a set with `Any` (`_from_string`).

I also converted our usage from `set`/`frozenset` to `tuple` to keep the list of constraints, to make pretty string representation of `Requirement` more "consistent".

@johntyree 