### PR TITLE
Clean up of error message improvement code

### DIFF
--- a/simplesat/sat/clause.py
+++ b/simplesat/sat/clause.py
@@ -92,3 +92,6 @@ class Clause(Constraint):
 
     def __repr__(self):
         return "Clause({}, learned={})".format(self.lits, self.learned)
+
+    def __lt__(self, other):
+        raise TypeError("no ordering relation is defined for clauses")

--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -127,11 +127,13 @@ class UNSAT(object):
             for i in range(1, len(seq)):
                 yield seq[i:]
 
+        # Find a shortest path between each pair of end points if there is one
         raw_paths = list(itertools.chain.from_iterable(
             breadth_first_search(start, get_neighbors, rest)
             for start, rest in zip(ends, tails(ends))))
 
-        # The best path is the one with the most conflicting jobs in it
+        # This is somewhat arbitrary, but for now we'll say that the best path
+        # is the one with the most jobs in it.
         empty = (0, ())
         path_groups = itertools.groupby(
             sorted(raw_paths, key=jobs_in_path, reverse=True),

--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -86,15 +86,19 @@ class UNSAT(object):
         # These paths are a minimal series of related clauses that describe the
         # conflict(s).
         clauses = self._conflict_details
-        end_points = self._end_points(clauses, implicand=self._implicand)
-        paths = self._find_conflict_paths(end_points, clauses)
+        end_clauses = self._end_clauses(clauses, implicand=self._implicand)
+        paths = self._find_conflict_paths(end_clauses, clauses)
         self._conflict_paths.extend(paths)
 
     def _key(self, clause):
         return tuple(sorted(l for l in clause.lits))
 
-    def _find_conflict_paths(self, end_points, relevant_clauses):
-        """ Return a tuple of paths between a set of clauses.
+    def _find_conflict_paths(self, end_clauses, relevant_clauses):
+        """ Return a tuple of paths representing conflicts between a set of
+        clauses.
+
+            See https://github.com/enthought/sat-solver/wiki/Unsatisfiability-Error-Messages
+            for discussion about how best to implement this.
         """
         # It's expensive to figure out which clauses are neighbors. This dict
         # maps ids to clauses containing that id. We can do this lookup for
@@ -113,10 +117,10 @@ class UNSAT(object):
 
         # If there aren't two end points then none of this makes any sense.
         # Just return what we have.
-        if len(end_points) < 2:
-            return end_points
+        if len(end_clauses) < 2:
+            return end_clauses
 
-        ends = OrderedDict.fromkeys(end_points)
+        ends = OrderedDict.fromkeys(end_clauses)
         ends = tuple(ends.keys())
 
         def jobs_in_path(path):
@@ -152,7 +156,7 @@ class UNSAT(object):
 
         return tuple(paths)
 
-    def _end_points(self, relevant_clauses, implicand=None):
+    def _end_clauses(self, relevant_clauses, implicand=None):
         """ Return the nodes which will serve as required points in our path.
 
         Given a bag of clauses, each possibly with rules and requirements

--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -145,8 +145,8 @@ class UNSAT(object):
 
     @property
     def rules(self):
-        return tuple(OrderedDict.fromkeys(
-            c.rule for path in self._conflict_paths for c in path).keys())
+        flat = (c.rule for path in self._conflict_paths for c in path)
+        return tuple(OrderedDict.fromkeys(flat).keys())
 
     @property
     def requirements(self):

--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -140,7 +140,7 @@ class UNSAT(object):
             if c.rule and c.rule._requirements
             if implicand in c or c.rule.reason in JOBTYPES
         )
-        roots = tuple(sorted(flat_clauses, key=lambda c: c.lits))
+        roots = tuple(sorted(flat_clauses, key=self._key))
         return roots
 
     @property

--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -140,7 +140,7 @@ class UNSAT(object):
     def requirements(self):
         # Every list of requirements ends at a job, so only take the last one
         return tuple(OrderedDict.fromkeys(
-            rule._requirements[-1] for rule in self.rules))
+            rule._requirements[0] for rule in self.rules))
 
     def clause_requirements(self, clause, ignore=None):
         """

--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -87,7 +87,7 @@ class UNSAT(object):
             self._conflict_paths.append(path)
 
     def _key(self, clause):
-        return sorted(abs(l) for l in clause.lits)
+        return tuple(sorted(l for l in clause.lits))
 
     def _find_conflict_path(self, end_points, relevant_clauses):
         """ Return a path between a set of clauses, given a pool of candidates.
