### PR TITLE
BUG: call to asdict must be deterministic

### DIFF
--- a/simplesat/constraints/constraint_modifiers.py
+++ b/simplesat/constraints/constraint_modifiers.py
@@ -88,7 +88,7 @@ class ConstraintModifiers(object):
     allow_older = attr(**_coerced_set)
 
     def asdict(self):
-        return asdict(self)
+        return {k: sorted(v) for k, v in six.iteritems(asdict(self))}
 
     @property
     def targets(self):


### PR DESCRIPTION
Without this, you can't do things like `yaml.dump(modifiers.asdict())` deterministically.