### PR TITLE
REF: don't depend on okonomiyaki besides versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ IS_RELEASED = False
 
 INSTALL_REQUIRES = [
     "attrs >= 15.2.0",
-    "okonomiyaki == 0.14.0",
+    "okonomiyaki >= 0.14.0",
     "six >= 1.9.0"
 ]
 

--- a/simplesat/constraints/tests/test_package_parser.py
+++ b/simplesat/constraints/tests/test_package_parser.py
@@ -1,7 +1,6 @@
 import sys
 import unittest
 
-from okonomiyaki.platforms import PythonImplementation
 from okonomiyaki.versions import EnpkgVersion
 
 from simplesat.constraints.package_parser import (
@@ -11,10 +10,6 @@ from simplesat.constraints.requirement import Requirement
 from simplesat.package import PackageMetadata
 from simplesat.errors import InvalidConstraint
 
-
-RUNNING_PYTHON = PythonImplementation(
-    "cp", sys.version_info[0], sys.version_info[1]
-)
 
 V = EnpkgVersion.from_string
 

--- a/simplesat/tests/test_repository.py
+++ b/simplesat/tests/test_repository.py
@@ -1,7 +1,6 @@
 import textwrap
 import unittest
 
-from okonomiyaki.platforms import PythonImplementation
 from okonomiyaki.versions import EnpkgVersion
 
 from simplesat.constraints import PrettyPackageStringParser


### PR DESCRIPTION
* we remove any usage of okonomiyaki except for `okonomiyaki.versions` (whose API is stable).
* this makes it safe to remove the upper version bound for okonomiyaki dependency