### PR TITLE
ENH: track package requirements through the work_queue

### DIFF
--- a/simplesat/rules_generator.py
+++ b/simplesat/rules_generator.py
@@ -309,7 +309,7 @@ class RulesGenerator(object):
             self._add_rule(rule, "package")
 
             for candidate in dependency_candidates:
-                work_queue.append(candidate)
+                work_queue.append((candidate, combined_requirements))
 
     def _add_conflicts_rules(self, package, requirements):
         """
@@ -363,10 +363,10 @@ class RulesGenerator(object):
         Create all the rules required to satisfy installing the given package.
         """
         work_queue = collections.deque()
-        work_queue.append(package)
+        work_queue.append((package, requirements))
 
         while len(work_queue) > 0:
-            p = work_queue.popleft()
+            p, requirements = work_queue.popleft()
             p_id = self._pool.package_id(p)
             if p_id not in self.added_package_ids:
                 self.added_package_ids.add(p_id)

--- a/simplesat/tests/epd_full_conflict.yaml
+++ b/simplesat/tests/epd_full_conflict.yaml
@@ -2025,7 +2025,7 @@ failure:
       Conflicting requirements:
       Requirements: 'EPD' <- 'numpy == 1.6.0-5'
           EPD-7.1-1 requires (+numpy-1.6.0-5)
-      Requirements: 'EPD' <- 'numpy'
+      Requirements: 'EPD' <- 'SimPy == 2.1.0-2' <- 'numpy' <- 'numpy'
           Can only install one of: (+numpy-1.8.1-1 | +numpy-1.6.0-5)
       Requirements: 'numpy > 1.8.0-0'
           Install command rule (+numpy-1.8.0-1 | +numpy-1.8.0-2 | +numpy-1.8.0-3 | +numpy-1.8.1-1)

--- a/simplesat/tests/simple_numpy_installed_blocking.yaml
+++ b/simplesat/tests/simple_numpy_installed_blocking.yaml
@@ -27,7 +27,7 @@ failure:
             Install command rule (+EPD_free-7.3-1)
         Requirements: 'EPD_free' <- 'MKL == 10.2-1'
             EPD_free-7.3-1 requires (+MKL-10.2-1)
-        Requirements: 'numpy > 1.8-0' <- 'MKL'
+        Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1' <- 'MKL'
             Can only install one of: (+MKL-10.2-1 | +MKL-10.3-1)
         Requirements: 'numpy > 1.8-0' <- 'MKL == 10.3-1'
             numpy-1.8.1-2 requires (+MKL-10.3-1)


### PR DESCRIPTION
This fixes a long-standing annoyance with the error reporting. It also enables us to rely on the requirement chain length, which makes it easier to figure out if a particular set of requirements came from a user (because there's only one) or if it was derived by following the dependency graph (because there's more than one).