### PR TITLE
Merge pull request #187 from enthought/bug/bad-metadata

### DIFF
--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -114,7 +114,7 @@ class UNSAT(object):
         # If there aren't two end points then none of this makes any sense.
         # Just return what we have.
         if len(end_clauses) < 2:
-            return end_clauses
+            return (end_clauses,)
 
         ends = OrderedDict.fromkeys(end_clauses)
         ends = tuple(ends.keys())

--- a/simplesat/tests/broken_metadata_self_conflict.yaml
+++ b/simplesat/tests/broken_metadata_self_conflict.yaml
@@ -1,0 +1,15 @@
+packages:
+    - A 10.2-1
+    - B 10.3-1; conflicts (A)
+    - C 1.7.1-1; depends (A, B)
+
+request:
+    - operation: "install"
+      requirement: "C"
+
+failure:
+  requirements: ['C']
+  raw: |
+    Conflicting requirements:
+    Requirements: 'C'
+        Install command rule (+C-1.7.1-1)

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -151,6 +151,9 @@ class TestNoInstallSet(ScenarioTestAssistant, TestCase):
     def test_three_way_conflict(self):
         self._check_solution("three_way_conflict.yaml")
 
+    def test_conflicting_single_package_dependencies(self):
+        self._check_solution("broken_metadata_self_conflict.yaml")
+
 
 class TestInstallSet(ScenarioTestAssistant, TestCase):
 


### PR DESCRIPTION
BUG: conflict paths returns  iter of iter of clause
(cherry picked from commit dc1f783360f721b465817c1658c8c1d3a24279d1)