### PR TITLE
TST: update scenario name for marked test

### DIFF
--- a/simplesat/tests/preserve_marked_conflict.yaml
+++ b/simplesat/tests/preserve_marked_conflict.yaml
@@ -1,4 +1,4 @@
-# Upgrade impossible because installed EPD_free depends on numpy < 1.8
+# Upgrade impossible because marked package EPD_free depends on numpy < 1.8
 packages:
     - MKL 10.2-1
     - MKL 10.3-1

--- a/simplesat/tests/preserve_marked_conflict_downgrade.yaml
+++ b/simplesat/tests/preserve_marked_conflict_downgrade.yaml
@@ -1,4 +1,4 @@
-# Downgrade impossible because installed EPD_free depends on numpy > 1.8
+# Downgrade impossible because marked EPD_free depends on numpy > 1.8
 packages:
     - MKL 10.2-1
     - MKL 10.3-1

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -187,11 +187,11 @@ class TestInstallSet(ScenarioTestAssistant, TestCase):
 
     # This is currently handled using marked packages
     def test_blocked_upgrade(self):
-        self._check_solution("simple_numpy_installed_blocking.yaml")
+        self._check_solution("preserve_marked_conflict.yaml")
 
     # This is currently handled using marked packages
     def test_blocked_downgrade(self):
-        self._check_solution("simple_numpy_installed_blocking_downgrade.yaml")
+        self._check_solution("preserve_marked_conflict_downgrade.yaml")
 
     def test_remove_no_reverse_dependencies(self):
         self._check_solution("simple_numpy_removed.yaml")


### PR DESCRIPTION
This just updates two scenario files' names to reflect their purposes as marked package preservation tests.