@@ -223,14 +223,8 @@ class UNSAT(object):
             flat_clauses = self.clause_trail(clause) or (clause,)
 
             for clause in flat_clauses:
-                if pool:
-                    pretties = (pool.id_to_string(l) for l in clause.lits)
-                else:
-                    pretties = clause.lits
-                key = tuple(sorted(pretties))
-
-                # Add it to our  set of clauses to include
-                details.setdefault(key, clause)
+                # Add it to our set of clauses to include
+                details.setdefault(self._key(clause), clause)
 
         reason = ["Conflicting requirements:"]
         for clause in details.values():

--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -150,7 +150,7 @@ class UNSAT(object):
 
     @property
     def requirements(self):
-        # Every list of requirements ends at a job, so only take the last one
+        # Every list of requirements start at a job, so only take the first one
         return tuple(OrderedDict.fromkeys(
             rule._requirements[0] for rule in self.rules))
 

--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -134,9 +134,13 @@ class UNSAT(object):
         user request or whose variable contain the variable with the assignment
         conflict.
         """
-        roots = [c for c in relevant_clauses
-                 if c.rule and c.rule._requirements
-                 if implicand in c or c.rule.reason in JOBTYPES]
+
+        flat_clauses = set(
+            c for c in relevant_clauses
+            if c.rule and c.rule._requirements
+            if implicand in c or c.rule.reason in JOBTYPES
+        )
+        roots = tuple(sorted(flat_clauses, key=lambda c: c.lits))
         return roots
 
     @property

--- a/simplesat/tests/epd_full_conflict.yaml
+++ b/simplesat/tests/epd_full_conflict.yaml
@@ -2020,12 +2020,12 @@ request:
 
 
 failure:
-  requirements: ['EPD', 'numpy > 1.8.0-0']
+  requirements: ['numpy > 1.8.0-0', 'EPD']
   raw: |
       Conflicting requirements:
-      Requirements: 'EPD' <- 'numpy == 1.6.0-5'
-          EPD-7.1-1 requires (+numpy-1.6.0-5)
-      Requirements: 'EPD' <- 'numpy'
-          Can only install one of: (+numpy-1.8.1-1 | +numpy-1.6.0-5)
       Requirements: 'numpy > 1.8.0-0'
           Install command rule (+numpy-1.8.0-1 | +numpy-1.8.0-2 | +numpy-1.8.0-3 | +numpy-1.8.1-1)
+      Requirements: 'EPD' <- 'numpy'
+          Can only install one of: (+numpy-1.8.1-1 | +numpy-1.6.0-5)
+      Requirements: 'EPD' <- 'numpy == 1.6.0-5'
+          EPD-7.1-1 requires (+numpy-1.6.0-5)

--- a/simplesat/tests/epd_full_conflict.yaml
+++ b/simplesat/tests/epd_full_conflict.yaml
@@ -2020,12 +2020,12 @@ request:
 
 
 failure:
-  requirements: ['numpy > 1.8.0-0', 'EPD']
+  requirements: ['EPD', 'numpy > 1.8.0-0']
   raw: |
       Conflicting requirements:
-      Requirements: 'numpy > 1.8.0-0'
-          Install command rule (+numpy-1.8.0-1 | +numpy-1.8.0-2 | +numpy-1.8.0-3 | +numpy-1.8.1-1)
-      Requirements: 'EPD' <- 'numpy'
-          Can only install one of: (+numpy-1.8.1-1 | +numpy-1.6.0-5)
       Requirements: 'EPD' <- 'numpy == 1.6.0-5'
           EPD-7.1-1 requires (+numpy-1.6.0-5)
+      Requirements: 'EPD' <- 'numpy'
+          Can only install one of: (+numpy-1.8.1-1 | +numpy-1.6.0-5)
+      Requirements: 'numpy > 1.8.0-0'
+          Install command rule (+numpy-1.8.0-1 | +numpy-1.8.0-2 | +numpy-1.8.0-3 | +numpy-1.8.1-1)

--- a/simplesat/tests/epd_full_conflict.yaml
+++ b/simplesat/tests/epd_full_conflict.yaml
@@ -2023,9 +2023,9 @@ failure:
   requirements: ['EPD', 'numpy > 1.8.0-0']
   raw: |
       Conflicting requirements:
-      Requirements: 'numpy == 1.6.0-5' <- 'EPD'
+      Requirements: 'EPD' <- 'numpy == 1.6.0-5'
           EPD-7.1-1 requires (+numpy-1.6.0-5)
-      Requirements: 'numpy' <- 'EPD'
+      Requirements: 'EPD' <- 'numpy'
           Can only install one of: (+numpy-1.8.1-1 | +numpy-1.6.0-5)
       Requirements: 'numpy > 1.8.0-0'
           Install command rule (+numpy-1.8.0-1 | +numpy-1.8.0-2 | +numpy-1.8.0-3 | +numpy-1.8.1-1)

--- a/simplesat/tests/explicit_conflict.yaml
+++ b/simplesat/tests/explicit_conflict.yaml
@@ -15,7 +15,7 @@ failure:
     Conflicting requirements:
     Requirements: 'atom'
         Install command rule (+atom-1.0.0-1)
-    Requirements: 'gdata ^= 1.0.0' <- 'atom'
+    Requirements: 'atom' <- 'gdata ^= 1.0.0'
         gdata-1.0.0-1 conflicts with +atom-1.0.0-1
     Requirements: 'gdata'
         Install command rule (+gdata-1.0.0-1)

--- a/simplesat/tests/simple_numpy_installed_blocking.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking.yaml
@@ -31,7 +31,5 @@ failure:
             Can only install one of: (+MKL-10.2-1 | +MKL-10.3-1)
         Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1'
             numpy-1.8.1-2 requires (+MKL-10.3-1)
-        Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1'
-            numpy-1.8.1-1 requires (+MKL-10.3-1)
         Requirements: 'numpy > 1.8-0'
             Install command rule (+numpy-1.8.1-1 | +numpy-1.8.1-2)

--- a/simplesat/tests/simple_numpy_installed_blocking.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking.yaml
@@ -20,18 +20,18 @@ installed:
     - numpy 1.7.1-1
 
 failure:
-    requirements: ['numpy > 1.8-0', 'EPD_free']
+    requirements: ['EPD_free', 'numpy > 1.8-0']
     raw: |
         Conflicting requirements:
-        Requirements: 'numpy > 1.8-0'
-            Install command rule (+numpy-1.8.1-1 | +numpy-1.8.1-2)
+        Requirements: 'EPD_free'
+            Install command rule (+EPD_free-7.3-1)
+        Requirements: 'EPD_free' <- 'MKL == 10.2-1'
+            EPD_free-7.3-1 requires (+MKL-10.2-1)
+        Requirements: 'numpy > 1.8-0' <- 'MKL'
+            Can only install one of: (+MKL-10.2-1 | +MKL-10.3-1)
         Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1'
             numpy-1.8.1-2 requires (+MKL-10.3-1)
         Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1'
             numpy-1.8.1-1 requires (+MKL-10.3-1)
-        Requirements: 'numpy > 1.8-0' <- 'MKL'
-            Can only install one of: (+MKL-10.2-1 | +MKL-10.3-1)
-        Requirements: 'EPD_free' <- 'MKL == 10.2-1'
-            EPD_free-7.3-1 requires (+MKL-10.2-1)
-        Requirements: 'EPD_free'
-            Install command rule (+EPD_free-7.3-1)
+        Requirements: 'numpy > 1.8-0'
+            Install command rule (+numpy-1.8.1-1 | +numpy-1.8.1-2)

--- a/simplesat/tests/simple_numpy_installed_blocking.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking.yaml
@@ -27,6 +27,8 @@ failure:
             Install command rule (+numpy-1.8.1-1 | +numpy-1.8.1-2)
         Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1'
             numpy-1.8.1-2 requires (+MKL-10.3-1)
+        Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1'
+            numpy-1.8.1-1 requires (+MKL-10.3-1)
         Requirements: 'numpy > 1.8-0' <- 'MKL'
             Can only install one of: (+MKL-10.2-1 | +MKL-10.3-1)
         Requirements: 'EPD_free' <- 'MKL == 10.2-1'

--- a/simplesat/tests/simple_numpy_installed_blocking.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking.yaml
@@ -25,11 +25,11 @@ failure:
         Conflicting requirements:
         Requirements: 'numpy > 1.8-0'
             Install command rule (+numpy-1.8.1-1 | +numpy-1.8.1-2)
-        Requirements: 'MKL == 10.3-1' <- 'numpy > 1.8-0'
+        Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1'
             numpy-1.8.1-2 requires (+MKL-10.3-1)
-        Requirements: 'MKL' <- 'numpy > 1.8-0'
+        Requirements: 'numpy > 1.8-0' <- 'MKL'
             Can only install one of: (+MKL-10.2-1 | +MKL-10.3-1)
-        Requirements: 'MKL == 10.2-1' <- 'EPD_free'
+        Requirements: 'EPD_free' <- 'MKL == 10.2-1'
             EPD_free-7.3-1 requires (+MKL-10.2-1)
         Requirements: 'EPD_free'
             Install command rule (+EPD_free-7.3-1)

--- a/simplesat/tests/simple_numpy_installed_blocking_downgrade.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking_downgrade.yaml
@@ -24,9 +24,9 @@ failure:
         Conflicting requirements:
         Requirements: 'numpy < 1.8-0'
             Install command rule (+numpy-1.7.1-1)
-        Requirements: 'numpy' <- 'numpy < 1.8-0'
+        Requirements: 'numpy < 1.8-0' <- 'numpy'
             Can only install one of: (+numpy-1.8.1-1 | +numpy-1.7.1-1)
-        Requirements: 'numpy == 1.8.1-1' <- 'EPD_free'
+        Requirements: 'EPD_free' <- 'numpy == 1.8.1-1'
             EPD_free-7.4-1 requires (+numpy-1.8.1-1)
         Requirements: 'EPD_free'
             Install command rule (+EPD_free-7.4-1)

--- a/simplesat/tests/simple_numpy_installed_blocking_downgrade.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking_downgrade.yaml
@@ -19,14 +19,14 @@ installed:
     - numpy 1.8.1-1
 
 failure:
-    requirements: ['numpy < 1.8-0', 'EPD_free']
+    requirements: ['EPD_free', 'numpy < 1.8-0']
     raw: |
         Conflicting requirements:
-        Requirements: 'numpy < 1.8-0'
-            Install command rule (+numpy-1.7.1-1)
-        Requirements: 'numpy < 1.8-0' <- 'numpy'
-            Can only install one of: (+numpy-1.8.1-1 | +numpy-1.7.1-1)
-        Requirements: 'EPD_free' <- 'numpy == 1.8.1-1'
-            EPD_free-7.4-1 requires (+numpy-1.8.1-1)
         Requirements: 'EPD_free'
             Install command rule (+EPD_free-7.4-1)
+        Requirements: 'EPD_free' <- 'numpy == 1.8.1-1'
+            EPD_free-7.4-1 requires (+numpy-1.8.1-1)
+        Requirements: 'numpy < 1.8-0' <- 'numpy'
+            Can only install one of: (+numpy-1.8.1-1 | +numpy-1.7.1-1)
+        Requirements: 'numpy < 1.8-0'
+            Install command rule (+numpy-1.7.1-1)

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -148,6 +148,9 @@ class TestNoInstallSet(ScenarioTestAssistant, TestCase):
         with self.assertRaises(NoPackageFound):
             self._check_solution("no_candidate.yaml")
 
+    def test_three_way_conflict(self):
+        self._check_solution("three_way_conflict.yaml")
+
 
 class TestInstallSet(ScenarioTestAssistant, TestCase):
 

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -80,7 +80,7 @@ class ScenarioTestAssistant(object):
         try:
             transaction = solver.solve(request)
         except SatisfiabilityError as failure:
-            self.assertEqualFailure(pool, failure, scenario)
+            self.assertFailureEqual(pool, failure, scenario)
         else:
             if scenario.failed:
                 msg = "Solver unexpectedly succeeded, but {0}."
@@ -92,7 +92,7 @@ class ScenarioTestAssistant(object):
                 self.assertEqualOperations(transaction.pretty_operations,
                                            scenario.pretty_operations)
 
-    def assertEqualFailure(self, pool, failure, scenario):
+    def assertFailureEqual(self, pool, failure, scenario):
         if not scenario.failed:
             msg = "Solver unexpectedly failed"
             if failure.unsat:
@@ -100,13 +100,13 @@ class ScenarioTestAssistant(object):
                 msg += ":\n{0}".format(reason)
             self.fail(msg)
 
-        req_names = [str(r) for r in failure.unsat.requirements]
-        r_names = scenario.failure['requirements']
-        self.assertEqual(req_names, r_names)
+        result = [str(r) for r in failure.unsat.requirements]
+        expected = scenario.failure['requirements']
+        self.assertEqual(expected, result)
 
-        message = failure.unsat.to_string(pool=pool)
-        r_message = scenario.failure['raw']
-        self.assertMultiLineEqual(message, r_message)
+        result = failure.unsat.to_string(pool=pool)
+        expected = scenario.failure['raw']
+        self.assertMultiLineEqual(expected, result)
 
     def assertEqualOperations(self, operations, scenario_operations):
         pairs = zip(operations, scenario_operations)

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -106,7 +106,7 @@ class ScenarioTestAssistant(object):
 
         message = failure.unsat.to_string(pool=pool)
         r_message = scenario.failure['raw']
-        self.assertEqual(message, r_message)
+        self.assertMultiLineEqual(message, r_message)
 
     def assertEqualOperations(self, operations, scenario_operations):
         pairs = zip(operations, scenario_operations)

--- a/simplesat/tests/three_way_conflict.yaml
+++ b/simplesat/tests/three_way_conflict.yaml
@@ -1,0 +1,32 @@
+
+packages:
+  - A 1.0.0-1
+  - A 2.0.0-1
+  - C 1.0.0-1; depends (A)
+  - D 1.0.0-1; conflicts (A ^= 1.0)
+  - E 1.0.0-1; conflicts (A ^= 2.0)
+
+request:
+  - operation: "install"
+    requirement: "C"
+  - operation: "install"
+    requirement: "D"
+  - operation: "install"
+    requirement: "E"
+
+failure:
+  requirements: ['C', 'E', 'D']
+  raw: |
+    Conflicting requirements:
+    Requirements: 'C'
+        Install command rule (+C-1.0.0-1)
+    Requirements: 'C' <- 'A'
+        C-1.0.0-1 requires (+A-1.0.0-1 | +A-2.0.0-1)
+    Requirements: 'E' <- 'A ^= 2.0'
+        E-1.0.0-1 conflicts with +A-2.0.0-1
+    Requirements: 'E'
+        Install command rule (+E-1.0.0-1)
+    Requirements: 'D' <- 'A ^= 1.0'
+        D-1.0.0-1 conflicts with +A-1.0.0-1
+    Requirements: 'D'
+        Install command rule (+D-1.0.0-1)

--- a/simplesat/tests/three_way_conflict.yaml
+++ b/simplesat/tests/three_way_conflict.yaml
@@ -14,19 +14,26 @@ request:
   - operation: "install"
     requirement: "E"
 
+installed:
+  - "A 1.0.0-1"
+  - "C 1.0.0-1"
+
+marked:
+  - "C"
+
 failure:
-  requirements: ['C', 'E', 'D']
+  requirements: ['C', 'D', 'E']
   raw: |
     Conflicting requirements:
     Requirements: 'C'
         Install command rule (+C-1.0.0-1)
     Requirements: 'C' <- 'A'
         C-1.0.0-1 requires (+A-1.0.0-1 | +A-2.0.0-1)
+    Requirements: 'D' <- 'A ^= 1.0'
+        A-1.0.0-1 conflicts with +D-1.0.0-1
+    Requirements: 'D'
+        Install command rule (+D-1.0.0-1)
     Requirements: 'E' <- 'A ^= 2.0'
         E-1.0.0-1 conflicts with +A-2.0.0-1
     Requirements: 'E'
         Install command rule (+E-1.0.0-1)
-    Requirements: 'D' <- 'A ^= 1.0'
-        D-1.0.0-1 conflicts with +A-1.0.0-1
-    Requirements: 'D'
-        Install command rule (+D-1.0.0-1)

--- a/simplesat/tests/three_way_conflict.yaml
+++ b/simplesat/tests/three_way_conflict.yaml
@@ -33,6 +33,12 @@ failure:
         A-1.0.0-1 conflicts with +D-1.0.0-1
     Requirements: 'D'
         Install command rule (+D-1.0.0-1)
+
+    Conflicting requirements:
+    Requirements: 'C'
+        Install command rule (+C-1.0.0-1)
+    Requirements: 'C' <- 'A'
+        C-1.0.0-1 requires (+A-1.0.0-1 | +A-2.0.0-1)
     Requirements: 'E' <- 'A ^= 2.0'
         E-1.0.0-1 conflicts with +A-2.0.0-1
     Requirements: 'E'

--- a/simplesat/tests/update_all_conflict.yaml
+++ b/simplesat/tests/update_all_conflict.yaml
@@ -29,7 +29,7 @@ failure:
         Update to latest command rule (+numpy-1.9.2-2)
     Requirements: 'numpy' <- 'numpy'
         Can only install one of: (+numpy-1.9.2-2 | +numpy-1.9.2-1)
-    Requirements: 'numpy == 1.9.2-1' <- 'pandas'
+    Requirements: 'pandas' <- 'numpy == 1.9.2-1'
         pandas-0.18.0-1 requires (+numpy-1.9.2-1)
     Requirements: 'pandas'
         Update to latest command rule (+pandas-0.18.0-1)

--- a/simplesat/utils/graph.py
+++ b/simplesat/utils/graph.py
@@ -123,7 +123,7 @@ def connected_nodes(node, neighbor_func, visited=None):
 
 
 def backtrack(end, start, visited):
-    """ Return a list of nodes from `start` to `end` by recursively looking up
+    """ Return a tuple of nodes from `start` to `end` by recursively looking up
     the current node in `visited`. `visited` is a dictionary of one-way edges
     between nodes.
     """
