### PR TITLE
ENH: be stricter about distribution name and version parsing

### DIFF
--- a/scripts/index_to_scary_package_strings.py
+++ b/scripts/index_to_scary_package_strings.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+import csv
+import string
+
+_fro = (string.ascii_lowercase +
+        string.ascii_uppercase +
+        string.digits)
+_to = ('a' * len(string.ascii_lowercase) +
+       'A' * len(string.ascii_uppercase) +
+       '0' * len(string.digits))
+TRANS = string.maketrans(_fro, _to)
+
+
+def proc(s):
+    return len(set(string.translate(s, TRANS)))
+
+
+def make_names_vers(lines):
+    reader = csv.reader(lines)
+    # Ignore header
+    next(reader)
+
+    for row in reader:
+        name = row[1].strip()
+        ver = row[2].strip()
+        yield (name, ver)
+
+
+def build_terrible_packages(names, vers):
+    worst_names = sorted(names, key=proc, reverse=True)
+    worst_versions = sorted(vers, key=proc, reverse=True)
+    return tuple(' '.join(s) for s in zip(worst_names, worst_versions))
+
+
+def build_long_packages(names, vers):
+    worst_names = sorted(names, key=len, reverse=True)
+    worst_versions = sorted(vers, key=len, reverse=True)
+    return tuple(' '.join(s) for s in zip(worst_names, worst_versions))
+
+
+def main():
+    """Run main."""
+    import argparse
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument('index_file', type=argparse.FileType())
+    parser.add_argument('out_file')
+    args = parser.parse_args(['brood-test-jaguar-dump.csv', 'out.txt'])
+    names, vers = zip(*make_names_vers(args.index_file))
+    terribles = build_terrible_packages(names, vers)
+    longs = build_long_packages(names, vers)
+
+    worsts = sorted(
+        set(terribles[:100] + terribles[-10:] + longs[:100] + longs[-10:]),
+        key=len)
+
+    with open(args.out_file, 'w') as f:
+        f.writelines('\n'.join(worsts))
+    return 0
+
+
+if __name__ == '__main__':
+    main()

--- a/simplesat/constraints/package_parser.py
+++ b/simplesat/constraints/package_parser.py
@@ -124,8 +124,12 @@ def package_to_pretty_string(package):
 
 
 def _parse_preamble(preamble):
-    parts = preamble.strip().split()
-    if not len(parts) == 2:
-        raise ValueError("Invalid preamble: {0!r}".format(preamble))
-    else:
-        return parts[0], parts[1]
+    msg = "Invalid preamble: {0!r}".format(preamble)
+    match = re.match(_DISTRIBUTION_RS + _WS_RS + _VERSION_RS, preamble)
+    if not match:
+        raise ValueError(msg)
+    if match.span()[-1] != len(preamble):
+        msg = msg + ", {!r}".format(match)
+        raise ValueError(msg)
+    groups = match.groupdict()
+    return groups['distribution'], groups['version']

