### PR TITLE
BUG: don't trim long php exception error messages

### DIFF
--- a/scripts/print_operations.php.in
+++ b/scripts/print_operations.php.in
@@ -70,4 +70,8 @@ class DebuggingSolver extends Solver
 $policy = new DefaultPolicy();
 
 $solver = new DebuggingSolver($policy, $pool, $installed_repo);
-$solver->print_operations($request);
+try {
+    $solver->print_operations($request);
+} catch (Exception $e) {
+    echo 'Exception:', $e->getMessage();
+}


### PR DESCRIPTION
When they are very long, php doesn't display the whole thing, for whatever reason.

Here I'm just printing it out. It's usually going to be a description of a conflict and might be lengthy.