### PR TITLE
ENH: Functions to compute dependencies and reverse dependencies

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,3 +1,4 @@
 -rdev_requirements.txt
 refactordoc
 sphinx
+sphinx_rtd_theme

--- a/simplesat/compute_dependencies.py
+++ b/simplesat/compute_dependencies.py
@@ -20,7 +20,7 @@ def _compute_dependency_dict(pool, package_ids, transitive=False):
 
 def _reverse_mapping(mapping):
     reversed_map = defaultdict(set)
-    for key, vals in mapping.iteritems():
+    for key, vals in mapping.items():
         for v in vals:
             reversed_map[v].add(key)
 

--- a/simplesat/compute_dependencies.py
+++ b/simplesat/compute_dependencies.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+import six
+
 from simplesat import Pool
 from simplesat.utils.graph import (package_lit_dependency_graph,
                                    transitive_neighbors)
@@ -76,7 +78,7 @@ def _compute_dependency_dict(pool, package_ids, transitive=False):
 
 def _reverse_mapping(mapping):
     reversed_map = defaultdict(set)
-    for key, vals in mapping.items():
+    for key, vals in six.iteritems(mapping):
         for v in vals:
             reversed_map[v].add(key)
 

--- a/simplesat/compute_dependencies.py
+++ b/simplesat/compute_dependencies.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from simplesat.utils.graph import (package_lit_dependency_graph,
                                    transitive_neighbors)
 
@@ -24,6 +26,40 @@ def compute_dependencies(pool, requirement, transitive=False):
     for package in pool.what_provides(requirement):
         package_id = pool.package_id(package)
         dependency_ids = neighbors[package_id]
+        for d_id in dependency_ids:
+            result_dependencies.add(pool.id_to_package(d_id))
+
+    return result_dependencies
+
+
+def compute_reverse_dependencies(pool, requirement, transitive=False):
+    """ Compute packages in the given pool that depend on the given requirement
+
+    Parameters
+    ----------------
+    pool : Pool
+    requirement : Requirement
+        The package requirement for which to compute reverse dependencies.
+
+    Returns
+    -----------
+    dependencies : sequence
+         Set of packages in the pool that depend on the given requirement.
+    """
+
+    package_ids = pool._id_to_package_.keys()
+    graph = package_lit_dependency_graph(pool, package_ids, closed=False)
+    neighbors = transitive_neighbors(graph)
+
+    reversed_graph = defaultdict(set)
+    for key, vals in neighbors.iteritems():
+        for v in vals:
+            reversed_graph[v].add(key)
+
+    result_dependencies = set()
+    for package in pool.what_provides(requirement):
+        package_id = pool.package_id(package)
+        dependency_ids = reversed_graph[package_id]
         for d_id in dependency_ids:
             result_dependencies.add(pool.id_to_package(d_id))
 

