### PR TITLE
Add "provides" package metadata.

### DIFF
--- a/simplesat/constraints/tests/test_package_parser.py
+++ b/simplesat/constraints/tests/test_package_parser.py
@@ -226,17 +226,21 @@ class TestPrettyPackageStringParser(unittest.TestCase):
 
         # Given
         package_string = '; '.join((
-            "bokeh 0.2.0-3",
+            "bokeh_git 0.2.0-3",
             "install_requires (zope *, numpy ^= 1.8.0, requests >= 0.2)",
-            "conflicts (requests ^= 0.2.5, requests > 0.4, bokeh_git)",
+            "conflicts (requests ^= 0.2.5, requests > 0.4, bokeh)",
+            "provides (webplot ^= 0.1, bokeh)",
         ))
         r_install_requires = (
             ("numpy", (("^= 1.8.0",),)),
             ("requests", ((">= 0.2",),)),
             ("zope", (("*",),)))
         r_conflicts = (
-            ("bokeh_git", (('',),)),
+            ("bokeh", (('',),)),
             ("requests", (("^= 0.2.5", "> 0.4"),)))
+        r_provides = (
+            ("bokeh", (('',),)),
+            ("webplot", (("^= 0.1",),)))
 
         # When
         package = parse(package_string)
@@ -244,12 +248,14 @@ class TestPrettyPackageStringParser(unittest.TestCase):
         version = package['version']
         install_requires = package['install_requires']
         conflicts = package['conflicts']
+        provides = package['provides']
 
         # Then
-        self.assertEqual(name, "bokeh")
+        self.assertEqual(name, "bokeh_git")
         self.assertEqual(version, V("0.2.0-3"))
         self.assertEqual(install_requires, r_install_requires)
         self.assertEqual(conflicts, r_conflicts)
+        self.assertEqual(provides, r_provides)
 
 
 class TestPackagePrettyString(unittest.TestCase):
@@ -315,6 +321,31 @@ class TestPackagePrettyString(unittest.TestCase):
         # Then
         self.assertEqual(pretty_string, r_pretty_string)
 
+    def test_provides(self):
+        # Given
+        provides = ((u"dance", ((u">= 10.3-1",),)),)
+        package = PackageMetadata(u"zumba", V("1.8.1-1"), provides=provides)
+
+        r_pretty_string = u"zumba 1.8.1-1; provides (dance >= 10.3-1)"
+
+        # When
+        pretty_string = package_to_pretty_string(package)
+
+        # Then
+        self.assertEqual(pretty_string, r_pretty_string)
+
+        # Given
+        provides = (("cardio", (("*",),)),)
+        package = PackageMetadata(u"zumba", V("1.8.1-1"), provides=provides)
+
+        r_pretty_string = "zumba 1.8.1-1; provides (cardio *)"
+
+        # When
+        pretty_string = package_to_pretty_string(package)
+
+        # Then
+        self.assertEqual(pretty_string, r_pretty_string)
+
     def test_complicated(self):
         # Given
         install_requires = (
@@ -322,17 +353,21 @@ class TestPackagePrettyString(unittest.TestCase):
             ("requests", ((">= 0.2",),)),
             ("zope", (("*",),)))
         conflicts = (
-            ("bokeh_git", (('',),)),
+            ("bokeh", (('',),)),
             ("requests", ((">= 0.2.5", "< 0.4"),)))
+        provides = (
+            ("bokeh", (('*',),)),)
         package = PackageMetadata(
-            u"bokeh", V("0.2.0-3"),
+            u"bokeh_git", V("0.2.0-3"),
             install_requires=install_requires,
-            conflicts=conflicts)
+            conflicts=conflicts,
+            provides=provides)
 
         r_pretty_string = '; '.join((
-            "bokeh 0.2.0-3",
+            "bokeh_git 0.2.0-3",
             "install_requires (numpy ^= 1.8.0, requests >= 0.2, zope *)",
-            "conflicts (bokeh_git, requests >= 0.2.5, requests < 0.4)",
+            "conflicts (bokeh, requests >= 0.2.5, requests < 0.4)",
+            "provides (bokeh *)",
         ))
 
         # When
@@ -369,6 +404,64 @@ class TestToPackage(unittest.TestCase):
         self.assertEqual(package.name, "numpy")
         self.assertEqual(package.version, V('1.8.1'))
         self.assertEqual(package.install_requires, (("MKL", (("^= 10.3",),)),))