@@ -132,7 +132,7 @@ def backtrack(end, start, visited):
     while node != start:
         node = visited[node]
         path.append(node)
-    return list(reversed(path))
+    return tuple(reversed(path))
 
 
 def breadth_first_search(start, neighbor_func, targets,

--- a/simplesat/utils/graph.py
+++ b/simplesat/utils/graph.py
@@ -138,9 +138,9 @@ def backtrack(end, start, visited):
 def breadth_first_search(start, neighbor_func, targets,
                          target_func=None, visited=None):
     """
-    Return an iterable of paths from `start` to each terminal node `end` such
-    that `terminate_func(end)` is in `targets`, by following neighbors as given
-    by `neighborfunc(node)`.
+    Return an iterable of paths from `start` to each reachable terminal node
+    `end` such that `terminate_func(end)` is in `targets`, by following
+    neighbors as given by `neighborfunc(node)`.
 
     Parameters
     ----------
@@ -178,5 +178,3 @@ def breadth_first_search(start, neighbor_func, targets,
                 continue
             queue.append(neighbor)
             visited[neighbor] = node
-    else:
-        yield ()

--- a/simplesat/utils/graph.py
+++ b/simplesat/utils/graph.py
@@ -135,24 +135,48 @@ def backtrack(end, start, visited):
     return list(reversed(path))
 
 
-def breadth_first_search(start, neighbor_func, terminate_func, visited=None):
+def breadth_first_search(start, neighbor_func, targets,
+                         target_func=None, visited=None):
     """
-    Return a path from `start` to `end` such that `terminate_func(end)` is
-    True by following neighbors as given by `neighborfunc(node)`.
+    Return an iterable of paths from `start` to each terminal node `end` such
+    that `terminate_func(end)` is in `targets`, by following neighbors as given
+    by `neighborfunc(node)`.
 
-    `visited` is used both to track the current path and to avoid recomputing
-    sections of the graph that have been visited before.
+    Parameters
+    ----------
+    start : node
+        The starting point of the search
+    neighbor_func : callable
+        neighbor_func(start) returns an iterable of nodes to visit
+    targets : set
+        The nodes we're searching for. The search terminates when each member
+        of `targets` has been encountered at least once, but only path is
+        returned per target.
+    target_func : callable (optional)
+        If given, then `target_func` is applied to node and the result
+        is used to determine if `node` is a target.
+    visited : dict (optional)
+        If given, it will be used to track the current path. You can use it to
+        directly inspect the search path after calling breadth_first_search().
     """
     queue = deque([start])
     visited = {} if visited is None else visited
     visited[start] = None
+    targets = set(targets)
     while queue:
         node = queue.popleft()
-        if terminate_func(node):
-            return backtrack(node, start, visited), visited
+        found = target_func(node) if target_func else node
+        if found in targets:
+            # We found an important node. Yield the path to this node.
+            targets.remove(found)
+            yield backtrack(node, start, visited)
+        if not targets:
+            # There are no more important nodes, we're done.
+            break
         for neighbor in neighbor_func(node):
             if neighbor in visited:
                 continue
             queue.append(neighbor)
             visited[neighbor] = node
-    return [], visited
+    else:
+        yield ()


### PR DESCRIPTION
This adds more comments and docstrings to the conflict handling code in UNSAT.

A major change is that the BFS now correctly returns paths that touch *all* of the end_points you give it. Before we simply stopped after the first one and got lucky because we had no tests for conflicts caused by three or more requirements together. We should catch those now and I've added a scenario with a made-up one in it.

This also fixes a non-determinism bug where python2 gives an arbitrary ordering to subclasses of `object`, so calls to `max`, `sorted` etc can differ based on the hash seed.