--- a/simplesat/compute_dependencies.py
+++ b/simplesat/compute_dependencies.py
@@ -6,11 +6,16 @@ from simplesat.utils.graph import (package_lit_dependency_graph,
 
 
 def _compute_dependency_dict(pool, package_ids, transitive=False):
-    """ Return mapping of nodes to their dependents. """
-    neighbors = package_lit_dependency_graph(pool, package_ids, closed=False)
+    """ Return mapping of package ids to their dependent package ids.
+
+    If transitive is False, a package id will point to only its immediate
+    dependencies. Otherwise, the mapping will include all recursive
+    dependencies.
+    """
+    graph = package_lit_dependency_graph(pool, package_ids, closed=False)
     if transitive:
-        neighbors = transitive_neighbors(neighbors)
-    return neighbors
+        return transitive_neighbors(graph)
+    return graph
 
 
 def _reverse_mapping(mapping):
@@ -22,22 +27,43 @@ def _reverse_mapping(mapping):
     return reversed_map
 
 
-def _dependencies_for_requirement(pool, neighbor_mapping, requirement):
-    result_dependencies = set()
-    for package_id in _package_ids_satisfying_requirement(pool, requirement):
-        dependency_ids = neighbor_mapping[package_id]
-        result_dependencies.update(pool.id_to_package(d_id)
-                                   for d_id in dependency_ids)
+def _neighbors_for_requirement(pool, neighbor_mapping, requirement):
+    """ Compute neighboring packages for all packages satisfying `requirement`
 
-    return result_dependencies
+    Parameters
+    ----------------
+    pool: Pool
+    neighbor_mapping : dict
+        Mapping from package ids to "neighboring" package ids. These may be,
+        for example, the packages which depend on a package or those on which
+        the package depends.
+    requirement : Requirement
+        The package requirement for which to look up neighbors. All packages
+        which satisfy the requirement will be used.
+
+    Returns
+    -----------
+    neighbors : set
+         Set of packages in the pool that are neighbors of packages which
+         satisfy `requirement`.
+    """
+    neighbors = set()
+    for package_id in _package_ids_satisfying_requirement(pool, requirement):
+        neighbor_ids = neighbor_mapping[package_id]
+        neighbors.update(pool.id_to_package(d_id) for d_id in neighbor_ids)
+
+    return neighbors
 
 
 def _package_ids_satisfying_requirement(pool, requirement):
+    """ Yield package ids found in `pool` which satisfy `requirement`. """
     for package in pool.what_provides(requirement):
         yield pool.package_id(package)
 
 
 def _package_ids_from_repositories(pool, repositories):
+    """ Return set of package ids in `pool` for all packages in the given repos
+    """
     return set(pool.package_id(pkg) for repo in repositories for pkg in repo)
 
 
@@ -56,17 +82,19 @@ def compute_dependencies(repositories, requirement, transitive=False):
     Returns
     -----------
     dependencies : set
-        Set of packages in the pool that the given package depends on
+        Set of packages in the given repositories that any packages satisfying
+        the given requirement depend on.
     """
     pool = Pool(repositories)
     package_ids = _package_ids_from_repositories(pool, repositories)
+
     neighbors = _compute_dependency_dict(pool, package_ids, transitive)
-    dependencies = _dependencies_for_requirement(pool, neighbors, requirement)
+    dependencies = _neighbors_for_requirement(pool, neighbors, requirement)
     return dependencies
 
 
 def compute_reverse_dependencies(repositories, requirement, transitive=False):
-    """ Compute packages in the given pool that depend on the given requirement
+    """ Compute packages in `repositories` that depend on the given requirement
 
     Parameters
     ----------------
@@ -80,13 +108,16 @@ def compute_reverse_dependencies(repositories, requirement, transitive=False):
     Returns
     -----------
     dependencies : set
-         Set of packages in the pool that depend on the given requirement.
+        Set of packages in the given repositories that depend on any of the
+        packages satisfying the given requirement.
     """
     pool = Pool(repositories)
     package_ids = _package_ids_from_repositories(pool, repositories)
-
     neighbors = _compute_dependency_dict(pool, package_ids, transitive)
+
+    # Reverse mapping so that package ids point to the packages which depend
+    # on them
     reverse_neighbors = _reverse_mapping(neighbors)
-    dependencies = _dependencies_for_requirement(pool, reverse_neighbors,
-                                                 requirement)
+    dependencies = _neighbors_for_requirement(pool, reverse_neighbors,
+                                              requirement)
     return dependencies

--- a/simplesat/compute_dependencies.py
+++ b/simplesat/compute_dependencies.py
@@ -1,0 +1,30 @@
+from simplesat.utils.graph import (package_lit_dependency_graph,
+                                   transitive_neighbors)
+
+
+def compute_dependencies(pool, requirement, transitive=False):
+    """ Compute packages in the given pool on the given requirement depends
+
+    Parameters
+    ----------------
+    pool : Pool
+    requirement : Requirement
+        The package requirement for which to compute dependencies.
+
+    Returns
+    -----------
+    dependencies : sequence
+        Set of packages in the pool that the given package depends on
+    """
+    package_ids = pool._id_to_package_.keys()
+    graph = package_lit_dependency_graph(pool, package_ids, closed=False)
+    neighbors = transitive_neighbors(graph)
+
+    result_dependencies = set()
+    for package in pool.what_provides(requirement):
+        package_id = pool.package_id(package)
+        dependency_ids = neighbors[package_id]
+        for d_id in dependency_ids:
+            result_dependencies.add(pool.id_to_package(d_id))
+
+    return result_dependencies

--- a/simplesat/tests/test_compute_dependencies.py
+++ b/simplesat/tests/test_compute_dependencies.py
@@ -1,0 +1,56 @@
+import unittest
+from textwrap import dedent
+
+from simplesat.constraints import InstallRequirement
+from simplesat.package import PackageMetadata
+from simplesat.test_utils import pool_and_repository_from_packages
+
+from ..compute_dependencies import compute_dependencies
+
+
+PACKAGE_DEF = dedent("""\
+    A 0.0.0-1; depends (B ^= 0.0.0)
+    B 0.0.0-1; depends (D == 0.0.0-2)
+    B 0.0.0-2; depends (D ^= 0.0.0)
+    C 0.0.0-1; depends (E ^= 1.0.0-1)
+    D 0.0.0-2
+    E 1.0.0-1
+""")
+
+
+class TestComputeDependencies(unittest.TestCase):
+
+    def setUp(self):
+        self.pool, self.repo = pool_and_repository_from_packages(PACKAGE_DEF)
+
+    def _package_set_from_string(self, *package_strings):
+        packages = set()
+        for package_str in package_strings:
+            packages.add(PackageMetadata._from_pretty_string(package_str))
+
+        return packages
+
+    def test_no_dependency(self):
+        requirement = InstallRequirement._from_string('D == 0.0.0-2')
+        expected_deps = set()
+        deps = compute_dependencies(self.pool, requirement)
+        self.assertEqual(deps, expected_deps)
+
+    def test_simple_dependency(self):
+        requirement = InstallRequirement._from_string('C ^= 0.0.0')
+        expected_deps = self._package_set_from_string(
+            'E 1.0.0-1'
+        )
+        deps = compute_dependencies(self.pool, requirement)
+        self.assertEqual(deps, expected_deps)
+
+    def test_multiple_satisfying_requirements(self):
+        requirement = InstallRequirement._from_string('A ^= 0.0.0')
+        expected_deps = self._package_set_from_string(
+            'B 0.0.0-1; depends (D == 0.0.0-2)',
+            'B 0.0.0-2; depends (D ^= 0.0.0)',
+            'D 0.0.0-2'
+        )
+
+        deps = compute_dependencies(self.pool, requirement)
+        self.assertEqual(deps, expected_deps)

--- a/simplesat/tests/test_compute_dependencies.py
+++ b/simplesat/tests/test_compute_dependencies.py
@@ -1,19 +1,22 @@
 import unittest
 from textwrap import dedent
 
-from simplesat.constraints import InstallRequirement
-from simplesat.package import PackageMetadata
-from simplesat.test_utils import pool_and_repository_from_packages
+from simplesat import InstallRequirement, Repository
+from simplesat.test_utils import packages_from_definition
 
 from ..compute_dependencies import (compute_dependencies,
                                     compute_reverse_dependencies)
 
 
-PACKAGE_DEF = dedent("""\
+PACKAGE_DEF_0 = dedent("""\
     A 0.0.0-1; depends (B ^= 0.0.0)
     B 0.0.0-1; depends (D == 0.0.0-2)
     B 0.0.0-2; depends (D ^= 0.0.0)
     C 0.0.0-1; depends (E >= 1.0.0)
+""")
+
+
+PACKAGE_DEF_1 = dedent("""\
     D 0.0.0-2
     E 0.0.0-1
     E 1.0.0-1
@@ -24,74 +27,65 @@ PACKAGE_DEF = dedent("""\
 class TestComputeDependencies(unittest.TestCase):
 
     def setUp(self):
-        self.pool, self.repo = pool_and_repository_from_packages(PACKAGE_DEF)
-
-    def _package_set_from_string(self, *package_strings):
-        packages = set()
-        for package_str in package_strings:
-            packages.add(PackageMetadata._from_pretty_string(package_str))
-
-        return packages
+        repo_0 = Repository(packages_from_definition(PACKAGE_DEF_0))
+        repo_1 = Repository(packages_from_definition(PACKAGE_DEF_1))
+        self.repos = [repo_0, repo_1]
 
     def test_no_dependency(self):
         requirement = InstallRequirement._from_string('D == 0.0.0-2')
         expected_deps = set()
-        deps = compute_dependencies(self.pool, requirement)
+        deps = compute_dependencies(self.repos, requirement)
         self.assertEqual(deps, expected_deps)
 
     def test_simple_dependency(self):
         requirement = InstallRequirement._from_string('C *')
-        expected_deps = self._package_set_from_string('E 1.0.0-1', 'E 1.0.1-1')
+        expected_deps = packages_from_definition(
+            """E 1.0.0-1
+               E 1.0.1-1""")
 
-        deps = compute_dependencies(self.pool, requirement)
-        self.assertEqual(deps, expected_deps)
+        deps = compute_dependencies(self.repos, requirement)
+        self.assertEqual(deps, set(expected_deps))
 
     def test_chained_requirements(self):
         requirement = InstallRequirement._from_string('A ^= 0.0.0')
-        expected_deps = self._package_set_from_string(
-            'B 0.0.0-1; depends (D == 0.0.0-2)',
-            'B 0.0.0-2; depends (D ^= 0.0.0)',
-            'D 0.0.0-2'
+        expected_deps = packages_from_definition(
+            """B 0.0.0-1; depends (D == 0.0.0-2)
+            B 0.0.0-2; depends (D ^= 0.0.0)
+            D 0.0.0-2 """
         )
 
-        deps = compute_dependencies(self.pool, requirement)
-        self.assertEqual(deps, expected_deps)
+        deps = compute_dependencies(self.repos, requirement)
+        self.assertEqual(deps, set(expected_deps))
 
 
 class TestComputeReverseDependencies(unittest.TestCase):
 
     def setUp(self):
-        self.pool, self.repo = pool_and_repository_from_packages(PACKAGE_DEF)
-
-    def _package_set_from_string(self, *package_strings):
-        packages = set()
-        for package_str in package_strings:
-            packages.add(PackageMetadata._from_pretty_string(package_str))
-
-        return packages
+        repo_0 = Repository(packages_from_definition(PACKAGE_DEF_0))
+        repo_1 = Repository(packages_from_definition(PACKAGE_DEF_1))
+        self.repos = [repo_0, repo_1]
 
     def test_no_dependency(self):
         requirement = InstallRequirement._from_string('A ^= 0.0.0')
 
-        deps = compute_reverse_dependencies(self.pool, requirement)
+        deps = compute_reverse_dependencies(self.repos, requirement)
         self.assertEqual(deps, set())
 
     def test_simple_dependency(self):
         requirement = InstallRequirement._from_string('E *')
-        expected_deps = self._package_set_from_string(
+        expected_deps = packages_from_definition(
             'C 0.0.0-1; depends (E >= 1.0.0)'
         )
 
-        deps = compute_reverse_dependencies(self.pool, requirement)
-        self.assertEqual(deps, expected_deps)
+        deps = compute_reverse_dependencies(self.repos, requirement)
+        self.assertEqual(deps, set(expected_deps))
 
     def test_chained_dependencies(self):
         requirement = InstallRequirement._from_string('D ^= 0.0.0')
-        expected_deps = self._package_set_from_string(
-            'A 0.0.0-1; depends (B ^= 0.0.0)',
-            'B 0.0.0-1; depends (D == 0.0.0-2)',
-            'B 0.0.0-2; depends (D ^= 0.0.0)',
+        expected_deps = packages_from_definition(
+            """A 0.0.0-1; depends (B ^= 0.0.0)
+            B 0.0.0-1; depends (D == 0.0.0-2)
+            B 0.0.0-2; depends (D ^= 0.0.0)"""
         )
-
-        deps = compute_reverse_dependencies(self.pool, requirement)
-        self.assertEqual(deps, expected_deps)
+        deps = compute_reverse_dependencies(self.repos, requirement)
+        self.assertEqual(deps, set(expected_deps))

--- a/simplesat/tests/test_compute_dependencies.py
+++ b/simplesat/tests/test_compute_dependencies.py
@@ -5,7 +5,8 @@ from simplesat.constraints import InstallRequirement
 from simplesat.package import PackageMetadata
 from simplesat.test_utils import pool_and_repository_from_packages
 
-from ..compute_dependencies import compute_dependencies
+from ..compute_dependencies import (compute_dependencies,
+                                    compute_reverse_dependencies)
 
 
 PACKAGE_DEF = dedent("""\
@@ -53,4 +54,34 @@ class TestComputeDependencies(unittest.TestCase):
         )
 
         deps = compute_dependencies(self.pool, requirement)
+        self.assertEqual(deps, expected_deps)
+
+
+class TestComputeReverseDependencies(unittest.TestCase):
+
+    def setUp(self):
+        self.pool, self.repo = pool_and_repository_from_packages(PACKAGE_DEF)
+
+    def _package_set_from_string(self, *package_strings):
+        packages = set()
+        for package_str in package_strings:
+            packages.add(PackageMetadata._from_pretty_string(package_str))
+
+        return packages
+
+    def test_no_dependency(self):
+        requirement = InstallRequirement._from_string('A ^= 0.0.0')
+
+        deps = compute_reverse_dependencies(self.pool, requirement)
+        self.assertEqual(deps, set())
+
+    def test_multiple_rev_dependencies(self):
+        requirement = InstallRequirement._from_string('D ^= 0.0.0')
+        expected_deps = self._package_set_from_string(
+            'A 0.0.0-1; depends (B ^= 0.0.0)',
+            'B 0.0.0-1; depends (D == 0.0.0-2)',
+            'B 0.0.0-2; depends (D ^= 0.0.0)',
+        )
+
+        deps = compute_reverse_dependencies(self.pool, requirement)
         self.assertEqual(deps, expected_deps)


### PR DESCRIPTION
Closes #171 

`compute_dependencies` will return a set of packages on which packages for a given requirement depend.

`compute_reverse_dependencies` returns a set of packages which the requirement depends on.

Both can return either immediate dependencies or all recursive dependencies via the `transitive` flag.

@cournape, please let me know what you think