+
+    def test_with_conflicts(self):
+        # Given
+        s = u"numpy 1.8.1; conflicts (MKL <= 10.3)"
+        parser = PrettyPackageStringParser(V)
+
+        # When
+        package = parser.parse_to_package(s)
+
+        # Then
+        self.assertEqual(package.name, "numpy")
+        self.assertEqual(package.version, V('1.8.1'))
+        self.assertEqual(package.conflicts, (("MKL", (("<= 10.3",),)),))
+
+    def test_with_provides(self):
+        # Given
+        s = u"numpy 1.8.1-4; provides (numeric)"
+        parser = PrettyPackageStringParser(V)
+
+        # When
+        package = parser.parse_to_package(s)
+
+        # Then
+        self.assertEqual(package.name, "numpy")
+        self.assertEqual(package.version, V('1.8.1-4'))
+        self.assertEqual(package.provides,
+                         (('numpy', (('*',),)),
+                          ("numeric", (("",),))))
+
+    def test_complicated(self):
+        # Given
+        install_requires = (
+            ("numpy", (("^= 1.8.0",),)),
+            ("requests", ((">= 0.2",),)),
+            ("zope", (("*",),)))
+        conflicts = (
+            ("bokeh", (('',),)),
+            ("requests", ((">= 0.2.5", "< 0.4"),)))
+        provides = (
+            ("bokeh", (('*',),)),)
+        expected = PackageMetadata(
+            u"bokeh_git", V("0.2.0-3"),
+            install_requires=install_requires,
+            conflicts=conflicts,
+            provides=provides)
+        parser = PrettyPackageStringParser(V)
+
+        # When
+        s = '; '.join((
+            "bokeh_git 0.2.0-3",
+            "install_requires (numpy ^= 1.8.0, requests >= 0.2, zope *)",
+            "conflicts (bokeh, requests >= 0.2.5, requests < 0.4)",
+            "provides (bokeh *)",
+        ))
+        result = parser.parse_to_package(s)
+
+        # Then
+        self.assertEqual(result, expected)
 
 
 class TestParseScaryPackages(unittest.TestCase):

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -296,13 +296,16 @@ def _connected_packages(solution, root_ids, pool):
     # Our strategy is as follows:
     # ... -> pkg.install_requires -> pkg names -> ids -> _id_to_package -> ...
 
-    def get_name(pkg_id):
-        return pool.id_to_package(abs(pkg_id)).name
+    def get_names(pkg_id):
+        provides = pool.id_to_package(abs(pkg_id)).provides
+        return tuple(name for name, _ in provides)
 
-    root_names = {get_name(pkg_id) for pkg_id in root_ids}
+    root_names = {name for pkg_id in root_ids for name in get_names(pkg_id)}
 
     solution_name_to_id = {
-        get_name(pkg_id): pkg_id for pkg_id in solution
+        name: pkg_id
+        for pkg_id in solution
+        for name in get_names(pkg_id)
         if pkg_id > 0
     }
 

--- a/simplesat/package.py
+++ b/simplesat/package.py
@@ -77,7 +77,7 @@ class PackageMetadata(object):
             A tuple of tuples mapping distribution names to disjunctions of
             conjunctions of version constraints.
 
-            For example, a consider a package that depends on the following:
+            For example, consider a package that depends on the following:
                 - nose
                 - six (> 1.2, <= 1.2.3), or >= 1.2.5-2
                     Written as intervals, (1.2, 1.2.3] or [1.2.5-2, \infty)
@@ -93,15 +93,17 @@ class PackageMetadata(object):
 
             This works the same way as install_requires, but instead denotes
             packages that must *not* be installed with this package.
-        provides : iterable of package names
-            The packages that are provided by this distribution. Useful when
-            this does not match the package name.
+        provides :  tuple(tuple(str, tuple(tuple(str))))
+            A tuple of tuples mapping package and virtual package names to
+            disjunctions of conjunctions of version constraints.
 
-            For example, a package ``foo`` is abandoned by its maintainer and a
-            fork ``bar`` is created to continue development. If ``bar`` is
-            intended to be a transparent replacement for ``foo``, then ``bar``
-            `provides` ``foo``.
+            For example, consider a package ``numpy-nomkl`` which should be a
+            drop-in replacement for the normal ``numpy`` or ``numeric``
+            packages. ``numpy-nomkl`` would have the following `provides`:
+                (("numpy", (("*",),)), ("numeric", (("*",),)))
 
