### PR TITLE
ENH: api functions for simplifying and satisfying requests

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -35,6 +35,8 @@ the following::
 .. autofunction:: simplesat.dependency_solver.packages_are_consistent
 .. autofunction:: simplesat.dependency_solver.requirements_are_complete
 .. autofunction:: simplesat.dependency_solver.requirements_are_satisfiable
+.. autofunction:: simplesat.dependency_solver.satisfy_requirements
+.. autofunction:: simplesat.dependency_solver.simplify_requirements
 .. automodule:: simplesat.constraints.requirement
     :members:
 

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -11,7 +11,7 @@ from simplesat.request import JobType, Request
 from simplesat.rules_generator import RulesGenerator
 from simplesat.sat.policy import InstalledFirstPolicy
 from simplesat.sat import MiniSATSolver
-from simplesat.transaction import Transaction
+from simplesat.transaction import Transaction, InstallOperation
 from simplesat.utils import timed_context, connected_nodes
 
 

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -1,4 +1,5 @@
 import collections
+import itertools
 
 import six
 
@@ -140,6 +141,82 @@ def requirements_are_satisfiable(packages, requirements, modifiers=None):
         return True
     except SatisfiabilityError:
         return False
+
+
+def satisfy_requirements(packages, requirements, modifiers=None):
+    """ Find a collection of packages that satisfy the requirements.
+
+    Parameters
+    ----------
+    packages : iterable of PackageMetadata
+        The packages available to draw from when satisfying requirements.
+    requirements : list of Requirement
+        The requirements used to identify relevent packages.
+    modifiers : ConstraintModifiers, optional
+        If not None, modify requirements before resolving packages.
+
+    Returns
+    -------
+    tuple of PackageMetadata
+        Return a list of packages that together satisfy all of the
+        `requirements`.
+
+    Raises
+    ------
+    SatisfiabilityError
+        If the `requirements` cannot be satisfied using the `packages`.
+
+    MissingInstallRequires
+        If no packages meet a dependency requirement.
+    """
+    request = Request(modifiers=modifiers)
+    for requirement in requirements:
+        request.install(requirement)
+    repositories = (Repository(packages),)
+    pool = Pool(repositories, modifiers=modifiers)
+    transaction = DependencySolver(pool, repositories, []).solve(request)
+    msg = ("""
+        Unexpected operation in the transaction. This should never occur.
+        Something in simplesat is broken.
+        {!r}""")
+    for op in transaction.operations:
+        # Our installed repository was empty so everything should be an install
+        # operation
+        assert isinstance(op, InstallOperation), msg.format(op)
+    packages = tuple(op.package for op in transaction.operations)
+    return packages
+
+
+def simplify_requirements(packages, requirements):
+    """ Return a reduced, but equivalent set of requirements.
+
+    Parameters
+    ----------
+    packages : iterable of PackageMetadata
+        The packages available to draw from when satisfying requirements.
+    requirements : list of Requirement
+        The requirements used to identify relevent packages.
+
+    Returns
+    -------
+    tuple of Requirement
+        The reduced requirements.
+    """
+
+    needed_packages = packages_from_requirements(packages, requirements)
+    pool = Pool([Repository(packages)])
+    R = InstallRequirement.from_constraints
+    dependencies = set(itertools.chain.from_iterable(
+        pool.what_provides(R(con))
+        for package in needed_packages
+        for con in package.install_requires
+    ))
+    simple_requirements = requirements_from_packages(
+        package
+        for package in needed_packages
+        if package not in dependencies
+    )
+    return simple_requirements
 
 
 class DependencySolver(object):

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -158,8 +158,8 @@ def satisfy_requirements(packages, requirements, modifiers=None):
     Returns
     -------
     tuple of PackageMetadata
-        Return a list of packages that together satisfy all of the
-        `requirements`.
+        Return a tuple of packages that together satisfy all of the
+        `requirements`. The packages are in topological order.
 
     Raises
     ------

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -165,9 +165,6 @@ def satisfy_requirements(packages, requirements, modifiers=None):
     ------
     SatisfiabilityError
         If the `requirements` cannot be satisfied using the `packages`.
-
-    MissingInstallRequires
-        If no packages meet a dependency requirement.
     """
     request = Request(modifiers=modifiers)
     for requirement in requirements:

--- a/simplesat/tests/test_solver.py
+++ b/simplesat/tests/test_solver.py
@@ -399,6 +399,7 @@ class TestSolver(unittest.TestCase):
             P(u"C 1.0.0-1; depends (B > 2.0.0-1)"),
             P(u"D 1.0.0-1;"),
             P(u"E 1.0.0-1; depends (C > 2.0, D < 1.0)"),
+            P(u"F 1.0.0-1; depends (NONEXISTENT)"),
         )
 
         modifiers = ConstraintModifiers(
@@ -408,6 +409,10 @@ class TestSolver(unittest.TestCase):
 
         # When / Then
         with self.assertRaises(SatisfiabilityError):
+            satisfy_requirements(packages, requirements, modifiers=modifiers)
+
+        with self.assertRaises(SatisfiabilityError):
+            requirements = (R(u'F'),)
             satisfy_requirements(packages, requirements, modifiers=modifiers)
 
     def test_simplify_requirements(self):

--- a/simplesat/tests/test_solver.py
+++ b/simplesat/tests/test_solver.py
@@ -8,6 +8,7 @@ from simplesat.dependency_solver import (
     DependencySolver, packages_are_consistent,
     requirements_from_packages, packages_from_requirements,
     requirements_are_satisfiable, requirements_are_complete,
+    simplify_requirements,
 )
 from simplesat.errors import MissingInstallRequires, SatisfiabilityError
 from simplesat.pool import Pool
@@ -347,6 +348,28 @@ class TestSolver(unittest.TestCase):
         # Then
         with self.assertRaises(SatisfiabilityError):
             self.resolve(request)
+
+    def test_simplify_requirements(self):
+
+        # Given
+        requirements = (
+            R(u'MKL == 10.3-1'),
+            R(u'mismatch == 1.2.3-5'),
+            R(u'numpy == 1.9.1-1'),
+        )
+        packages = (
+            P(u'MKL 10.3-1'),
+            P(u'numpy 1.9.1-1; depends (MKL == 10.3-1, mismatch == 1.2.3-4)'),
+            P(u'mismatch 1.2.3-5'),
+            P(u'unused 1.2.3-0'),
+        )
+
+        # When
+        result = simplify_requirements(packages, requirements)
+        expected = requirements[1:]
+
+        # Then
+        self.assertEqual(result, expected)
 
     def test_strange_key_error_bug_on_failure(self):
         # Given


### PR DESCRIPTION
These new API-level functions provide two abilities.

`simplify_requirements` - to turn a large list of package requirements into an equivalent set of smaller requirements for a given suite of packages. It does so by removing all requirements that are captured as dependencies of other requirements. For a self-consistent set of requirements, this will leave us with just the "leaf nodes" of the dependency tree. For requirements that are not self-consistent, the requirements with "mismatched" versions will also be included as they are not captured by any dependencies. This should make this a lossless operation.

`satisfy_requirements` - to use a set of packages to "solve" a requirement. This is the core functionality of this package, wrapped up in small function with an easy to use API. You pass in a set of packages and a set of requirements and it gives you back the subset of packages needed to satisfy them.

TODO:
- [x] test `satisfy_requirements`