--- a/simplesat/constraints/package_parser.py
+++ b/simplesat/constraints/package_parser.py
@@ -34,6 +34,7 @@ class PrettyPackageStringParser(object):
 
             numpy 1.8.1-1; install_requires (MKL == 10.3, nose ^= 1.3.4); conflicts (numeric)  # noqa
         """
+        pretty_string = pretty_string.strip()
         pkg = {}
 
         try:
@@ -125,11 +126,11 @@ def package_to_pretty_string(package):
 
 def _parse_preamble(preamble):
     msg = "Invalid preamble: {0!r}".format(preamble)
-    match = re.match(_DISTRIBUTION_RS + _WS_RS + _VERSION_RS, preamble)
+    match = PACKAGE_RC.match(preamble)
     if not match:
         raise ValueError(msg)
     if match.span()[-1] != len(preamble):
-        msg = msg + ", {!r}".format(match)
+        msg = msg + ", {!r}".format(match.group(0))
         raise ValueError(msg)
     groups = match.groupdict()
     return groups['distribution'], groups['version']

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -144,7 +144,7 @@ def _tokenize(scanner, requirement_string):
         for part in requirement_string.split(","):
             scanned, remaining = scanner.scan(part.strip())
             if len(remaining) > 0:
-                msg = "Invalid requirement string: {0!r}"
+                msg = "{0!r}"
                 for tok in scanned:
                     if isinstance(tok, DistributionNameToken):
                         msg += "(distribution name: {0!r})".format(tok.value)
@@ -177,8 +177,7 @@ class _RawConstraintsParser(object):
                 assert isinstance(requirement_block[0], AnyToken)
                 return Any()
             else:
-                msg = ("Invalid requirement string: {0!r}".
-                       format(requirement_string))
+                msg = "{0!r}".format(requirement_string)
                 raise InvalidConstraint(msg)
 
         constraints = []
@@ -197,7 +196,7 @@ class _RawRequirementParser(object):
 
     def parse(self, requirement_string, version_factory):
         def compute_constraint(requirement_block):
-            msg = "Invalid requirement {0!r}".format(requirement_string)
+            msg = "{0!r}".format(requirement_string)
 
             if len(requirement_block) == 3:
                 distribution, operator, version = requirement_block

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -10,9 +10,11 @@ from simplesat.constraints.kinds import (
 from simplesat.errors import SolverException
 
 
-# NOTE: re.Scanner seems to ignore (?i), so we have to write case-insensitivity
-# into the regex manually. We must also permit a leading underscore because of
-# names like `_distribute_remove`
+# NOTE: The _DISTRIBUTION_R regex is based on PEP508. Additionally, we remove
+# the '-' because it breaks too many other things to do otherwise. We must also
+# permit a leading underscore because of names like `_distribute_remove`
+# re.Scanner seems to ignore (?i), so we have to write case-insensitivity into
+# the regex manually.
 _DISTRIBUTION_R = r"([a-zA-Z0-9_][a-zA-Z0-9._]*[a-zA-Z0-9]|[a-zA-Z0-9])"
 _VERSION_R = r"(\d\w*(?:\.\w+)*(?:-\w+)?)"
 _EQUAL_R = r"=="

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -12,11 +12,12 @@ from simplesat.errors import SolverException
 
 # NOTE: The _DISTRIBUTION_R regex is based on PEP508. Additionally, we remove
 # the '-' because it breaks too many other things to do otherwise. We must also
-# permit a leading underscore because of names like `_distribute_remove`
-# re.Scanner seems to ignore (?i), so we have to write case-insensitivity into
-# the regex manually.
-_DISTRIBUTION_R = r"([a-zA-Z0-9_][a-zA-Z0-9._]*[a-zA-Z0-9]|[a-zA-Z0-9])"
-_VERSION_R = r"(\d\w*(?:\.\w+)*(?:-\w+)?)"
+# permit a leading or trailling underscore because of names like
+# `_distribute_remove` re.Scanner seems to ignore (?i), so we have to write
+# case-insensitivity into the regex manually.
+_DISTRIBUTION_NAME_R = r"(?!\.)(?:\.?\w+)+(?<!\.)"
+_DISTRIBUTION_R = "({})".format(_DISTRIBUTION_NAME_R)
+_VERSION_R = r"((?=\d){}(?:-\w+)?)".format(_DISTRIBUTION_NAME_R)
 _EQUAL_R = r"=="
 _GEQ_R = r">="
 _GT_R = r">"

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -10,16 +10,20 @@ from simplesat.constraints.kinds import (
 from simplesat.errors import SolverException
 
 
-_VERSION_R = "[^=><!,\s;^][^,\s;]+"
-_EQUAL_R = "=="
-_GEQ_R = ">="
+# NOTE: re.Scanner seems to ignore (?i), so we have to write case-insensitivity
+# into the regex manually. We must also permit a leading underscore because of
+# names like `_distribute_remove`
+_DISTRIBUTION_R = r"([a-zA-Z0-9_][a-zA-Z0-9._]*[a-zA-Z0-9]|[a-zA-Z0-9])"
+_VERSION_R = r"(\d\w*(?:\.\w+)*(?:-\w+)?)"
+_EQUAL_R = r"=="
+_GEQ_R = r">="
 _GT_R = r">"
 _LEQ_R = r"<="
 _LT_R = r"<"
 _NOT_R = r"!="
 _ENPKG_UPSTREAM_MATCH_R = r"\^="
 _ANY_R = r"\*"
-_WS_R = " +"
+_WS_R = r" +"
 
 _CONSTRAINTS_SCANNER = re.Scanner([
     (_VERSION_R, lambda scanner, token: VersionToken(token)),
@@ -35,11 +39,9 @@ _CONSTRAINTS_SCANNER = re.Scanner([
     (_WS_R, lambda scanner, token: None),
 ])
 
-_DISTRIBUTION_R = "[a-zA-Z_][^\s,-]*"
-
 _REQUIREMENTS_SCANNER = re.Scanner([
-    (_DISTRIBUTION_R, lambda scanner, token: DistributionNameToken(token)),
     (_VERSION_R, lambda scanner, token: VersionToken(token)),
+    (_DISTRIBUTION_R, lambda scanner, token: DistributionNameToken(token)),
     (_EQUAL_R, lambda scanner, token: EqualToken(token)),
     (_GEQ_R, lambda scanner, token: GEQToken(token)),
     (_GT_R, lambda scanner, token: GTToken(token)),

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -145,6 +145,12 @@ def _tokenize(scanner, requirement_string):
             scanned, remaining = scanner.scan(part.strip())
             if len(remaining) > 0:
                 msg = "Invalid requirement string: {0!r}"
+                for tok in scanned:
+                    if isinstance(tok, DistributionNameToken):
+                        msg += "(distribution name: {0!r})".format(tok.value)
+                    if isinstance(tok, VersionToken):
+                        msg += "(version: {0!r})".format(tok.value)
+                msg += "(unparsed {0!r})".format(remaining)
                 raise InvalidConstraint(msg.format(requirement_string))
             elif len(scanned) > 0:
                 tokens.append(scanned)

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -193,9 +193,8 @@ class _RawRequirementParser(object):
             if len(requirement_block) == 3:
                 distribution, operator, version = requirement_block
                 name = distribution.value
-                return (
-                    name, (_operator_factory(operator, version, version_factory),)
-                )
+                op = _operator_factory(operator, version, version_factory)
+                return name, (op,)
             elif len(requirement_block) == 2:
                 distribution, operator = requirement_block
                 name = distribution.value

--- a/simplesat/constraints/tests/test_package_parser.py
+++ b/simplesat/constraints/tests/test_package_parser.py
@@ -7,6 +7,7 @@ from okonomiyaki.versions import EnpkgVersion
 from simplesat.constraints.package_parser import (
     PrettyPackageStringParser, package_to_pretty_string
 )
+from simplesat.constraints.requirement import Requirement
 from simplesat.package import PackageMetadata
 
 
@@ -367,3 +368,132 @@ class TestToPackage(unittest.TestCase):
         self.assertEqual(package.name, "numpy")
         self.assertEqual(package.version, V('1.8.1'))
         self.assertEqual(package.install_requires, (("MKL", (("^= 10.3",),)),))
+
+
+class TestParseScaryPackages(unittest.TestCase):
+
+    # NOTE: gathered with 'scripts/index_to_scary_package_strings.py'
+    SCARY_PACKAGE_STRINGS = """
+        wb 19-4
+        qt 2.5-1
+        pytz 19-4
+        ply 214-1
+        _pylor 8a-0
+        pylor_ 4-2
+        sympy 210-1
+        pycdf 210-3
+        zdaemon 210-4
+        argparse 210-5
+        setupdocs 214-2
+        z3c.amf 3.0a1-1
+        traitsgui 210-2
+        ua2.djfab 0.1a1-1
+        z3ext.seo 2.0b8-1
+        tw2.core 1.2.0a1-1
+        lck.i18n 1.2.0a1-1
+        tw2.jquery 1.2.0a1-1
+        p01.fswidget 1.0b2-1
+        multiprocessing 214-2
+        z3ext.content 2.0b1-1
+        webapp2_static 1.0b2-1
+        z3c.offlinepack 1.0b4-1
+        js.jquery_jqote2 1.0b3-1
+        p01.recipe.setup 1.0a3-1
+        js.jquery_jqote2 0.1a1-1
+        z3c.checkversions 0.1a2-1
+        z3ext.preferences 1.0b7-1
+        js.jquery_jqote2 2.0b11-1
+        z3c.repoexternals 1.0b1-1
+        js.jquery_jqote2 1.2.0a1-1
+        py_1digit_checksum 1.0b2-1
+        sphinxjp.themes.s6 4.5b1-1
+        z3c.layer.ready2go 0.1b8-1
+        z3ext.content.forms 1.2.0a1-1
+        z3ext.portlets.recent 0.1.0a2-1
+        o2w_cache_invalidator 1.2.0a1-1
+        z3c.setuptools_mercurial 1.0b1-1
+        isotoma.depends.plone4_1 1.0b4-1
+        z3c.setuptools_mercurial 1.7b5-1
+        isotoma.depends.plone4_1 1.0a1-1
+        z3c.setuptools_mercurial 1.0a2-1
+        example.rtsubsites_theme 1.0rc4-1
+        isotoma.depends.zope2_13_8 2.0b7-1
+        isotoma.depends.plone4_1 1.5.0b1-1
+        isotoma.depends.zope2_13_8 1.2b1-1
+        isotoma.depends.zope2_13_8 1.7b4-1
+        z3c.setuptools_mercurial 2.0.1b1-1
+        c2.search.customdescription 2.0b2-1
+        isotoma.depends.zope2_13_8 1.3rc5-1
+        tiddlywebplugins.sqlalchemy2 1.0b2-1
+        products.zope_hotfix_20110622 0.1a1-1
+        plonetheme.greenearththeme3_0 2.0b9-1
+        plonetheme.greenearththeme3_0 0.1a1-1
+        products.zope_hotfix_20110622 3.0a1-1
+        plonetheme.greenearththeme3_0 1.0b3-1
+        products.zope_hotfix_20111024 0.2a1-1
+        isotoma.depends.plone4_1 4.3.0.dev80-1
+        isotoma.recipe.zope2instance 1.2.0a1-1
+        products.zope_hotfix_20111024 0.1b12-1
+        products.zope_hotfix_20111024 2.1.1a1-1
+        products.zope_hotfix_20111024 1.2.0a1-1
+        d51.django.virtualenv.test_runner 1.0b1-1
+        products.zope_hotfix_cve_2010_3198 0.1a1-1
+        products.zope_hotfix_cve_2010_1104 1.0a5-1
+        products.zope_hotfix_cve_2011_3587 2.0b4-1
+        d51.django.virtualenv.test_runner 1.0rc11-1
+        d51.django.virtualenv.test_runner 1.2.0a1-1
+        products.zope_hotfix_cve_2011_3587 0.8.0b1-1
+        collective.z3cform.datagridfield_demo 2.0b9-1
+        collective.z3cform.datagridfield_demo 1.2.0a1-1
+        collective.z3cform.datagridfield_demo 2.5.4rc-1
+        collective.z3cform.datagridfield_demo 1.3a7.1-1
+        products.zope_hotfix_cve_2010_3198 4.3.0.dev80-1
+        collective.z3cform.datagridfield_demo 4.3.0.dev29-1
+        collective.blueprint.translationlinker 0.10.2.dev4396-1
+        trytond_account_invoice_line_standalone 0.10.2.dev4365-1
+        pyf.components.postprocess.email_sender 0.12.0.dev4791-1
+        pyf.components.consumers.xhtmlpdfwriter 0.12.0.dev4716-1
+        trytond_purchase_invoice_line_standalone 0.12.0.dev4681-1
+        experimental.daterangeindexoptimisations 0.11.0.dev4622-1
+        trytond_purchase_invoice_line_standalone 0.12.4.dev4948-1
+        harobed.paster_template.advanced_package 0.13.0.dev5015-1
+        trytond_purchase_invoice_line_standalone 0.11.0.dev4638-1
+        trytond_purchase_invoice_line_standalone 2.0.4.dev25071-1
+        trytond_purchase_invoice_line_standalone 0.11.0.dev4629-1
+        harobed.paster_template.advanced_package 2.0.4.dev25079-1
+        harobed.paster_template.advanced_package 0.12.0.dev4690-1
+        trytond_purchase_invoice_line_standalone 0.11.0.dev4670-1
+        trytond_purchase_invoice_line_standalone 0.11.0.dev4647-1
+        trytond_purchase_invoice_line_standalone 2.0.4.dev25079-1
+        trytond_purchase_invoice_line_standalone 0.3.1.dev0-20160104
+        trytond_purchase_invoice_line_standalone 0.3.0.dev0-20151222
+        data_analysis_common_reader_writers_addon 0.3.0.dev0-20151217
+        """.strip().splitlines()
+
+    def test_pretty_package_parse(self):
+        # Given
+        parser = PrettyPackageStringParser(EnpkgVersion.from_string)
+        package_strings = self.SCARY_PACKAGE_STRINGS
+
+        # When
+        for package_string in package_strings:
+            # When
+            package = parser.parse_to_package(package_string)
+            expected = tuple(package_string.split())
+            result = (package.name, str(package.version))
+
+            # Then
+            self.assertEqual(expected, result)
+
+    def test_requirement_parsing(self):
+        # Given
+        package_strings = self.SCARY_PACKAGE_STRINGS
+
+        # When
+        for package_string in package_strings:
+            name, version = package_string.split()
+            expected = name + ' == ' + version
+            result = str(Requirement._from_string(expected))
+
+            # Then
+            self.assertEqual(expected, result)


### PR DESCRIPTION
This tries hard to be more strict about what we accept as a valid distribution name.

I've tested on all the distribution names in the index and was able to round trip them all through a Requirement object successfully.

