### PR TITLE
Pass other args through to solve.py when comparing with composer

### DIFF
--- a/scripts/compare_with_composer.sh
+++ b/scripts/compare_with_composer.sh
@@ -2,14 +2,16 @@
 
 set -eCu
 
+
 SCENARIO="$1"
+shift
 TMPDIR=$(mktemp -d)
 trap 'rm -r $TMPDIR' EXIT
 US="$TMPDIR/us"
 THEM="$TMPDIR/them"
 
 set -x
-python scripts/solve.py --simple "$SCENARIO" | sort -k 2 > "$US"
+python scripts/solve.py --simple "$@" "$SCENARIO" | sort -k 2 > "$US"
 python scripts/scenario_to_php.py --composer-root composer "$SCENARIO" scripts/print_operations.php.in
 time php scripts/print_operations.php | sort -k 2 > "$THEM"
 diff -y "$US" "$THEM"


### PR DESCRIPTION
This just allows one to pass the other arguments to `script/solve.py` along, such as `--no-prefer-installed`.