+            At this time, no version constraint is permitted for names
+            specified in `provides`.
         """
         self._name = name
         self._provides = tuple(provides or ())

--- a/simplesat/package.py
+++ b/simplesat/package.py
@@ -124,10 +124,16 @@ class PackageMetadata(object):
         return self._hash
 
     def __eq__(self, other):
-        return self._key == other._key
+        try:
+            return self._key == other._key
+        except AttributeError:
+            return NotImplemented
 
     def __ne__(self, other):
-        return self._key != other._key
+        try:
+            return self._key != other._key
+        except AttributeError:
+            return NotImplemented
 
 
 class RepositoryPackageMetadata(object):
@@ -173,7 +179,13 @@ class RepositoryPackageMetadata(object):
         return self._hash
 
     def __eq__(self, other):
-        return self._key == other._key
+        try:
+            return self._key == other._key
+        except AttributeError:
+            return NotImplemented
 
     def __ne__(self, other):
-        return self._key != other._key
+        try:
+            return self._key != other._key
+        except AttributeError:
+            return NotImplemented

--- a/simplesat/pool.py
+++ b/simplesat/pool.py
@@ -4,6 +4,7 @@ from .utils import DefaultOrderedDict
 from simplesat.constraints import (
     ConstraintModifiers, Requirement, modify_requirement
 )
+from simplesat.errors import InvalidConstraint
 
 
 class Pool(object):
@@ -51,7 +52,10 @@ class Pool(object):
             self._package_to_id_[package] = current_id
             for constraints in package.provides:
                 req = Requirement.from_constraints(constraints)
-                assert not req.has_any_version_constraint
+                if req.has_any_version_constraint:
+                    msg = ('Version constraints are not supported for'
+                           ' package.provides metadata: {}')
+                    raise InvalidConstraint(msg.format(req))
                 self._packages_by_name_[req.name].append(package)
 
     def what_provides(self, requirement, use_modifiers=True):

--- a/simplesat/pool.py
+++ b/simplesat/pool.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 from .utils import DefaultOrderedDict
-from simplesat.constraints import modify_requirement
+from simplesat.constraints import (
+    ConstraintModifiers, Requirement, modify_requirement
+)
 
 
 class Pool(object):
@@ -47,7 +49,10 @@ class Pool(object):
             self._id += 1
             self._id_to_package_[current_id] = package
             self._package_to_id_[package] = current_id
-            self._packages_by_name_[package.name].append(package)
+            for constraints in package.provides:
+                req = Requirement.from_constraints(constraints)
+                assert not req.has_any_version_constraint
+                self._packages_by_name_[req.name].append(package)
 
     def what_provides(self, requirement, use_modifiers=True):
         """ Computes the list of packages fulfilling the given

--- a/simplesat/rules_generator.py
+++ b/simplesat/rules_generator.py
@@ -22,7 +22,6 @@ class RuleType(enum.Enum):
     package_requires = 7
     package_conflicts = 8
     package_same_name = 10
-    package_implicit_obsoletes = 11
     package_installed = 12
     package_broken = 100
 
