### PR TITLE
Use keyword arg syntax when constructing RulesGenerator

### DIFF
--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -85,7 +85,8 @@ class DependencySolver(object):
         for package in installed_repository:
             installed_map[pool.package_id(package)] = package
 
-        rules_generator = RulesGenerator(pool, request, installed_map)
+        rules_generator = RulesGenerator(
+            pool, request, installed_map=installed_map)
 
         return all_requirement_ids, list(rules_generator.iter_rules())
 

--- a/simplesat/test_utils.py
+++ b/simplesat/test_utils.py
@@ -38,7 +38,8 @@ def generate_rules_for_requirement(pool, requirement, installed_map=None):
     request = Request()
     request.install(requirement)
 
-    rules_generator = RulesGenerator(pool, request, installed_map)
+    rules_generator = RulesGenerator(
+        pool, request, installed_map=installed_map)
     rules = list(rules_generator.iter_rules())
     return rules
 

--- a/simplesat/tests/test_rules_generator.py
+++ b/simplesat/tests/test_rules_generator.py
@@ -33,7 +33,8 @@ class TestRulesGenerator(unittest.TestCase):
         pool = Pool(repos)
         installed_map = {
             pool.package_id(p): p for p in scenario.installed_repository}
-        rules_generator = RulesGenerator(pool, scenario.request, installed_map)
+        rules_generator = RulesGenerator(
+            pool, scenario.request, installed_map=installed_map)
         rules = list(rules_generator.iter_rules())
 
         # Then
@@ -79,7 +80,8 @@ class TestRulesGenerator(unittest.TestCase):
         pool = Pool(repos)
         installed_map = {
             pool.package_id(p): p for p in scenario.installed_repository}
-        rules_generator = RulesGenerator(pool, scenario.request, installed_map)
+        rules_generator = RulesGenerator(
+            pool, scenario.request, installed_map=installed_map)
         rules = list(rules_generator.iter_rules())
 
         # Then
@@ -120,7 +122,8 @@ class TestRulesGenerator(unittest.TestCase):
         pool = Pool(repos)
         installed_map = {
             pool.package_id(p): p for p in scenario.installed_repository}
-        rules_generator = RulesGenerator(pool, scenario.request, installed_map)
+        rules_generator = RulesGenerator(
+            pool, scenario.request, installed_map=installed_map)
 
         # Then
         with self.assertRaises(NoPackageFound):
@@ -145,7 +148,8 @@ class TestRulesGenerator(unittest.TestCase):
         pool = Pool(repos)
         installed_map = {
             pool.package_id(p): p for p in scenario.installed_repository}
-        rules_generator = RulesGenerator(pool, scenario.request, installed_map)
+        rules_generator = RulesGenerator(
+            pool, scenario.request, installed_map=installed_map)
 
         # Then
         with self.assertRaises(NoPackageFound):


### PR DESCRIPTION
Wasted a bit of time before I realized that most call-sites weren't doing this and my args were ending up in the wrong order.

Someday the world will be on Python 3 and we can pretend this never happened. 