### PR TITLE
Fix full package name parsing

### DIFF
--- a/simplesat/constraints/package_parser.py
+++ b/simplesat/constraints/package_parser.py
@@ -7,12 +7,13 @@ from .parser import _DISTRIBUTION_R, _VERSION_R, _WS_R
 
 _WS_RS = _WS_R
 _MAYBE_WS_RS = " *"
+_SEP_RS = r"(?:(?:{})|(?:{}))".format(_WS_RS, '-')
 _DISTRIBUTION_RS = "(?P<distribution>{})".format(_DISTRIBUTION_R)
 _VERSION_RS = "(?P<version>{})".format(_VERSION_R)
 _CONSTRAINT_RS = "(?P<constraint>[^,]*)"
 
 CONSTRAINT_BLOCK_RC = re.compile("(?P<kind>\w+)\s*\((?P<constraints>.*?)\)")
-PACKAGE_RC = re.compile(_DISTRIBUTION_RS + _WS_RS + _VERSION_RS)
+PACKAGE_RC = re.compile(_DISTRIBUTION_RS + _SEP_RS + _VERSION_RS)
 CONSTRAINT_RC = re.compile(_DISTRIBUTION_RS + _MAYBE_WS_RS + _CONSTRAINT_RS)
 
 CONSTRAINT_SYNONYMS = {

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -138,7 +138,7 @@ def requirements_are_satisfiable(repositories, requirements, modifiers=None):
     try:
         DependencySolver(pool, repositories, []).solve(request)
         return True
-    except SatisfiabilityError:
+    except (SatisfiabilityError, NoPackageFound):
         return False
 
 
@@ -224,6 +224,9 @@ class DependencySolver(object):
         ------
         SatisfiabilityError
             If no resolution is found.
+
+        MissingInstallRequires
+            If no packages meet a dependency requirement.
         """
         modifiers = request.modifiers
         self._pool.modifiers = modifiers if modifiers.targets else None


### PR DESCRIPTION
Our pretty package parser was getting upset at packages that hyphenate between the distribution name and the version.

This fixes that.