### PR TITLE
BUG: fix package name parsing in requirement

### DIFF
--- a/simplesat/constraints/requirement.py
+++ b/simplesat/constraints/requirement.py
@@ -10,14 +10,18 @@ from simplesat.errors import (
 
 from .kinds import Any, Equal
 from .multi import MultiConstraints
-from .parser import _RawConstraintsParser, _RawRequirementParser
+from .parser import (
+    _RawConstraintsParser, _RawRequirementParser,
+    _DISTRIBUTION_NAME_R, _VERSION_R
+)
 
 
-_FULL_PACKAGE_RE = re.compile("""\
-                              (?P<name>[^-.]+)
-                              -
-                              (?P<version>(.*))
-                              $""", re.VERBOSE)
+_FULL_PACKAGE_RC = re.compile("""\
+        (?P<name>{})
+        (?:-|\s+)
+        (?P<version>{})
+        $""".format(_DISTRIBUTION_NAME_R, _VERSION_R),
+    re.VERBOSE)
 
 
 def parse_package_full_name(full_name):
@@ -25,7 +29,7 @@ def parse_package_full_name(full_name):
     Parse a package full name (e.g. 'numpy-1.6.0-1') into a (name,
     version_string) pair.
     """
-    m = _FULL_PACKAGE_RE.match(full_name)
+    m = _FULL_PACKAGE_RC.match(full_name)
     if m:
         return m.group("name"), m.group("version")
     else:

--- a/simplesat/constraints/tests/test_requirement.py
+++ b/simplesat/constraints/tests/test_requirement.py
@@ -216,23 +216,17 @@ class TestRequirementFromString(unittest.TestCase):
 
 
 class TestParsePackageFullName(unittest.TestCase):
+
     def test_simple(self):
         # Given
-        package_s = "numpy-1.8.1-1"
+        for package_s in ("numpy-1.8.1-1", "numpy 1.8.1-1"):
 
-        # When
-        name, version = parse_package_full_name(package_s)
+            # When
+            name, version = parse_package_full_name(package_s)
 
-        # Then
-        self.assertEqual(name, "numpy")
-        self.assertEqual(version, "1.8.1-1")
-
-        # Given
-        package_s = "numpy 1.8.1"
-
-        # When/Then
-        with self.assertRaises(SolverException):
-            parse_package_full_name(package_s)
+            # Then
+            self.assertEqual(name, "numpy")
+            self.assertEqual(version, "1.8.1-1")
 
 
 class TestRequirement(unittest.TestCase):


### PR DESCRIPTION
As part of the lunch-n-learn, I made this change. I no longer remember why... **BUT** it *does* make the parsing of package names more consistent with the rest of the code both here and elsewhere.

The main change is that this permits a hyphen in between the name and the version and uses the regular expressions written to match the name and version as closely as possible.

For reasons still unknown, we actually had a test before to ensure that package names with a space instead of a hyphen caused errors. Since we don't allow spaces or hyphens in package names, I'm not sure why.

Thoughts on this?