### PR TITLE
 Support ad-hoc tightening of constraints 2

### DIFF
--- a/simplesat/request.py
+++ b/simplesat/request.py
@@ -9,6 +9,7 @@ class JobType(Enum):
     install = 1
     remove = 2
     update = 3
+    constrain = 4
 
 
 @attributes

--- a/simplesat/rules_generator.py
+++ b/simplesat/rules_generator.py
@@ -14,6 +14,7 @@ class RuleType(enum.Enum):
     job_install = 2
     job_remove = 3
     job_update = 4
+    job_constrain = 5
     package_requires = 7
     package_conflicts = 8
     package_same_name = 10
@@ -91,6 +92,8 @@ class PackageRule(object):
             rule_desc = "Update to latest command rule ({})".format(s)
         elif self._reason == RuleType.job_remove:
             rule_desc = "Remove command rule ({})".format(s)
+        elif self._reason == RuleType.job_constrain:
+            rule_desc = "Ad-hoc constraint ({})".format(s)
         elif self._reason == RuleType.package_same_name:
             parts = [pool.id_to_string(abs(literal))
                      for literal in self.literals]
@@ -402,6 +405,49 @@ class RulesGenerator(object):
         )
         self._add_rule(rule, "job")
 
+    def _add_constrain_job_rules(self, job):
+        """
+        Add ad-hoc rules that constrain the solution to satisfy the
+        requirement.
+
+        This operation differs from just adding an "install" rule in that that
+        it does *not* force installation of any packages. I.e. the solution
+        must *not* satisfy the *negation* of the requirement given.
+
+        For example the install job for "MKL > 10.0" would translate to "Must
+        install an MKL version greater than 10.0.0-0," whereas a constrain job
+        would be read as "Must not install an MKL version less than or equal to
+        10.0.0-0."
+
+        """
+        # XXX: an alternative approach might be to actually negate the
+        # constraint, but that requires more logic and seems more likely to
+        # need special rules for edge cases.
+
+        # If we supported compound constraints, this would all be much easier.
+
+        R = Requirement._from_string
+        name_package_ids = set(
+            self._pool.package_id(p)
+            for p in self._pool.what_provides(R(job.requirement.name))
+        )
+        matched_package_ids = set(
+            self._pool.package_id(p)
+            for p in self._pool.what_provides(job.requirement)
+        )
+        package_ids = name_package_ids.difference(matched_package_ids)
+
+        if len(package_ids) == 0:
+            return
+
+        for package_id in sorted(package_ids):
+            rule = PackageRule(
+                (-package_id,),
+                RuleType.job_constrain,
+                requirements=[job.requirement],
+            )
+            self._add_rule(rule, "job")
+
     def _add_installed_package_rules(self, package):
         packages_all_versions = self._pool.name_to_packages(package.name)
         for other in packages_all_versions:
@@ -415,6 +461,8 @@ class RulesGenerator(object):
                 self._add_remove_job_rules(job)
             elif job.kind == JobType.update:
                 self._add_update_job_rules(job)
+            elif job.kind == JobType.constrain:
+                self._add_constrain_job_rules(job)
             else:
                 msg = "Job kind {0!r} not supported".format(job.kind)
                 raise NotImplementedError(msg)

--- a/simplesat/tests/constraint_modifiers.yaml
+++ b/simplesat/tests/constraint_modifiers.yaml
@@ -3,11 +3,14 @@ packages:
   - A 1.0.0-1;
   - A 2.0.0-1;
   - A 2.1.0-1;
-  - B 1.0.0-1; depends (A ^= 1.0, A != 2.1.0-1)
+  - A 3.0.0-1;
+  - B 1.0.0-1; depends (A != 2.1.0-1)
+  - B 1.2.0-1; depends (A != 2.1.0-1, A >= 1.0, A < 3.0)
   - B 2.0.0-1; depends (A != 2.1.0-1)
   - C 1.0.0-1; depends (B > 2.0.0-1)
   - D 1.0.0-1;
   - E 1.0.0-1; depends (C > 2.0, D < 1.0)
+  - F 1.0.0-1;
 
 installed:
   - A 0.0.1-1
@@ -22,20 +25,22 @@ modifiers:
     - D
 
 request:
-  - operation: "install"
-    requirement: "B ^= 1.0.0"
+  - operation: "constrain"
+    requirement: "B ^= 1.2.0"
   - operation: "install"
     requirement: "E"
+  - operation: "constrain"  # Shouldn't fail because it won't install anything
+    requirement: "F > 2.0"
 
 transaction:
   - kind: "remove"
     package: "A 0.0.1-1"
   - kind: "install"
-    package: "A 2.0.0-1"
+    package: "A 3.0.0-1"
   - kind: "install"
     package: "D 1.0.0-1"
   - kind: "install"
-    package: "B 1.0.0-1"
+    package: "B 1.2.0-1"
   - kind: "install"
     package: "C 1.0.0-1"
   - kind: "install"
@@ -44,11 +49,11 @@ transaction:
 pretty_transaction:
   - kind: "update"
     from: "A 0.0.1-1"
-    to: "A 2.0.0-1"
+    to: "A 3.0.0-1"
   - kind: "install"
     package: "D 1.0.0-1"
   - kind: "install"
-    package: "B 1.0.0-1"
+    package: "B 1.2.0-1"
   - kind: "install"
     package: "C 1.0.0-1"
   - kind: "install"

--- a/simplesat/tests/test_rules_generator.py
+++ b/simplesat/tests/test_rules_generator.py
@@ -191,3 +191,33 @@ class TestRulesGenerator(unittest.TestCase):
         expected = (-1, 2, 3)
         result = rule.literals
         self.assertEqual(expected, result)
+
+    def test_adhoc_constraint(self):
+        # Given
+        yaml = u"""
+            packages:
+              - quark 1.1.0-1
+              - quark 1.2.0-1
+              - quark 2.1.0-1
+              - quark 3.1.0-1
+
+            request:
+              - operation: "constrain"
+                requirement: "quark > 2.0"
+        """
+        scenario = Scenario.from_yaml(io.StringIO(yaml))
+        repos = list(scenario.remote_repositories)
+        repos.append(scenario.installed_repository)
+        pool = Pool(repos)
+        installed_map = {
+            pool.package_id(p): p for p in scenario.installed_repository}
+
+        # When
+        rules_generator = RulesGenerator(pool, scenario.request, installed_map)
+        rules = tuple(rules_generator.iter_rules())
+
+        # Then
+        self.assertEqual(len(rules), 2)
+        for rule, expected in zip(rules, ((-1,), (-2,))):
+            result = rule.literals
+            self.assertEqual(expected, result)


### PR DESCRIPTION
# This PR is against #140, *NOT* `master`. This is for comparison.

This is a rebase of #141 on top of the improved #140.

I'm still researching the various uses of this, but as you can see, our current architecture gives it to us very cheaply, regardless.

One use for this from an IT perspective might be simply to exercise control over the package set deployed site-wide. An administrator, independent of any particular application, might be interested in preventing a particular package version from being installed. For example, pinning `FooBar` to `>= 0.18, < 0.19` until they can certify the 0.19 series.

My original idea was to use this feature in conjunction with some kind of list of blessed versions to help in recreating an environment, for example via a Cargo-style lock file.