### PR TITLE
Bug/asserted requirement

### DIFF
--- a/simplesat/sat/minisat.py
+++ b/simplesat/sat/minisat.py
@@ -339,7 +339,9 @@ class MiniSATSolver(object):
             # Clause is guaranteed to be false under the current variable
             # assignments.
             self.status = False
-        elif len(clause) == 1:
+            return
+
+        if len(clause) == 1:
             # Unit facts are enqueued.
             if not self.enqueue(clause[0], cause=clause):
                 # Bail out if we've found a conflict
@@ -353,7 +355,7 @@ class MiniSATSolver(object):
             self.watches[-p].append(clause)
             self.watches[-q].append(clause)
 
-            self.clauses.append(clause)
+        self.clauses.append(clause)
 
     def _setup_assignments(self):
         """Initialize assignments table.

--- a/simplesat/sat/tests/test_minisat.py
+++ b/simplesat/sat/tests/test_minisat.py
@@ -120,7 +120,7 @@ class TestMiniSATSolver(unittest.TestCase):
         # Then
         self.assertIsNone(s.status)
         self.assertEqual(len(s.watches), 0)
-        self.assertEqual(len(s.clauses), 0)
+        self.assertEqual(len(s.clauses), 1)
         self.assertTrue(mock_enqueue.called)
 
     @mock.patch.object(MiniSATSolver, 'enqueue')

--- a/simplesat/tests/one_directly_implied_requirement.yaml
+++ b/simplesat/tests/one_directly_implied_requirement.yaml
@@ -1,0 +1,16 @@
+packages:
+    - onechoice 2.4.0-1
+    - twochoices 1.2-1;
+    - twochoices 1.3-1;
+
+request:
+    - operation: "install"
+      requirement: "onechoice"
+    - operation: "install"
+      requirement: "twochoices"
+
+transaction:
+    - kind: "install"
+      package: "onechoice 2.4.0-1"
+    - kind: "install"
+      package: "twochoices 1.3-1"

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -132,6 +132,9 @@ class ScenarioTestAssistant(object):
 
 class TestNoInstallSet(ScenarioTestAssistant, TestCase):
 
+    def test_one_directly_implied_requirement(self):
+        self._check_solution("one_directly_implied_requirement.yaml")
+
     def test_directly_implied_solution(self):
         self._check_solution("directly_implied_solution.yaml")
 


### PR DESCRIPTION
This fixes a bug that crashes the `UndeterminedClausePolicy` when the solver is run with a package name that has only one corresponding package version. This gets turned into a rule with one literal, which is then turned into a clause with one literal.

Clauses with one literal are assertions that warrant immediate assignment of a value. Since we knew that they were satisfied, we weren't tracking these clauses at all. This leads to problems in the Policy, which assumes that all package literals will appear in at least one clause.

We didn't run into this sooner because it requires *both* a requirement for a package with a single version *and* a requirement for some other package having more than one version such that the solver is forced to ask the policy for a suggestion.

The fix is to also track clauses with one literal. Clauses with no literals are still ignored.

@noraderam this one is subtle but worth understanding.