### PR TITLE
ENH: Request and ConstraintModifiers tweaks

### DIFF
--- a/simplesat/constraints/constraint_modifiers.py
+++ b/simplesat/constraints/constraint_modifiers.py
@@ -90,6 +90,12 @@ class ConstraintModifiers(object):
     def asdict(self):
         return {k: sorted(v) for k, v in six.iteritems(asdict(self))}
 
+    def update(self, other_modifiers):
+        """ Update modifiers with values from ConstraintModifiers instance. """
+        self.allow_any.update(other_modifiers.allow_any)
+        self.allow_newer.update(other_modifiers.allow_newer)
+        self.allow_older.update(other_modifiers.allow_older)
+
     @property
     def targets(self):
         return set.union(self.allow_newer, self.allow_any, self.allow_older)

--- a/simplesat/constraints/tests/test_constraint_modifiers.py
+++ b/simplesat/constraints/tests/test_constraint_modifiers.py
@@ -1,0 +1,50 @@
+import unittest
+
+from ..constraint_modifiers import ConstraintModifiers
+
+
+class TestConstraintModifiers(unittest.TestCase):
+
+    def test_initialization(self):
+        # Given
+        modifiers = ConstraintModifiers(allow_any='abc',
+                                        allow_newer=('u', 'v'),
+                                        allow_older=['x', 'y'])
+
+        # Then
+        self.assertEqual(modifiers.allow_any, set(('abc',)))
+        self.assertEqual(modifiers.allow_newer, set(('u', 'v')))
+        self.assertEqual(modifiers.allow_older, set(('x', 'y')))
+
+    def test_asdict(self):
+        # Given
+        modifiers = ConstraintModifiers(allow_any=('c', 'b'),
+                                        allow_newer=('z', 'a'),
+                                        allow_older=['x', 'y'])
+
+        # Then
+        modifiers_dict = modifiers.asdict()
+        expected_dict = {'allow_any': ['b', 'c'],
+                         'allow_newer': ['a', 'z'],
+                         'allow_older': ['x', 'y']}
+        self.assertEqual(modifiers_dict, expected_dict)
+
+    def test_update(self):
+        # Given
+        modifiers = ConstraintModifiers(allow_any=('a', 'b'))
+        other_modifiers = ConstraintModifiers(allow_any='new',
+                                              allow_newer=('u', 'v'))
+
+        # Then
+        modifiers.update(other_modifiers)
+        self.assertEqual(modifiers.allow_any, set(('a', 'b', 'new')))
+        self.assertEqual(modifiers.allow_newer, set(('u', 'v')))
+        self.assertEqual(modifiers.allow_older, set())
+
+    def test_targets(self):
+        # Given
+        modifiers = ConstraintModifiers(allow_any=('a', 'b', 'c'),
+                                        allow_newer=('u', 'v'))
+
+        # Then
+        self.assertEqual(modifiers.targets, set(('a', 'b', 'c', 'u', 'v')))

--- a/simplesat/request.py
+++ b/simplesat/request.py
@@ -46,7 +46,8 @@ class Request(object):
     {'allow_older': [], 'allow_any': ['MKL'], 'allow_newer': []}
     """
 
-    modifiers = attr(default=Factory(ConstraintModifiers))
+    modifiers = attr(default=Factory(ConstraintModifiers),
+                     validator=instance_of(ConstraintModifiers))
     jobs = attr(default=Factory(list))
 
     def install(self, requirement):


### PR DESCRIPTION
Implements a couple minor improvements discussed previously.

- Validate the `ConstraintModifiers` attribute on `Request
- Add `update` method directly to `ConstraintModifiers`

Also adds a few tests