@@ -364,7 +363,7 @@ class RulesGenerator(object):
         Create rules for each of the known conflicts with `package`.
         """
 
-        # Conflicts due to implicit obsoletion or same-name
+        # Conflicts due to same-name
         pkg_requirement = ConflictRequirement._from_string(package.name)
         obsolete_providers = self._pool.what_provides(pkg_requirement)
         # We add our new requirement to the stack of requirements we've
@@ -374,11 +373,8 @@ class RulesGenerator(object):
             if requirements is not None
             else None)
         for provider in obsolete_providers:
-            if provider != package:
-                if provider.name == package.name:
-                    reason = RuleType.package_same_name
-                else:
-                    reason = RuleType.package_implicit_obsoletes
+            if provider != package and provider.name == package.name:
+                reason = RuleType.package_same_name
                 rule = self._create_conflicts_rule(
                     package, provider, reason, combined_requirements)
                 self._add_rule(rule, "package")

--- a/simplesat/tests/conflict_by_provides.yaml
+++ b/simplesat/tests/conflict_by_provides.yaml
@@ -1,0 +1,23 @@
+
+packages:
+  - zumba 1.8.1-1; provides (dance)
+  - ballet 3.2.0-1; provides (dance)
+  - white_tornado 6.6.6-1; conflicts (dance)
+
+request:
+  - operation: "install"
+    requirement: "ballet"
+  - operation: "install"
+    requirement: "white_tornado"
+
+
+failure:
+  requirements: ['ballet', 'white_tornado']
+  raw: |
+    Conflicting requirements:
+    Requirements: 'ballet'
+        Install command rule (+ballet-3.2.0-1)
+    Requirements: 'white_tornado' <- 'dance'
+        white_tornado-6.6.6-1 conflicts with +ballet-3.2.0-1
+    Requirements: 'white_tornado'
+        Install command rule (+white_tornado-6.6.6-1)

--- a/simplesat/tests/multiple_provides.yaml
+++ b/simplesat/tests/multiple_provides.yaml
@@ -1,0 +1,16 @@
+
+packages:
+  - meta 1.0-1;
+  - pil 1.0-1; provides (imaging)
+  - pillow 2.0-1; provides (imaging); conflicts (pil)
+  - pilfer 3.0-1; provides (imaging); conflicts (pil, pillow); install_requires (meta == 1.0-1)
+
+request:
+  - operation: "install"
+    requirement: "imaging"
+
+transaction:
+  - kind: install
+    package: meta 1.0-1
+  - kind: install
+    package: pilfer 3.0-1

--- a/simplesat/tests/simple_provides.yaml
+++ b/simplesat/tests/simple_provides.yaml
@@ -1,0 +1,11 @@
+
+packages:
+  - zumba 1.8.1-1; provides (dance)
+
+request:
+  - operation: "install"
+    requirement: "dance"
+
+transaction:
+  - kind: "install"
+    package: "zumba 1.8.1-1"

--- a/simplesat/tests/test_rules_generator.py
+++ b/simplesat/tests/test_rules_generator.py
@@ -59,6 +59,44 @@ class TestRulesGenerator(unittest.TestCase):
         # Then
         self.assertIs(package, installed_repo_package)
 
+    def test_provides(self):
+        yaml = u"""
+            packages:
+              - A 1.0-1; provides (X)
+              - B 1.0-1; provides (X)
+              - C 1.0-1; provides (X)
+              - X 1.0-1
+              - Z 1.0; depends (X)
+
+            request:
+              - operation: "install"
+                requirement: "Z"
+        """
+
+        scenario = Scenario.from_yaml(io.StringIO(yaml))
+
+        # When
+        repos = list(scenario.remote_repositories)
+        repos.append(scenario.installed_repository)
+        pool = Pool(repos)
+        installed_package_ids = {
+            pool.package_id(p): p for p in scenario.installed_repository}
+        rules_generator = RulesGenerator(
+            pool, scenario.request,
+            installed_package_ids=installed_package_ids)
+        rules = list(rules_generator.iter_rules())
+
+        # Then
+        self.assertEqual(len(rules), 2)
+
+        # Given/When
+        conflict = rules[0]
+        r_literals = (-5, 1, 2, 3, 4)
+
+        # Then
+        self.assertEqual(conflict.reason, RuleType.package_requires)
+        self.assertEqual(conflict.literals, r_literals)
+
     def test_conflicts(self):
         # Given
         yaml = u"""

--- a/simplesat/tests/test_rules_generator.py
+++ b/simplesat/tests/test_rules_generator.py
@@ -90,12 +90,12 @@ class TestRulesGenerator(unittest.TestCase):
         self.assertEqual(len(rules), 2)
 
         # Given/When
-        conflict = rules[0]
+        rule = rules[0]
         r_literals = (-5, 1, 2, 3, 4)
 
         # Then
-        self.assertEqual(conflict.reason, RuleType.package_requires)
-        self.assertEqual(conflict.literals, r_literals)
+        self.assertEqual(rule.reason, RuleType.package_requires)
+        self.assertEqual(rule.literals, r_literals)
 
     def test_conflicts(self):
         # Given

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -154,6 +154,15 @@ class TestNoInstallSet(ScenarioTestAssistant, TestCase):
     def test_conflicting_single_package_dependencies(self):
         self._check_solution("broken_metadata_self_conflict.yaml")
 
+    def test_simple_provides(self):
+        self._check_solution("simple_provides.yaml")
+
+    def test_multiple_provides(self):
+        self._check_solution("multiple_provides.yaml")
+
+    def test_conflict_by_provides(self):
+        self._check_solution("conflict_by_provides.yaml")
+
 
 class TestInstallSet(ScenarioTestAssistant, TestCase):
 


### PR DESCRIPTION
This adds `PackageMetadata.provides` and the associated code around that. It works by dumping all of the providers of a given name into pool's the internal `name_to_packages` list. The rest of the behavior falls out from that.

If package A `provides` package B, then either A or B can be used to satisfy dependencies (or cause conflicts with) B. This does imply that package A *replaces* package B or that package B is somehow obsolete or that package A should be preferred. With the current implementation, if two packages provide the same thing then you'll get whichever has a higher version number, but this is unspecified. If you care about priority, you'll need to use some of the other metadata features (not yet implemented).

See https://github.com/enthought/sat-solver/issues/177