### PR TITLE
ENH: Optionally ignore installed packages 

### DIFF
--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -347,7 +347,7 @@ class DependencySolver(object):
                 soft_update_packages.update((pkg for pkg in providers
                                             if pkg in installed_repository))
 
-            all_requirement_ids.extend([pool.package_id(p) for p in providers])
+            all_requirement_ids.extend(pool.package_id(p) for p in providers)
 
         installed_package_ids = collections.OrderedDict()
         for package in installed_repository:

--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -327,7 +327,8 @@ class DependencySolver(object):
 
         for job in request.jobs:
             assert job.kind in (
-                JobType.install, JobType.remove, JobType.update
+                JobType.install, JobType.remove, JobType.hard_update,
+                JobType.soft_update
             ), 'Unknown job kind: {}'.format(job.kind)
 
             requirement = job.requirement
@@ -337,7 +338,7 @@ class DependencySolver(object):
             if len(providers) == 0:
                 raise NoPackageFound(requirement, str(requirement))
 
-            if job.kind == JobType.update:
+            if job.kind == JobType.hard_update:
                 # An update request *must* install the latest package version
                 def key(package):
                     return (package.version, package in installed_repository)

--- a/simplesat/request.py
+++ b/simplesat/request.py
@@ -8,7 +8,8 @@ from .constraints import Requirement, ConstraintModifiers
 class JobType(Enum):
     install = 1
     remove = 2
-    update = 3
+    soft_update = 3
+    hard_update = 4
 
 
 @attributes
@@ -56,8 +57,11 @@ class Request(object):
     def remove(self, requirement):
         self._add_job(requirement, JobType.remove)
 
-    def update(self, requirement):
-        self._add_job(requirement, JobType.update)
+    def hard_update(self, requirement):
+        self._add_job(requirement, JobType.hard_update)
+
+    def soft_update(self, requirement):
+        self._add_job(requirement, JobType.soft_update)
 
     def allow_newer(self, package_name):
         self.modifiers.allow_newer.add(package_name)

--- a/simplesat/rules_generator.py
+++ b/simplesat/rules_generator.py
@@ -495,7 +495,7 @@ class RulesGenerator(object):
 
     def _add_job_rules(self):
         for job in self.request.jobs:
-            if job.kind == JobType.install or job.kind == JobType.soft_update:
+            if job.kind in (JobType.install, JobType.soft_update):
                 self._add_install_job_rules(job)
             elif job.kind == JobType.remove:
                 self._add_remove_job_rules(job)

--- a/simplesat/rules_generator.py
+++ b/simplesat/rules_generator.py
@@ -495,11 +495,11 @@ class RulesGenerator(object):
 
     def _add_job_rules(self):
         for job in self.request.jobs:
-            if job.kind == JobType.install:
+            if job.kind == JobType.install or job.kind == JobType.soft_update:
                 self._add_install_job_rules(job)
             elif job.kind == JobType.remove:
                 self._add_remove_job_rules(job)
-            elif job.kind == JobType.update:
+            elif job.kind == JobType.hard_update:
                 self._add_update_job_rules(job)
             else:
                 msg = "Job kind {0!r} not supported".format(job.kind)

--- a/simplesat/sat/policy/undetermined_clause_policy.py
+++ b/simplesat/sat/policy/undetermined_clause_policy.py
@@ -22,10 +22,11 @@ class UndeterminedClausePolicy(IPolicy):
         self._pool = pool
 
         by_version = six.functools.partial(pkg_id_to_version, self._pool)
-        installed_packages = set(package for package in installed_repository)
-        prefer_installed = installed_packages - ignore_installed_packages
+        installed_packages = set(installed_repository)
+        prefer_installed_pkgs = installed_packages - ignore_installed_packages
         self._prefer_installed_pkg_ids = sorted(
-            (pool.package_id(pkg) for pkg in prefer_installed), key=by_version)
+            (pool.package_id(pkg) for pkg in prefer_installed_pkgs),
+            key=by_version)
 
         installed_package_ids = (pool.package_id(pkg)
                                  for pkg in installed_repository)

--- a/simplesat/sat/policy/undetermined_clause_policy.py
+++ b/simplesat/sat/policy/undetermined_clause_policy.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 
 import six
 
-from simplesat.utils import DefaultOrderedDict
 from .policy import IPolicy, pkg_id_to_version
 from .policy_logger import LoggedPolicy
 
@@ -24,7 +23,7 @@ class UndeterminedClausePolicy(IPolicy):
             (pool.package_id(package) for package in installed_repository),
             key=by_version
         )
-        self._preferred_package_ids = {
+        self._local_package_ids = {
             self._package_key(package_id): package_id
             for package_id in self._installed_ids
         }
@@ -95,7 +94,7 @@ class UndeterminedClausePolicy(IPolicy):
             # the virtual <installed> repository to act as if it always has the
             # highest priority.
             key = self._package_key(candidate_id)
-            candidate_id = self._preferred_package_ids.get(key, candidate_id)
+            candidate_id = self._local_package_ids.get(key, candidate_id)
 
         return candidate_id
 
@@ -117,20 +116,6 @@ class UndeterminedClausePolicy(IPolicy):
             return max(unassigned, key=by_version)
         except ValueError:
             return None
-
-    def _group_packages_by_name(self, decision_set):
-        installed_packages = []
-        new_package_map = DefaultOrderedDict(list)
-        installed_ids = set(self._installed_ids)
-
-        for package_id in sorted(decision_set):
-            package = self._pool.id_to_package(package_id)
-            if package_id in installed_ids:
-                installed_packages.append(package)
-            else:
-                new_package_map[package.name].append(package)
-
-        return installed_packages, new_package_map
 
     def _refresh_decision_set(self, assignments):
         self._update_cache_from_assignments(assignments)

--- a/simplesat/sat/policy/undetermined_clause_policy.py
+++ b/simplesat/sat/policy/undetermined_clause_policy.py
@@ -28,21 +28,11 @@ class UndeterminedClausePolicy(IPolicy):
             (pool.package_id(pkg) for pkg in prefer_installed_pkgs),
             key=by_version)
 
-        installed_package_ids = (pool.package_id(pkg)
-                                 for pkg in installed_repository)
-        self._local_package_ids = {
-            self._package_key(package_id): package_id
-            for package_id in installed_package_ids
-        }
         self._decision_set = set()
         self._requirements = set()
         self._unsatisfied_clauses = set()
         self._id_to_clauses = defaultdict(list)
         self._all_ids = set()
-
-    def _package_key(self, package_id):
-        package = self._pool.id_to_package(package_id)
-        return (package.name, package.version)
 
     def add_requirements(self, package_ids):
         self._requirements.update(package_ids)
@@ -93,13 +83,6 @@ class UndeterminedClausePolicy(IPolicy):
 
         assert assignments.get(candidate_id) is None, \
             "Trying to assign to a variable which is already assigned."
-
-        # If this exact package version is available locally, use it.
-        # NOTE: when repository priority is implemented, this will cause
-        # the virtual <installed> repository to act as if it always has the
-        # highest priority.
-        key = self._package_key(candidate_id)
-        candidate_id = self._local_package_ids.get(key, candidate_id)
 
         return candidate_id
 

--- a/simplesat/test_utils.py
+++ b/simplesat/test_utils.py
@@ -162,7 +162,7 @@ class Scenario(object):
             getattr(request, kind)(requirement)
 
         if update_all:
-            request_job = request.update
+            request_job = request.hard_update
         else:
             request_job = request.install
 

--- a/simplesat/tests/complex_numpy_downgrade.yaml
+++ b/simplesat/tests/complex_numpy_downgrade.yaml
@@ -1,0 +1,3382 @@
+packages:
+- _distribute_remove 1.0.0-1
+- _dummy_free_egg 1.0.0-1
+- _osx64app 1.0-1
+- abstract_rendering 0.5.1-1
+- affine 1.2.0-1
+- agw 0.9.1-1
+- alabaster 0.7.3-1
+- alabaster 0.7.6-1
+- alabaster 0.7.7-1
+- amqp 1.4.5-1
+- aniso8601 0.92-1
+- ansi2html 1.1.0-1; depends (six ^= 1.10.0)
+- ansi2html 1.1.1-1; depends (six ^= 1.10.0)
+- anyjson 0.3.3-2
+- anyjson 0.3.3-3
+- apipkg 1.4-1
+- appinst 2.0.4-1
+- appinst 2.1.0-1
+- appinst 2.1.1-1
+- appinst 2.1.2-1
+- appinst 2.1.5-1
+- appnope 0.1.0-1
+- appscript 1.0.1-1
+- apptools 4.0.0-1; depends (configobj)
+- apptools 4.0.1-1; depends (configobj)
+- apptools 4.1.0-1; depends (configobj)
+- apptools 4.2.0-1; depends (configobj)
+- apptools 4.2.0-2; depends (configobj, traitsui ^= 4.3.0, envisage ^= 4.3.0)
+- apptools 4.2.0-4; depends (configobj, traitsui ^= 4.4.0, envisage ^= 4.4.0)
+- apptools 4.2.1-1; depends (configobj, traitsui ^= 4.4.0, envisage ^= 4.4.0)
+- apptools 4.2.1-2; depends (configobj ^= 5.0.5, traitsui ^= 4.4.0, envisage ^= 4.4.0)
+- apptools 4.2.1-3; depends (configobj ^= 5.0.6, traitsui ^= 4.4.0, envisage ^= 4.4.0)
+- apptools 4.3.0-1; depends (configobj ^= 5.0.6, traitsui ^= 4.4.0, envisage ^= 4.4.0)
+- apptools 4.3.0-2; depends (configobj ^= 5.0.6, traitsui ^= 4.4.0, envisage ^= 4.4.0)
+- apptools 4.3.0-3; depends (configobj ^= 5.0.6, traitsui ^= 4.5.1, envisage ^= 4.4.0)
+- apptools 4.3.0-4; depends (configobj ^= 5.0.6, traitsui ^= 4.5.1, envisage ^= 4.4.0)
+- apptools 4.3.0-5; depends (configobj ^= 5.0.6, traitsui ^= 4.5.1, envisage ^= 4.4.0)
+- apptools 4.3.0-6; depends (configobj ^= 5.0.6, traitsui ^= 4.5.1, envisage ^= 4.4.0)
+- apptools 4.3.0-7; depends (configobj ^= 5.0.6, traitsui ^= 5.0.0, envisage ^= 4.4.0)
+- apptools 4.3.0-8; depends (configobj ^= 5.0.6, traitsui ^= 5.0.0, envisage ^= 4.4.0)
+- apptools 4.4.0-1; depends (configobj ^= 5.0.6, traitsui ^= 5.0.0)
+- apptools 4.4.0-2; depends (configobj ^= 5.0.6, traitsui ^= 5.0.0)
+- apptools 4.4.0-3; depends (configobj ^= 5.0.6, traitsui ^= 5.1.0)
+- arch 3.0-2; depends (scipy ^= 0.15.1, matplotlib ^= 1.4.3)
+- arch 3.0-3; depends (scipy ^= 0.15.1, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- arch 3.0-4; depends (scipy ^= 0.15.1, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- arch 3.0-5; depends (scipy ^= 0.15.1, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- arch 3.0-6; depends (scipy ^= 0.16.0, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- arch 3.0-7; depends (scipy ^= 0.16.0, six ^= 1.10.0, matplotlib ^= 1.4.3)
+- arch 3.0-9; depends (scipy ^= 0.16.1, six ^= 1.10.0, matplotlib ^= 1.4.3)
+- arch 3.0-10; depends (scipy ^= 0.16.1, six ^= 1.10.0, matplotlib ^= 1.5.0)
+- arch 3.0-11; depends (scipy ^= 0.16.1, six ^= 1.10.0, matplotlib ^= 1.5.0)
+- arch 3.0-12; depends (scipy ^= 0.16.1, six ^= 1.10.0, matplotlib ^= 1.5.1)
+- arch 3.0-13; depends (scipy ^= 0.17.0, six ^= 1.10.0, matplotlib ^= 1.5.1)
+- arch 3.0-14; depends (scipy ^= 0.17.0, six ^= 1.10.0, matplotlib ^= 1.5.1)
+- arch 3.0-15; depends (scipy ^= 0.17.0, six ^= 1.10.0, matplotlib ^= 1.5.1)
+- argcomplete 0.8.1-1
+- argcomplete 0.8.3-1
+- argcomplete 0.8.4-1
+- argcomplete 0.8.9-1
+- argcomplete 1.0.0-1
+- astropy 0.2.4-1; depends (numpy ^= 1.7.1)
+- astropy 0.2.4-2; depends (numpy ^= 1.8.0)
+- astropy 0.3.0-1; depends (numpy ^= 1.8.0)
+- astropy 0.3.2-1; depends (numpy ^= 1.8.0)
+- astropy 0.3.2-2; depends (numpy ^= 1.8.1)
+- astropy 0.4.1-1; depends (numpy ^= 1.8.1)
+- astropy 0.4.2-1; depends (numpy ^= 1.8.1)
+- astropy 0.4.4-1; depends (numpy ^= 1.8.1)
+- astropy 1.0-1; depends (numpy ^= 1.8.1)
+- astropy 1.0.1-1; depends (numpy ^= 1.8.1)
+- astropy 1.0.2-1; depends (numpy ^= 1.8.1)
+- astropy 1.0.2-2; depends (numpy ^= 1.9.2)
+- astropy 1.0.3-1; depends (numpy ^= 1.9.2)
+- astropy 1.0.4-1; depends (numpy ^= 1.9.2)
+- astropy 1.0.4-2; depends (numpy ^= 1.9.2)
+- astropy 1.0.7-1; depends (numpy ^= 1.9.2)
+- astropy 1.1.1-1; depends (numpy ^= 1.9.2)
+- astropy 1.1.2-1; depends (numpy ^= 1.9.2)
+- astropy 1.1.2-2; depends (numpy ^= 1.10.4)
+- atom 0.3.5-1
+- atom 0.3.8-1
+- atom 0.3.9-1
+- atom 0.3.10-1
+- attrs 15.1.0-1
+- attrs 15.2.0-1
+- babel 1.3-1; depends (pytz ^= 2014.9.0)
+- babel 2.1.1-1; depends (pytz ^= 2014.9.0)
+- babel 2.1.1-2; depends (pytz ^= 2015.7)
+- babel 2.2.0-1; depends (pytz ^= 2015.7)
+- babel 2.2.0-2; depends (pytz ^= 2016.3)
+- babel 2.3.4-1; depends (pytz ^= 2016.3)
+- backports.lzma 0.0.3-1; depends (backports_lzma_remove ^= 1.0.0, xz ^= 5.2.2)
+- backports_abc 0.4-1
+- backports_lzma_remove 1.0.0-1
+- basemap 1.0-2; depends (numpy ^= 1.5.1, matplotlib ^= 1.0.1)
+- basemap 1.0-3; depends (numpy ^= 1.6.0, matplotlib ^= 1.0.1)
+- basemap 1.0.1-1; depends (numpy ^= 1.6.0, matplotlib ^= 1.0.1)
+- basemap 1.0.1-2; depends (numpy ^= 1.6.1, matplotlib ^= 1.0.1)
+- basemap 1.0.1-3; depends (numpy ^= 1.6.1, matplotlib ^= 1.1.0)
+- basemap 1.0.2-1; depends (numpy ^= 1.6.1, matplotlib ^= 1.1.0)
+- basemap 1.0.6-1; depends (numpy ^= 1.6.1, matplotlib ^= 1.2.0)
+- basemap 1.0.6-2; depends (numpy ^= 1.6.1, matplotlib ^= 1.2.0)
+- basemap 1.0.6-3; depends (numpy ^= 1.7.1, matplotlib ^= 1.2.0)
+- basemap 1.0.6-4; depends (numpy ^= 1.7.1, matplotlib ^= 1.2.1)
+- basemap 1.0.6-5; depends (numpy ^= 1.7.1, matplotlib ^= 1.3.0)
+- basemap 1.0.6-6; depends (numpy ^= 1.7.1, matplotlib ^= 1.3.1)
+- basemap 1.0.6-7; depends (numpy ^= 1.8.0, matplotlib ^= 1.3.1)
+- basemap 1.0.7-1; depends (numpy ^= 1.8.0, matplotlib ^= 1.3.1)
+- basemap 1.0.7-2; depends (numpy ^= 1.8.1, matplotlib ^= 1.3.1)
+- basemap 1.0.7-3; depends (numpy ^= 1.8.1, matplotlib ^= 1.4.0)
+- basemap 1.0.7-4; depends (geos ^= 3.4.2, numpy ^= 1.8.1, matplotlib ^= 1.4.0)
+- basemap 1.0.7-5; depends (geos ^= 3.4.2, numpy ^= 1.8.1, matplotlib ^= 1.4.2)
+- basemap 1.0.7-6; depends (geos ^= 3.4.2, numpy ^= 1.8.1, matplotlib ^= 1.4.3)
+- basemap 1.0.7-7; depends (geos ^= 3.4.2, numpy ^= 1.9.2, matplotlib ^= 1.4.3)
+- basemap 1.0.7-8; depends (geos ^= 3.4.2, numpy ^= 1.9.2, matplotlib ^= 1.5.0)
+- basemap 1.0.7-9; depends (geos ^= 3.5.0, numpy ^= 1.9.2, matplotlib ^= 1.5.0)
+- basemap 1.0.7-10; depends (geos ^= 3.5.0, numpy ^= 1.9.2, matplotlib ^= 1.5.1)
+- basemap 1.0.7-11; depends (geos ^= 3.5.0, numpy ^= 1.10.4, matplotlib ^= 1.5.1)
+- basemap_ld 1.0.1-1; depends (basemap ^= 1.0.1)
+- basemap_ld 1.0.2-1; depends (basemap ^= 1.0.2)
+- basemap_ld 1.0.6-1; depends (basemap ^= 1.0.6)
+- basemap_ld 1.0.7-1; depends (basemap ^= 1.0.7)
+- bcolz 0.7.1-1; depends (numpy ^= 1.8.1)
+- bcolz 0.7.2-1; depends (numpy ^= 1.8.1)
+- bcolz 0.8.0-1; depends (libblosc ^= 1.4.1, numpy ^= 1.8.1)
+- bcolz 0.8.1-1; depends (libblosc ^= 1.4.1, numpy ^= 1.8.1)
+- bcolz 0.8.1-2; depends (libblosc ^= 1.4.1, numpy ^= 1.9.2)
+- bcolz 0.9.0-1; depends (libblosc ^= 1.4.1, numpy ^= 1.9.2)
+- bcolz 0.10.0-1; depends (libblosc ^= 1.4.1, numpy ^= 1.9.2)
+- bcolz 0.11.3-1; depends (numpy ^= 1.9.2)
+- bcolz 0.11.3-2; depends (numpy ^= 1.9.2)
+- bcolz 0.11.3-3; depends (numpy ^= 1.9.2)
+- bcolz 0.12.1-1; depends (numpy ^= 1.9.2)
+- bcolz 0.12.1-2; depends (numpy ^= 1.10.4)
+- bcolz 0.12.1-3; depends (numpy ^= 1.10.4)
+- bcolz 1.0.0-1; depends (numpy ^= 1.10.4)
+- bcrypt 1.0.2-1; depends (cffi ^= 0.8.6)
+- bcrypt 1.0.2-2; depends (cffi ^= 0.9.2)
+- bcrypt 1.0.2-3; depends (cffi ^= 1.0.3)
+- bcrypt 1.0.2-4; depends (cffi ^= 1.1.2)
+- bcrypt 1.0.2-5; depends (cffi ^= 1.2.1)
+- bcrypt 1.0.2-6; depends (cffi ^= 1.2.1)
+- bcrypt 1.0.2-7; depends (cffi ^= 1.2.1)
+- bcrypt 1.0.2-8; depends (cffi ^= 1.3.1)
+- bcrypt 1.0.2-9; depends (cffi ^= 1.4.2)
+- bcrypt 2.0.0-1; depends (cffi ^= 1.4.2)
+- bcrypt 2.0.0-2; depends (cffi ^= 1.5.2)
+- bdot 0.1.7-1; depends (bcolz ^= 0.12.1, numpy ^= 1.9.2)
+- bdot 0.1.7-2; depends (bcolz ^= 0.12.1, numpy ^= 1.10.4)
+- bdot 0.1.7-3; depends (bcolz ^= 0.12.1, numpy ^= 1.10.4)
+- bdot 0.1.7-4; depends (bcolz ^= 1.0.0, numpy ^= 1.10.4)
+- beautifulsoup4 4.3.2-1; depends (lxml ^= 3.4.0, html5lib ^= 0.999)
+- beautifulsoup4 4.3.2-2; depends (lxml ^= 3.4.1, html5lib ^= 0.999)
+- beautifulsoup4 4.3.2-3; depends (lxml ^= 3.4.2, html5lib ^= 0.999)
+- beautifulsoup4 4.3.2-4; depends (lxml ^= 3.4.3, html5lib ^= 0.999)
+- beautifulsoup4 4.3.2-5; depends (lxml ^= 3.4.4, html5lib ^= 0.999)
+- beautifulsoup4 4.4.1-1; depends (lxml ^= 3.4.4, html5lib ^= 0.999)
+- beautifulsoup4 4.4.1-2; depends (lxml ^= 3.5.0, html5lib ^= 0.999)
+- beautifulsoup4 4.4.1-3; depends (lxml ^= 3.6.0, html5lib ^= 0.999)
+- behave 1.2.5-1; depends (parse ^= 1.6.6, parse_type ^= 0.3.4, six ^= 1.10.0)
+- biggus 0.7.0-1; depends (pep8 ^= 1.5.7, numpy ^= 1.8.1)
+- biggus 0.7.0-2; depends (pep8 ^= 1.5.7, numpy ^= 1.8.1)
+- biggus 0.7.0-3; depends (pep8 ^= 1.6.1, numpy ^= 1.8.1)
+- biggus 0.7.0-4; depends (pep8 ^= 1.6.2, numpy ^= 1.8.1)
+- biggus 0.7.0-5; depends (pep8 ^= 1.6.2, numpy ^= 1.9.2)
+- biggus 0.7.0-6; depends (pep8 ^= 1.7.0, numpy ^= 1.9.2)
+- biggus 0.7.0-7; depends (pep8 ^= 1.7.0, numpy ^= 1.10.4)
+- billiard 3.3.0.18-1
+- billiard 3.3.0.18-2
+- biopython 1.56-1; depends (numpy ^= 1.5.1)
+- biopython 1.57-1; depends (numpy ^= 1.5.1)
+- biopython 1.57-2; depends (numpy ^= 1.6.0)
+- biopython 1.57-3; depends (numpy ^= 1.6.1)
+- biopython 1.58-1; depends (numpy)
+- biopython 1.59-1; depends (numpy)
+- biopython 1.59-2; depends (numpy)
+- biopython 1.59-3; depends (numpy)
+- biopython 1.62.0-1; depends (numpy ^= 1.8.0)
+- biopython 1.64.0-1; depends (numpy ^= 1.8.0)
+- biopython 1.64.0-2; depends (numpy ^= 1.8.1)
+- biopython 1.65-1; depends (numpy ^= 1.8.1)
+- biopython 1.65-2; depends (numpy ^= 1.9.2)
+- biopython 1.66-1; depends (numpy ^= 1.9.2)
+- biopython 1.66-2; depends (numpy ^= 1.10.4)
+- biopython 1.66-3; depends (numpy ^= 1.10.4)
+- bitarray 0.3.5-3
+- bitarray 0.5.0-1
+- bitarray 0.5.1-1
+- bitarray 0.5.2-1
+- bitarray 0.6.0-1
+- bitarray 0.7.0-1
+- bitarray 0.8.0-1
+- bitarray 0.8.1-1
+- blaze 0.7.0-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.2, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.1.3, pandas ^= 0.15.2, psutil ^= 2.2.0, numba ^= 0.15.1, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.5.1, bcolz ^= 0.7.2, pymongo ^= 2.7.2, python_dateutil ^= 2.2.0)
+- blaze 0.7.0-2; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.2, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.1.4, pandas ^= 0.15.2, psutil ^= 2.2.0, numba ^= 0.15.1, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.5.1, bcolz ^= 0.7.2, pymongo ^= 2.7.2, python_dateutil ^= 2.2.0)
+- blaze 0.7.0-3; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.2, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.1.4, pandas ^= 0.15.2, psutil ^= 2.2.0, numba ^= 0.17.0, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.5.1, bcolz ^= 0.8.0, pymongo ^= 2.7.2, python_dateutil ^= 2.2.0)
+- blaze 0.7.0-4; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.2, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.1, pandas ^= 0.15.2, psutil ^= 2.2.0, numba ^= 0.17.0, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.5.1, bcolz ^= 0.8.0, pymongo ^= 2.7.2, python_dateutil ^= 2.2.0)
+- blaze 0.7.2-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.3, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.2, pandas ^= 0.15.2, psutil ^= 2.2.0, numba ^= 0.17.0, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.5.1, bcolz ^= 0.8.0, pymongo ^= 2.7.2, python_dateutil ^= 2.2.0)
+- blaze 0.7.2-2; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.3, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.2, pandas ^= 0.15.2, psutil ^= 2.2.1, numba ^= 0.17.0, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.5.1, bcolz ^= 0.8.0, pymongo ^= 2.8, python_dateutil ^= 2.2.0)
+- blaze 0.7.2-3; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.3, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.2, pandas ^= 0.15.2, psutil ^= 2.2.1, numba ^= 0.17.0, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.5.3, bcolz ^= 0.8.0, pymongo ^= 2.8, python_dateutil ^= 2.2.0)
+- blaze 0.7.2-4; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.3, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.2, pandas ^= 0.15.2, psutil ^= 2.2.1, numba ^= 0.17.0, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.5.3, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.2.0)
+- blaze 0.7.2-6; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.3, cytoolz ^= 0.7.1, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.2, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.17.0, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.6.0, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.2.0)
+- blaze 0.7.2-7; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.3, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.2, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.17.0, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.6.0, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.2.0)
+- blaze 0.7.2-8; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, pytables ^= 3.1.1, datashape ^= 0.4.3, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.2, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.18.1, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.6.0, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.2.0)
+- blaze 0.7.2-9; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.9, pytables ^= 3.1.1, datashape ^= 0.4.3, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.8.1, into ^= 0.2.2, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.18.1, toolz ^= 0.7.1, h5py ^= 2.4.0, requests ^= 2.6.0, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.2.0)
+- blaze 0.7.3-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.9, pytables ^= 3.1.1, datashape ^= 0.4.4, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.8.1, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.18.1, toolz ^= 0.7.1, odo ^= 0.3.1, h5py ^= 2.4.0, requests ^= 2.6.0, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.2.0)
+- blaze 0.7.3-2; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.0, pytables ^= 3.1.1, datashape ^= 0.4.4, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.8.1, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.18.2, toolz ^= 0.7.1, odo ^= 0.3.1, h5py ^= 2.5.0, requests ^= 2.6.0, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.7.3-3; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.1, pytables ^= 3.1.1, datashape ^= 0.4.4, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.8.1, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.18.2, toolz ^= 0.7.1, odo ^= 0.3.1, h5py ^= 2.5.0, requests ^= 2.6.2, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.7.3-4; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.1, pytables ^= 3.1.1, datashape ^= 0.4.4, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.18.2, toolz ^= 0.7.1, odo ^= 0.3.1, h5py ^= 2.5.0, requests ^= 2.6.2, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.0-2; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, pytables ^= 3.1.1, datashape ^= 0.4.5, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.0, psutil ^= 2.2.1, numba ^= 0.18.2, toolz ^= 0.7.1, odo ^= 0.3.2, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.0-3; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, pytables ^= 3.1.1, datashape ^= 0.4.5, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.1, psutil ^= 2.2.1, numba ^= 0.18.2, toolz ^= 0.7.1, odo ^= 0.3.2, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.8.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.0-4; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, pytables ^= 3.1.1, datashape ^= 0.4.5, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.1, psutil ^= 2.2.1, numba ^= 0.18.2, toolz ^= 0.7.2, odo ^= 0.3.2, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.9.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.0-6; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, pytables ^= 3.1.1, datashape ^= 0.4.5, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 2.2.1, numba ^= 0.19.2, toolz ^= 0.7.2, odo ^= 0.3.2, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.9.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.0-7; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, pytables ^= 3.2.0, datashape ^= 0.4.5, cytoolz ^= 0.7.2, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 2.2.1, numba ^= 0.19.2, toolz ^= 0.7.2, odo ^= 0.3.2, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.9.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.0-8; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.6, pytables ^= 3.2.0, datashape ^= 0.4.5, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 2.2.1, numba ^= 0.19.2, toolz ^= 0.7.2, odo ^= 0.3.2, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.9.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.0-9; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.6, pytables ^= 3.2.0, datashape ^= 0.4.5, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 2.2.1, numba ^= 0.19.2, toolz ^= 0.7.2, odo ^= 0.3.2, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.9.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.2-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.6, pytables ^= 3.2.0, datashape ^= 0.4.5, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 2.2.1, numba ^= 0.20.0, toolz ^= 0.7.2, odo ^= 0.3.2, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.9.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.2-2; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.6, pytables ^= 3.2.0, datashape ^= 0.4.6, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 2.2.1, numba ^= 0.20.0, toolz ^= 0.7.4, odo ^= 0.3.3, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.10.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.2-3; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.6, pytables ^= 3.2.0, datashape ^= 0.4.6, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 3.2.1, numba ^= 0.20.0, toolz ^= 0.7.4, odo ^= 0.3.3, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.10.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.2-4; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.6, pytables ^= 3.2.0, datashape ^= 0.4.6, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 3.2.1, numba ^= 0.21.0, toolz ^= 0.7.4, odo ^= 0.3.3, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.10.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.2-5; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.0, datashape ^= 0.4.6, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 3.2.1, numba ^= 0.21.0, toolz ^= 0.7.4, odo ^= 0.3.3, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.10.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-1; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.0, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 3.2.1, numba ^= 0.21.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.10.0, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-2; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.0, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 3.2.1, numba ^= 0.21.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-3; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.0, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 3.2.1, numba ^= 0.21.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.7.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-4; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.0, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 3.2.1, numba ^= 0.21.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.8.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-5; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.0, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.16.2, psutil ^= 3.2.1, numba ^= 0.21.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.8.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-6; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.0, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.2.1, numba ^= 0.21.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.8.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-7; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.0, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.2.1, numba ^= 0.22.1, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.8.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-8; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, pytables ^= 3.2.2, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.2.1, numba ^= 0.22.1, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.8.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-9; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.2.1, numba ^= 0.22.1, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.8.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-10; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.4.7, cytoolz ^= 0.7.3, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.2.1, numba ^= 0.22.1, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.9.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-11; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.4.7, cytoolz ^= 0.7.4, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.2.1, numba ^= 0.22.1, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.9.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-12; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.4.7, cytoolz ^= 0.7.4, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.22.1, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.9.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-13; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.5.0, cytoolz ^= 0.7.4, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.22.1, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.9.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-14; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.5.0, cytoolz ^= 0.7.4, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.23.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.9.0, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-15; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.5.0, cytoolz ^= 0.7.4, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.23.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.11.3, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-16; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.5.0, cytoolz ^= 0.7.4, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.23.0, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.8.3-17; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.5.0, cytoolz ^= 0.7.4, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.23.1, toolz ^= 0.7.4, odo ^= 0.3.4, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.9.1-1; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.4, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.23.1, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.9.1-2; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.23.1, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.9.1-3; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.24.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.9.1-4; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.17.1, psutil ^= 3.3.0, numba ^= 0.24.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.9.1-6; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.18.0, psutil ^= 3.3.0, numba ^= 0.24.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.4.2)
+- blaze 0.9.1-7; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.18.0, psutil ^= 3.3.0, numba ^= 0.24.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.5.1)
+- blaze 0.9.1-8; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.9.2, pandas ^= 0.18.0, psutil ^= 3.3.0, numba ^= 0.25.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.5.1)
+- blaze 0.9.1-9; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.10.4, pandas ^= 0.18.0, psutil ^= 3.3.0, numba ^= 0.25.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.5.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.5.1)
+- blaze 0.9.1-10; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.10.4, pandas ^= 0.18.0, psutil ^= 3.3.0, numba ^= 0.25.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.6.0, requests ^= 2.9.1, bcolz ^= 0.12.1, pymongo ^= 2.8, python_dateutil ^= 2.5.1)
+- blaze 0.9.1-11; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.10.4, pandas ^= 0.18.0, psutil ^= 3.3.0, numba ^= 0.25.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.6.0, requests ^= 2.9.1, bcolz ^= 1.0.0, pymongo ^= 2.8, python_dateutil ^= 2.5.1)
+- blaze 0.9.1-12; depends (flask_cors ^= 2.1.2, multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, pytables ^= 3.2.2, datashape ^= 0.5.1, cytoolz ^= 0.7.5, flask ^= 0.10.1, numpy ^= 1.10.4, pandas ^= 0.18.0, psutil ^= 3.3.0, numba ^= 0.25.0, toolz ^= 0.7.4, odo ^= 0.4.2, h5py ^= 2.6.0, requests ^= 2.9.1, bcolz ^= 1.0.0, pymongo ^= 2.8, python_dateutil ^= 2.5.2)
+- blist 1.3.4-1
+- blist 1.3.6-1
+- blockcanvas 4.0.0-1
+- blockcanvas 4.0.1-1
+- blockcanvas 4.0.3-1
+- blosc 1.2.3-1; depends (libblosc ^= 1.3.5, numpy ^= 1.8.0)
+- blosc 1.2.3-2; depends (libblosc ^= 1.3.5, numpy ^= 1.8.1)
+- blosc 1.2.3-3; depends (libblosc ^= 1.4.1, numpy ^= 1.8.1)
+- blosc 1.2.3-4; depends (libblosc ^= 1.4.1, numpy ^= 1.9.2)
+- blosc 1.2.8-1; depends (numpy ^= 1.9.2)
+- blosc 1.2.8-2; depends (numpy ^= 1.10.4)
+- blz 0.6.2-1; depends (libblosc ^= 1.3.5, numexpr ^= 2.2.2)
+- blz 0.6.2-4; depends (libblosc ^= 1.3.5, numexpr ^= 2.4.0)
+- blz 0.6.2-5; depends (libblosc ^= 1.4.1, numexpr ^= 2.4.0)
+- blz 0.6.2-6; depends (libblosc ^= 1.4.1, numexpr ^= 2.4.0)
+- bokeh 0.6.1-2; depends (flask ^= 0.10.1, tornado ^= 4.0.2, gevent ^= 1.0.1, pandas ^= 0.15.0, pyzmq ^= 14.3.1)
+- bokeh 0.6.1-4; depends (flask ^= 0.10.1, tornado ^= 4.0.2, gevent ^= 1.0.1, pandas ^= 0.15.1, pyzmq ^= 14.4.1)
+- bokeh 0.6.1-5; depends (flask ^= 0.10.1, tornado ^= 4.0.2, gevent ^= 1.0.1, pandas ^= 0.15.1, pyzmq ^= 14.4.1)
+- bokeh 0.6.1-6; depends (flask ^= 0.10.1, tornado ^= 4.0.2, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.4.1)
+- bokeh 0.6.1-7; depends (flask ^= 0.10.1, tornado ^= 4.0.2, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.4.1)
+- bokeh 0.6.1-8; depends (flask ^= 0.10.1, tornado ^= 4.0.2, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.5.0)
+- bokeh 0.7.1-1; depends (flask ^= 0.10.1, tornado ^= 4.0.2, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.5.0)
+- bokeh 0.7.1-2; depends (flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.5.0)
+- bokeh 0.7.1-3; depends (flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.5.0)
+- bokeh 0.7.1-4; depends (flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.5.0)
+- bokeh 0.8.0-1; depends (flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.5.0)
+- bokeh 0.8.1-1; depends (flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, pandas ^= 0.15.2, pyzmq ^= 14.5.0)
+- bokeh 0.8.1-2; depends (flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, pandas ^= 0.16.0, pyzmq ^= 14.5.0)
+- bokeh 0.8.2-1; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, blaze ^= 0.7.2, ipython ^= 3.0.0, pandas ^= 0.16.0, pyzmq ^= 14.5.0)
+- bokeh 0.8.2-2; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, blaze ^= 0.7.3, ipython ^= 3.0.0, pandas ^= 0.16.0, pyzmq ^= 14.5.0)
+- bokeh 0.8.2-3; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, blaze ^= 0.7.3, ipython ^= 3.1.0, pandas ^= 0.16.0, pyzmq ^= 14.5.0)
+- bokeh 0.8.2-4; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, blaze ^= 0.8.0, ipython ^= 3.1.0, pandas ^= 0.16.0, pyzmq ^= 14.6.0)
+- bokeh 0.8.2-5; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, blaze ^= 0.8.0, ipython ^= 3.1.0, pandas ^= 0.16.1, pyzmq ^= 14.6.0)
+- bokeh 0.9.0-1; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, blaze ^= 0.8.0, ipython ^= 3.1.0, pandas ^= 0.16.1, pyzmq ^= 14.6.0)
+- bokeh 0.9.0-2; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.1, gevent ^= 1.0.1, blaze ^= 0.8.0, ipython ^= 3.1.0, pandas ^= 0.16.2, pyzmq ^= 14.6.0)
+- bokeh 0.9.0-3; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2, gevent ^= 1.0.1, blaze ^= 0.8.0, ipython ^= 3.2.0, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.9.1-1; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2, gevent ^= 1.0.1, blaze ^= 0.8.0, ipython ^= 3.2.0, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.9.1-2; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2, gevent ^= 1.0.1, blaze ^= 0.8.2, ipython ^= 3.2.0, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.9.1-3; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2, gevent ^= 1.0.1, blaze ^= 0.8.2, ipython ^= 3.2.1, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.9.3-1; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2, gevent ^= 1.0.1, blaze ^= 0.8.2, ipython ^= 3.2.1, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.9.3-2; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2, gevent ^= 1.0.1, blaze ^= 0.8.2, ipython ^= 4.0.0, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.9.3-3; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2.1, gevent ^= 1.0.1, blaze ^= 0.8.2, ipython ^= 4.0.0, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.10.0-1; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2.1, gevent ^= 1.0.1, blaze ^= 0.8.3, ipython ^= 4.0.0, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.10.0-2; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2.1, gevent ^= 1.0.1, blaze ^= 0.8.3, ipython ^= 4.0.0, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.10.0-3; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2.1, gevent ^= 1.0.1, blaze ^= 0.8.3, ipython ^= 4.0.0, pandas ^= 0.16.2, pyzmq ^= 14.7.0)
+- bokeh 0.10.0-5; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.2.1, gevent ^= 1.0.1, blaze ^= 0.8.3, ipython ^= 4.0.0, pandas ^= 0.17.1, pyzmq ^= 14.7.0)
+- bokeh 0.10.0-7; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.3, gevent ^= 1.0.2, blaze ^= 0.8.3, ipython ^= 4.0.0, pandas ^= 0.17.1, pyzmq ^= 14.7.0)
+- bokeh 0.10.0-8; depends (abstract_rendering ^= 0.5.1, flask ^= 0.10.1, tornado ^= 4.3, gevent ^= 1.0.2, blaze ^= 0.8.3, ipython ^= 4.0.0, pandas ^= 0.17.1, pyzmq ^= 14.7.0)
+- bokeh 0.11.0-1; depends (pyyaml ^= 3.11, futures ^= 3.0.3, tornado ^= 4.3, six ^= 1.10.0, jinja2 ^= 2.8, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, requests ^= 2.9.0)
+- bokeh 0.11.0-2; depends (pyyaml ^= 3.11, futures ^= 3.0.3, tornado ^= 4.3, six ^= 1.10.0, jinja2 ^= 2.8, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, requests ^= 2.9.1)
+- bokeh 0.11.1-1; depends (pyyaml ^= 3.11, futures ^= 3.0.3, tornado ^= 4.3, six ^= 1.10.0, jinja2 ^= 2.8, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, requests ^= 2.9.1)
+- bokeh 0.11.1-2; depends (pyyaml ^= 3.11, futures ^= 3.0.3, tornado ^= 4.3, six ^= 1.10.0, jinja2 ^= 2.8, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, requests ^= 2.9.1)
+- bokeh 0.11.1-3; depends (pyyaml ^= 3.11, futures ^= 3.0.3, tornado ^= 4.3, six ^= 1.10.0, jinja2 ^= 2.8, python_dateutil ^= 2.5.1, numpy ^= 1.9.2, requests ^= 2.9.1)
+- bokeh 0.11.1-4; depends (pyyaml ^= 3.11, futures ^= 3.0.3, tornado ^= 4.3, six ^= 1.10.0, jinja2 ^= 2.8, python_dateutil ^= 2.5.1, numpy ^= 1.10.4, requests ^= 2.9.1)
+- bokeh 0.11.1-5; depends (pyyaml ^= 3.11, futures ^= 3.0.3, tornado ^= 4.3, six ^= 1.10.0, jinja2 ^= 2.8, python_dateutil ^= 2.5.2, numpy ^= 1.10.4, requests ^= 2.9.1)
+- boto 2.19.0-1; depends (pyyaml ^= 3.10, lxml ^= 3.2.3, keyring ^= 0.9.2, rsa ^= 3.1.2, requests ^= 1.2.3, paramiko ^= 1.10.1)
+- boto 2.19.0-2; depends (pyyaml ^= 3.10, lxml ^= 3.3.5, keyring ^= 3.7.0, rsa ^= 3.1.2, requests ^= 2.2.1, paramiko ^= 1.10.1)
+- boto 2.29.1-1; depends (pyyaml ^= 3.10, lxml ^= 3.3.5, keyring ^= 3.7.0, rsa ^= 3.1.2, requests ^= 2.3.0, paramiko ^= 1.14.0)
+- boto 2.32.1-1; depends (pyyaml ^= 3.11, lxml ^= 3.3.5, keyring ^= 3.7.0, rsa ^= 3.1.2, requests ^= 2.3.0, paramiko ^= 1.14.0)
+- boto 2.32.1-2; depends (pyyaml ^= 3.11, lxml ^= 3.3.6, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.4.0, paramiko ^= 1.14.0)
+- boto 2.34.0-1; depends (pyyaml ^= 3.11, lxml ^= 3.4.0, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.4.3, paramiko ^= 1.15.1)
+- boto 2.34.0-2; depends (pyyaml ^= 3.11, lxml ^= 3.4.1, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.5.0, paramiko ^= 1.15.1)
+- boto 2.35.1-1; depends (pyyaml ^= 3.11, lxml ^= 3.4.1, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.5.1, paramiko ^= 1.15.2)
+- boto 2.36.0-1; depends (pyyaml ^= 3.11, lxml ^= 3.4.1, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.5.1, paramiko ^= 1.15.2)
+- boto 2.36.0-2; depends (pyyaml ^= 3.11, lxml ^= 3.4.2, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.5.1, paramiko ^= 1.15.2)
+- boto 2.36.0-3; depends (pyyaml ^= 3.11, lxml ^= 3.4.2, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.5.3, paramiko ^= 1.15.2)
+- boto 2.36.0-4; depends (pyyaml ^= 3.11, lxml ^= 3.4.2, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.6.0, paramiko ^= 1.15.2)
+- boto 2.36.0-5; depends (pyyaml ^= 3.11, lxml ^= 3.4.3, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.6.2, paramiko ^= 1.15.2)
+- boto 2.38.0-1; depends (pyyaml ^= 3.11, lxml ^= 3.4.3, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.6.2, paramiko ^= 1.15.2)
+- boto 2.38.0-2; depends (pyyaml ^= 3.11, lxml ^= 3.4.3, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.7.0, paramiko ^= 1.15.2)
+- boto 2.38.0-3; depends (pyyaml ^= 3.11, lxml ^= 3.4.4, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.7.0, paramiko ^= 1.15.2)
+- boto 2.38.0-4; depends (pyyaml ^= 3.11, lxml ^= 3.4.4, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.8.0, paramiko ^= 1.15.2)
+- boto 2.38.0-5; depends (pyyaml ^= 3.11, lxml ^= 3.4.4, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.8.0, paramiko ^= 1.16.0)
+- boto 2.38.0-6; depends (pyyaml ^= 3.11, lxml ^= 3.4.4, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.9.0, paramiko ^= 1.16.0)
+- boto 2.38.0-7; depends (pyyaml ^= 3.11, lxml ^= 3.5.0, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.9.0, paramiko ^= 1.16.0)
+- boto 2.38.0-8; depends (pyyaml ^= 3.11, lxml ^= 3.5.0, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.9.1, paramiko ^= 1.16.0)
+- boto 2.39.0-1; depends (pyyaml ^= 3.11, lxml ^= 3.5.0, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.9.1, paramiko ^= 1.16.0)
+- boto 2.39.0-2; depends (pyyaml ^= 3.11, lxml ^= 3.6.0, keyring ^= 4.0, rsa ^= 3.1.2, requests ^= 2.9.1, paramiko ^= 1.16.0)
+- bottleneck 0.6.0-2; depends (numpy ^= 1.7.1)
+- bottleneck 0.6.0-3; depends (numpy ^= 1.7.1)
+- bottleneck 0.7.0-1; depends (numpy ^= 1.7.1)
+- bottleneck 0.7.0-2; depends (numpy ^= 1.8.0)
+- bottleneck 0.7.0-5; depends (numpy ^= 1.8.1)
+- bottleneck 0.7.0-6; depends (numpy ^= 1.9.2)
+- bottleneck 1.0.0-1; depends (numpy ^= 1.9.2)
+- bottleneck 1.0.0-2; depends (numpy ^= 1.9.2)
+- bottleneck 1.0.0-3; depends (numpy ^= 1.10.4)
+- bottleneck 1.0.0-4; depends (numpy ^= 1.10.4)
+- brewer2mpl 1.3.1-2
+- brewer2mpl 1.4.0-3
+- brewer2mpl 1.4.0-4
+- brood_json_schemas 0.3.0-1
+- brood_json_schemas 0.4.0-1
+- bsdiff4 1.0.0-1
+- bsdiff4 1.0.1-1
+- bsdiff4 1.1.0-1
+- bsdiff4 1.1.1-1
+- bsdiff4 1.1.4-1
+- bz2file 0.98-1
+- bzip2 1.0.6-1
+- cachecontrol 0.11.5-1; depends (requests ^= 2.7.0)
+- cachecontrol 0.11.5-2; depends (requests ^= 2.8.0)
+- cachecontrol 0.11.5-3; depends (requests ^= 2.9.0)
+- cachecontrol 0.11.5-4; depends (requests ^= 2.9.1)
+- cachecontrol 0.11.6-1; depends (requests ^= 2.9.1)
+- cartopy 0.10.0-1; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, libproj ^= 4.8.0, matplotlib ^= 1.3.1, scipy ^= 0.13.3, shapely ^= 1.2.17)
+- cartopy 0.10.0-2; depends (scipy ^= 0.13.3, pil ^= 1.1.7, pyshp ^= 1.2.0, matplotlib ^= 1.3.1, shapely ^= 1.2.17)
+- cartopy 0.10.0-3; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, libproj ^= 4.8.0, matplotlib ^= 1.3.1, scipy ^= 0.13.3, shapely ^= 1.2.17)
+- cartopy 0.10.0-4; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, libproj ^= 4.8.0, matplotlib ^= 1.3.1, scipy ^= 0.14.0, shapely ^= 1.2.17)
+- cartopy 0.10.0-5; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, libproj ^= 4.8.0, matplotlib ^= 1.3.1, scipy ^= 0.14.0, shapely ^= 1.3.2)
+- cartopy 0.10.0-8; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, libproj ^= 4.8.0, matplotlib ^= 1.4.0, scipy ^= 0.14.0, shapely ^= 1.3.2)
+- cartopy 0.11.0-1; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.0, scipy ^= 0.14.0, shapely ^= 1.3.2)
+- cartopy 0.11.0-2; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.0, scipy ^= 0.14.0, shapely ^= 1.4.1)
+- cartopy 0.11.0-3; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.2, scipy ^= 0.14.0, shapely ^= 1.4.1)
+- cartopy 0.11.0-4; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.2, scipy ^= 0.14.0, shapely ^= 1.5.1)
+- cartopy 0.11.0-5; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.2, scipy ^= 0.14.1rc1, shapely ^= 1.5.1)
+- cartopy 0.11.2-1; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.2, scipy ^= 0.14.1rc1, shapely ^= 1.5.1)
+- cartopy 0.11.2-2; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.2, scipy ^= 0.15.1, shapely ^= 1.5.1)
+- cartopy 0.11.2-3; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.2, scipy ^= 0.15.1, shapely ^= 1.5.1)
+- cartopy 0.11.2-4; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.2, scipy ^= 0.15.1, shapely ^= 1.5.1)
+- cartopy 0.11.2-5; depends (pil ^= 1.1.7, pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.3, scipy ^= 0.15.1, shapely ^= 1.5.1)
+- cartopy 0.11.2-6; depends (pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.3, scipy ^= 0.15.1, pillow ^= 2.8.1, shapely ^= 1.5.1)
+- cartopy 0.11.2-7; depends (pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.3, scipy ^= 0.15.1, pillow ^= 2.9.0, shapely ^= 1.5.1)
+- cartopy 0.11.2-8; depends (pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.3, scipy ^= 0.16.0, pillow ^= 2.9.0, shapely ^= 1.5.1)
+- cartopy 0.11.2-9; depends (pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.4.3, scipy ^= 0.16.1, pillow ^= 2.9.0, shapely ^= 1.5.1)
+- cartopy 0.11.2-10; depends (pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.0, scipy ^= 0.16.1, pillow ^= 2.9.0, shapely ^= 1.5.1)
+- cartopy 0.11.2-11; depends (pyshp ^= 1.2.0, geos ^= 3.4.2, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.0, scipy ^= 0.16.1, pillow ^= 2.9.0, shapely ^= 1.5.1)
+- cartopy 0.13.0-1; depends (pyshp ^= 1.2.0, geos ^= 3.5.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.0, scipy ^= 0.16.1, pillow ^= 2.9.0, shapely ^= 1.5.13)
+- cartopy 0.13.0-2; depends (pyshp ^= 1.2.0, geos ^= 3.5.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.0, scipy ^= 0.16.1, pillow ^= 3.0.0, shapely ^= 1.5.13)
+- cartopy 0.13.0-3; depends (pyshp ^= 1.2.0, geos ^= 3.5.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.1, scipy ^= 0.16.1, pillow ^= 3.0.0, shapely ^= 1.5.13)
+- cartopy 0.13.0-4; depends (pyshp ^= 1.2.0, geos ^= 3.5.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.1, scipy ^= 0.16.1, pillow ^= 3.0.0, shapely ^= 1.5.13)
+- cartopy 0.13.0-5; depends (pyshp ^= 1.2.0, geos ^= 3.5.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.1, scipy ^= 0.16.1, pillow ^= 3.0.0, shapely ^= 1.5.13)
+- cartopy 0.13.0-6; depends (pyshp ^= 1.2.0, geos ^= 3.5.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.1, scipy ^= 0.16.1, pillow ^= 3.1.0, shapely ^= 1.5.13)
+- cartopy 0.13.0-7; depends (pyshp ^= 1.2.0, geos ^= 3.5.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.1, scipy ^= 0.17.0, pillow ^= 3.1.0, shapely ^= 1.5.13)
+- cartopy 0.13.0-8; depends (pyshp ^= 1.2.0, geos ^= 3.5.0, libproj ^= 4.8.0, owslib ^= 0.8.8, matplotlib ^= 1.5.1, scipy ^= 0.17.0, pillow ^= 3.1.0, shapely ^= 1.5.13)
+- cassowarypy 0.27-1
+- casuarius 1.0b1-1
+- casuarius 1.0-1
+- casuarius 1.1-1
+- casuarius 1.1-2
+- casuarius 1.1-3
+- casuarius 1.1-5
+- casuarius 1.1-6
+- casuarius 1.1-7
+- catalyst 1.0.0b1-1; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.4.2, pyside ^= 1.2.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.1, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.3.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.17.1, pyzmq ^= 15.1.0, envisage ^= 4.4.0)
+- catalyst 1.0.0b1-2; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.4.2, pyside ^= 1.2.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.1, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.17.1, pyzmq ^= 15.1.0, envisage ^= 4.5.1)
+- catalyst 1.0.0b2-1; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.4.2, pyside ^= 1.2.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.1, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.17.1, pyzmq ^= 15.1.0, envisage ^= 4.5.1)
+- catalyst 1.0.0b2-2; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.4.2, pyside ^= 1.2.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.1, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.17.1, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.0b3-1; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.4.2, pyside ^= 1.2.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.1, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.17.1, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.0b3-2; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.4.2, pyside ^= 1.2.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.17.1, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.0b3-3; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.4.2, pyside ^= 1.2.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.0b3-4; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.5.1, pyside ^= 1.2.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.0rc3-1; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.5.1, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.0rc3-2; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.5.1, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.0rc3-3; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.5.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.0-1; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.5.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.1-1; depends (configobj ^= 5.0.6, pyface ^= 5.0.0, python_dateutil ^= 2.5.2, traitsui ^= 5.0.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.1-5; depends (configobj ^= 5.0.6, pyface ^= 5.1.0, python_dateutil ^= 2.5.2, traitsui ^= 5.1.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.1-6; depends (configobj ^= 5.0.6, pyface ^= 5.1.0, python_dateutil ^= 2.5.2, traitsui ^= 5.1.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- catalyst 1.0.1-7; depends (configobj ^= 5.0.6, pyface ^= 5.1.0, python_dateutil ^= 2.5.2, traitsui ^= 5.1.0, futures ^= 3.0.3, enclosure ^= 0.4.2, traits ^= 4.5.0, humanize ^= 0.5.1, faulthandler ^= 2.4, apptools ^= 4.4.0, chardet ^= 2.3.0, requests ^= 2.9.1, pandas ^= 0.18.0, pyzmq ^= 15.2.0, envisage ^= 4.5.1)
+- cdecimal 2.3-1
+- celery 3.1.13-2; depends (billiard ^= 3.3.0.18, pytz ^= 2013.8.0, kombu ^= 3.0.21)
+- celery 3.1.13-3; depends (billiard ^= 3.3.0.18, pytz ^= 2014.9.0, kombu ^= 3.0.21)
+- celery 3.1.19-1; depends (billiard ^= 3.3.0.18, pytz ^= 2015.7, kombu ^= 3.0.21)
+- celery 3.1.19-2; depends (billiard ^= 3.3.0.18, pytz ^= 2016.3, kombu ^= 3.0.21)
+- certifi 14.05.14-1
+- certifi 2015.11.20.1-1
+- cffi 0.8.2-1; depends (libffi ^= 3.0.13, pycparser ^= 2.10.0)
+- cffi 0.8.6-1; depends (libffi ^= 3.0.13, pycparser ^= 2.10.0)
+- cffi 0.9.2-1; depends (libffi ^= 3.0.13, pycparser ^= 2.10.0)
+- cffi 0.9.2-2; depends (libffi ^= 3.0.13, pycparser ^= 2.12)
+- cffi 1.0.3-1; depends (libffi ^= 3.0.13, pycparser ^= 2.13)
+- cffi 1.1.2-1; depends (libffi ^= 3.0.13, pycparser ^= 2.13)
+- cffi 1.2.1-1; depends (libffi ^= 3.0.13, pycparser ^= 2.14)
+- cffi 1.2.1-2; depends (libffi ^= 3.0.13, pycparser ^= 2.14)
+- cffi 1.3.1-1; depends (libffi ^= 3.0.13, pycparser ^= 2.14)
+- cffi 1.4.2-1; depends (libffi ^= 3.0.13, pycparser ^= 2.14)
+- cffi 1.5.2-1; depends (libffi ^= 3.0.13, pycparser ^= 2.14)
+- chaco 4.0.0-1; depends (enable ^= 4.0.0, numpy ^= 1.6.0)
+- chaco 4.0.0-2; depends (enable ^= 4.0.0, numpy ^= 1.6.1)
+- chaco 4.0.1-1; depends (enable ^= 4.0.0, numpy ^= 1.6.1)
+- chaco 4.1.0-1; depends (enable ^= 4.1.0, numpy ^= 1.6.1)
+- chaco 4.2.0-1; depends (enable ^= 4.2.0, numpy ^= 1.6.1)
+- chaco 4.3.0-1; depends (enable ^= 4.3.0, numpy ^= 1.6.1)
+- chaco 4.3.0-2; depends (enable ^= 4.3.0, numpy ^= 1.7.1)
+- chaco 4.3.0-3; depends (enable ^= 4.3.0, numpy ^= 1.8.0)
+- chaco 4.4.1-1; depends (enable ^= 4.3.0, numpy ^= 1.8.0)
+- chaco 4.4.1-2; depends (enable ^= 4.4.1, numpy ^= 1.8.0)
+- chaco 4.4.1-3; depends (enable ^= 4.4.1, numpy ^= 1.8.1)
+- chaco 4.5.0-1; depends (enable ^= 4.4.1, numpy ^= 1.8.1)
+- chaco 4.5.0-2; depends (enable ^= 4.5.1, numpy ^= 1.8.1)
+- chaco 4.5.0-3; depends (enable ^= 4.5.1, numpy ^= 1.9.2)
+- chaco 4.5.0-4; depends (enable ^= 4.5.1, numpy ^= 1.10.4)
+- chameleon 2.16-1
+- chameleon 2.18-1
+- chameleon 2.19-1
+- chameleon 2.20-1
+- chameleon 2.22-1
+- characteristic 14.3.0-1
+- chardet 2.3.0-1
+- cheetah 2.4.3-2
+- cheetah 2.4.4-1
+- chest 0.2.2-1; depends (numpy ^= 1.8.1, heapdict ^= 1.0.0)
+- chest 0.2.2-2; depends (numpy ^= 1.9.2, heapdict ^= 1.0.0)
+- chest 0.2.3-1; depends (numpy ^= 1.9.2, heapdict ^= 1.0.0)
+- chest 0.2.3-2; depends (numpy ^= 1.9.2, heapdict ^= 1.0.0)
+- chest 0.2.3-3; depends (numpy ^= 1.10.4, heapdict ^= 1.0.0)
+- click 2.1.0-1; depends (colorama ^= 0.3.1)
+- click 3.3-1; depends (colorama ^= 0.3.1)
+- click 3.3-2; depends (colorama ^= 0.3.3)
+- click 4.0-1; depends (colorama ^= 0.3.3)
+- click 4.1-1; depends (colorama ^= 0.3.3)
+- click 6.2-1; depends (colorama ^= 0.3.3)
+- click 6.2-2; depends (colorama ^= 0.3.6)
+- click 6.3-1; depends (colorama ^= 0.3.6)
+- click 6.6-1; depends (colorama ^= 0.3.7)
+- clint 0.4.1-1
+- cloud 2.1.6-1
+- cloud 2.2.0-1
+- cloud 2.2.2-1
+- cloud 2.2.4-1
+- cloud 2.3.0-1
+- cloud 2.3.8-1
+- cloud 2.3.9-1
+- cloud 2.4.1-1
+- cloud 2.4.6-1
+- cloudpickle 0.1.1-1
+- cmake 3.0.2-1
+- cmake 3.0.2-2
+- cmake 3.1.1-1
+- cmake 3.4.3-1
+- codetools 4.0.0-1
+- codetools 4.1.0-1
+- codetools 4.1.0-2; depends (traits ^= 4.3.0)
+- codetools 4.2.0-1; depends (traits ^= 4.4.0)
+- codetools 4.2.0-2; depends (traits ^= 4.5.0)
+- colorama 0.3.1-1
+- colorama 0.3.3-1
+- colorama 0.3.6-1
+- colorama 0.3.7-1
+- configobj 4.7.2-2
+- configobj 5.0.5-1
+- configobj 5.0.6-1
+- contextlib2 0.5.1-1
+- coverage 3.4-2
+- coverage 3.5-1
+- coverage 3.5.1-1
+- coverage 3.5.2-1
+- coverage 3.7.1-1
+- coverage 4.0.3-1
+- cryptography 0.6.1-1
+- cryptography 0.6.1-2; depends (cffi ^= 0.8.6)
+- cryptography 0.6.1-3; depends (cffi ^= 0.9.2)
+- cryptography 0.8.1-1; depends (enum34 ^= 1.0.4, cffi ^= 0.9.2, six ^= 1.9.0, pyasn1 ^= 0.1.7, setuptools ^= 14.3.1)
+- cryptography 0.8.1-2; depends (enum34 ^= 1.0.4, cffi ^= 0.9.2, six ^= 1.9.0, pyasn1 ^= 0.1.7, setuptools ^= 14.3.1)
+- cryptography 0.8.2-1; depends (enum34 ^= 1.0.4, cffi ^= 0.9.2, six ^= 1.9.0, pyasn1 ^= 0.1.7, setuptools ^= 14.3.1)
+- cryptography 0.8.2-2; depends (enum34 ^= 1.0.4, cffi ^= 0.9.2, six ^= 1.9.0, pyasn1 ^= 0.1.7, setuptools ^= 15.1)
+- cryptography 0.8.2-3; depends (enum34 ^= 1.0.4, cffi ^= 0.9.2, six ^= 1.9.0, pyasn1 ^= 0.1.7, setuptools ^= 15.2)
+- cryptography 0.8.2-4; depends (enum34 ^= 1.0.4, cffi ^= 1.0.3, six ^= 1.9.0, pyasn1 ^= 0.1.7, setuptools ^= 15.2)
+- cryptography 0.8.2-5; depends (enum34 ^= 1.0.4, cffi ^= 1.0.3, six ^= 1.9.0, pyasn1 ^= 0.1.7, setuptools ^= 16.0)
+- cryptography 0.8.2-6; depends (enum34 ^= 1.0.4, cffi ^= 1.0.3, six ^= 1.9.0, pyasn1 ^= 0.1.7, setuptools ^= 17.1.1)
+- cryptography 0.9.1-1; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.9.0, cffi ^= 1.1.2, setuptools ^= 17.1.1, pyasn1 ^= 0.1.7)
+- cryptography 0.9.3-1; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.9.0, cffi ^= 1.1.2, setuptools ^= 17.1.1, pyasn1 ^= 0.1.7)
+- cryptography 0.9.3-2; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.9.0, cffi ^= 1.1.2, setuptools ^= 18.2, pyasn1 ^= 0.1.7)
+- cryptography 0.9.3-3; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.9.0, cffi ^= 1.2.1, setuptools ^= 18.2, pyasn1 ^= 0.1.7)
+- cryptography 0.9.3-4; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.9.0, cffi ^= 1.2.1, setuptools ^= 18.2, pyasn1 ^= 0.1.9)
+- cryptography 0.9.3-5; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.9.0, cffi ^= 1.2.1, setuptools ^= 18.2, pyasn1 ^= 0.1.9)
+- cryptography 0.9.3-6; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.2.1, setuptools ^= 18.4, pyasn1 ^= 0.1.9)
+- cryptography 1.1.1-1; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.3.1, setuptools ^= 18.4, pyasn1 ^= 0.1.9)
+- cryptography 1.1.1-2; depends (enum34 ^= 1.0.4, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.3.1, setuptools ^= 18.7.1, pyasn1 ^= 0.1.9)
+- cryptography 1.1.1-3; depends (enum34 ^= 1.1.1, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.3.1, setuptools ^= 18.7.1, pyasn1 ^= 0.1.9)
+- cryptography 1.1.1-4; depends (enum34 ^= 1.1.1, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.3.1, setuptools ^= 19.1.1, pyasn1 ^= 0.1.9)
+- cryptography 1.1.1-5; depends (enum34 ^= 1.1.1, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.4.2, setuptools ^= 19.1.1, pyasn1 ^= 0.1.9)
+- cryptography 1.1.1-6; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.4.2, setuptools ^= 19.1.1, pyasn1 ^= 0.1.9)
+- cryptography 1.2.1-1; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.4.2, setuptools ^= 19.4, pyasn1 ^= 0.1.9)
+- cryptography 1.2.1-2; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.4.2, setuptools ^= 19.4, pyasn1 ^= 0.1.9)
+- cryptography 1.2.1-3; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.4.2, setuptools ^= 20.1.1, pyasn1 ^= 0.1.9)
+- cryptography 1.2.3-1; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.4.2, setuptools ^= 20.2.2, pyasn1 ^= 0.1.9)
+- cryptography 1.2.3-2; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.4.2, setuptools ^= 20.2.2, pyasn1 ^= 0.1.9)
+- cryptography 1.2.3-3; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.5.2, setuptools ^= 20.2.2, pyasn1 ^= 0.1.9)
+- cryptography 1.3-1; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.5.2, setuptools ^= 20.2.2, pyasn1 ^= 0.1.9)
+- cryptography 1.3-2; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.5.2, setuptools ^= 20.3.1, pyasn1 ^= 0.1.9)
+- cryptography 1.3-3; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.5.2, setuptools ^= 20.6.7, pyasn1 ^= 0.1.9)
+- cryptography 1.3.1-1; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.5.2, setuptools ^= 20.6.7, pyasn1 ^= 0.1.9)
+- cryptography 1.3.1-2; depends (enum34 ^= 1.1.2, idna ^= 2.0, six ^= 1.10.0, cffi ^= 1.5.2, setuptools ^= 20.6.7, pyasn1 ^= 0.1.9)
+- cryptography_vectors 0.6.1-1
+- cryptography_vectors 0.8.1-1
+- cryptography_vectors 0.8.2-1
+- cryptography_vectors 0.9.1-1
+- cryptography_vectors 0.9.3-1
+- cryptography_vectors 1.1.1-1
+- cryptography_vectors 1.2.1-1
+- cryptography_vectors 1.2.3-1
+- cryptography_vectors 1.3-1
+- cryptography_vectors 1.3.1-1
+- cssselect 0.9.1-1
+- curl 7.23.1-1
+- curl 7.25.0-1
+- curl 7.25.0-2
+- curl 7.25.0-3
+- curl 7.25.0-6
+- curl 7.37.0-1
+- curl 7.38.0-1
+- curl 7.43.0-1
+- cycler 0.9.0-1
+- cycler 0.9.0-2
+- cycler 0.10.0-1
+- cython 0.13-2
+- cython 0.14-1
+- cython 0.14.1-1
+- cython 0.15-1
+- cython 0.15.1-1
+- cython 0.16-1
+- cython 0.19.1-1
+- cython 0.19.2-1
+- cython 0.20.2-1
+- cython 0.21-1
+- cython 0.21.1-1
+- cython 0.21.2-1
+- cython 0.22-1
+- cython 0.22.1-1
+- cython 0.23.4-1
+- cython 0.24-1
+- cytoolz 0.7.0-1
+- cytoolz 0.7.1-1
+- cytoolz 0.7.2-1
+- cytoolz 0.7.3-1
+- cytoolz 0.7.4-1
+- cytoolz 0.7.5-1
+- dask 0.4.0-1; depends (psutil ^= 2.2.1, chest ^= 0.2.2, toolz ^= 0.7.1, networkx ^= 1.9.1)
+- dask 0.5.0-1; depends (psutil ^= 2.2.1, chest ^= 0.2.2, toolz ^= 0.7.2, networkx ^= 1.9.1)
+- dask 0.5.0-2; depends (psutil ^= 2.2.1, chest ^= 0.2.2, toolz ^= 0.7.2, networkx ^= 1.9.1)
+- dask 0.6.0-1; depends (psutil ^= 2.2.1, chest ^= 0.2.2, toolz ^= 0.7.2, networkx ^= 1.9.1)
+- dask 0.6.0-2; depends (psutil ^= 2.2.1, chest ^= 0.2.2, toolz ^= 0.7.4, networkx ^= 1.9.1)
+- dask 0.6.0-3; depends (psutil ^= 2.2.1, chest ^= 0.2.3, toolz ^= 0.7.4, networkx ^= 1.10)
+- dask 0.6.0-4; depends (psutil ^= 3.2.1, chest ^= 0.2.3, toolz ^= 0.7.4, networkx ^= 1.10)
+- dask 0.6.0-5; depends (psutil ^= 3.2.1, chest ^= 0.2.3, toolz ^= 0.7.4, networkx ^= 1.10)
+- dask 0.7.3-1; depends (psutil ^= 3.2.1, chest ^= 0.2.3, toolz ^= 0.7.4, networkx ^= 1.10)
+- dask 0.7.3-2; depends (psutil ^= 3.2.1, chest ^= 0.2.3, toolz ^= 0.7.4, networkx ^= 1.10)
+- dask 0.7.3-3; depends (psutil ^= 3.2.1, chest ^= 0.2.3, toolz ^= 0.7.4, networkx ^= 1.10)
+- dask 0.7.5-1; depends (psutil ^= 3.2.1, chest ^= 0.2.3, toolz ^= 0.7.4, networkx ^= 1.10)
+- dask 0.7.5-2; depends (psutil ^= 3.3.0, chest ^= 0.2.3, toolz ^= 0.7.4, networkx ^= 1.10)
+- dask 0.7.6-1; depends (psutil ^= 3.3.0, partd ^= 0.3.2, pandas ^= 0.17.1, cloudpickle ^= 0.1.1, toolz ^= 0.7.4)
+- dask 0.8.0-1; depends (psutil ^= 3.3.0, partd ^= 0.3.2, pandas ^= 0.17.1, cloudpickle ^= 0.1.1, toolz ^= 0.7.4)
+- dask 0.8.1-1; depends (psutil ^= 3.3.0, partd ^= 0.3.2, pandas ^= 0.18.0, cloudpickle ^= 0.1.1, toolz ^= 0.7.4)
+- datashape 0.4.2-1
+- datashape 0.4.3-1
+- datashape 0.4.4-1
+- datashape 0.4.4-2
+- datashape 0.4.4-3
+- datashape 0.4.5-1; depends (multipledispatch ^= 0.4.7, numpy ^= 1.9.2, python_dateutil ^= 2.4.2)
+- datashape 0.4.6-1; depends (multipledispatch ^= 0.4.8, numpy ^= 1.9.2, python_dateutil ^= 2.4.2)
+- datashape 0.4.7-1; depends (multipledispatch ^= 0.4.8, numpy ^= 1.9.2, python_dateutil ^= 2.4.2)
+- datashape 0.4.7-2; depends (multipledispatch ^= 0.4.8, numpy ^= 1.9.2, python_dateutil ^= 2.4.2)
+- datashape 0.4.7-3; depends (multipledispatch ^= 0.4.8, numpy ^= 1.9.2, python_dateutil ^= 2.4.2)
+- datashape 0.5.0-1; depends (multipledispatch ^= 0.4.8, numpy ^= 1.9.2, python_dateutil ^= 2.4.2)
+- datashape 0.5.1-1; depends (multipledispatch ^= 0.4.8, numpy ^= 1.9.2, python_dateutil ^= 2.4.2)
+- datashape 0.5.1-2; depends (multipledispatch ^= 0.4.8, numpy ^= 1.9.2, python_dateutil ^= 2.5.1)
+- datashape 0.5.1-3; depends (multipledispatch ^= 0.4.8, numpy ^= 1.10.4, python_dateutil ^= 2.5.1)
+- datashape 0.5.1-4; depends (multipledispatch ^= 0.4.8, numpy ^= 1.10.4, python_dateutil ^= 2.5.2)
+- decorator 3.4.0-1
+- decorator 3.4.2-1
+- decorator 4.0.2-1
+- decorator 4.0.4-1
+- decorator 4.0.6-1
+- decorator 4.0.9-1
+- dill 0.2.2-1
+- dill 0.2.2-2
+- dill 0.2.3-1
+- dill 0.2.4-1
+- distribute 0.6.14-2
+- distribute 0.6.14-3
+- distribute 0.6.15-1
+- distribute 0.6.16-1
+- distribute 0.6.17-1
+- distribute 0.6.19-1
+- distribute 0.6.24-1
+- distribute 0.6.25-1
+- distribute 0.6.26-1
+- distribute 0.6.26-2
+- distribute 0.6.49-1
+- distribute_remove 1.0.0-2
+- distribute_remove 1.0.0-3
+- dnspython 1.12.0-1
+- doclinks 7.1-1; depends (appinst)
+- doclinks 7.1-2; depends (appinst)
+- doclinks 7.2-1; depends (appinst)
+- doclinks 7.2-2; depends (appinst)
+- doclinks 7.3-1; depends (appinst)
+- doctest_tools 1.0a3-1
+- docutils 0.7-2
+- docutils 0.8.1-1
+- docutils 0.8.1-2
+- docutils 0.11-1
+- docutils 0.12-1
+- drmaa 0.4b3-1
+- dummy_free_egg 1.0.0-1
+- dummy_free_egg 1.0.0-2
+- dynd_python 0.6.6-1; depends (libdynd ^= 0.6.6, numpy ^= 1.8.1)
+- dynd_python 0.6.6-2; depends (libdynd ^= 0.6.6, numpy ^= 1.9.2)
+- dynd_python 0.6.6-3; depends (libdynd ^= 0.6.6, numpy ^= 1.9.2)
+- ecdsa 0.11.0-1
+- ecdsa 0.13-1
+- enable 4.0.0-1; depends (numpy ^= 1.6.0, pil ^= 1.1.7)
+- enable 4.0.0-2; depends (numpy ^= 1.6.1, pil ^= 1.1.7)
+- enable 4.1.0-1; depends (numpy ^= 1.6.1, pil ^= 1.1.7)
+- enable 4.2.0-1; depends (numpy ^= 1.6.1, pil ^= 1.1.7)
+- enable 4.3.0-2; depends (numpy ^= 1.6.1, pil ^= 1.1.7)
+- enable 4.3.0-4; depends (numpy ^= 1.7.1, pil ^= 1.1.7)
+- enable 4.3.0-5; depends (numpy ^= 1.7.1, pil ^= 1.1.7, traits ^= 4.3.0)
+- enable 4.3.0-6; depends (numpy ^= 1.7.1, pil ^= 1.1.7, traits ^= 4.3.0)
+- enable 4.3.0-7; depends (numpy ^= 1.7.1, pil ^= 1.1.7, traitsui ^= 4.3.0)
+- enable 4.3.0-8; depends (numpy ^= 1.8.0, pil ^= 1.1.7, traitsui ^= 4.3.0)
+- enable 4.3.0-10; depends (numpy ^= 1.8.0, pil ^= 1.1.7, traitsui ^= 4.4.0)
+- enable 4.4.1-2; depends (numpy ^= 1.8.0, pil ^= 1.1.7, traitsui ^= 4.4.0)
+- enable 4.4.1-3; depends (numpy ^= 1.8.0, pil ^= 1.1.7, traitsui ^= 4.4.0)
+- enable 4.4.1-4; depends (numpy ^= 1.8.1, pil ^= 1.1.7, traitsui ^= 4.4.0)
+- enable 4.4.1-5; depends (numpy ^= 1.8.1, pil ^= 1.1.7, traitsui ^= 4.4.0)
+- enable 4.5.1-1; depends (numpy ^= 1.8.1, pyparsing ^= 2.0.3, kiwisolver ^= 0.1.3, pil ^= 1.1.7, traitsui ^= 4.4.0)
+- enable 4.5.1-2; depends (numpy ^= 1.8.1, pyparsing ^= 2.0.3, kiwisolver ^= 0.1.3, pil ^= 1.1.7, traitsui ^= 4.4.0)
+- enable 4.5.1-3; depends (numpy ^= 1.9.2, pyparsing ^= 2.0.3, kiwisolver ^= 0.1.3, pil ^= 1.1.7, traitsui ^= 4.4.0)
+- enable 4.5.1-4; depends (traitsui ^= 4.4.0, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 2.8.1, kiwisolver ^= 0.1.3)
+- enable 4.5.1-5; depends (traitsui ^= 4.5.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 2.8.1, kiwisolver ^= 0.1.3)
+- enable 4.5.1-6; depends (traitsui ^= 4.5.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 2.8.1, kiwisolver ^= 0.1.3)
+- enable 4.5.1-7; depends (traitsui ^= 4.5.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 2.9.0, kiwisolver ^= 0.1.3)
+- enable 4.5.1-8; depends (traitsui ^= 4.5.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 2.9.0, kiwisolver ^= 0.1.3)
+- enable 4.5.1-9; depends (traitsui ^= 5.0.0, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 2.9.0, kiwisolver ^= 0.1.3)
+- enable 4.5.1-10; depends (traitsui ^= 5.0.0, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 2.9.0, kiwisolver ^= 0.1.3)
+- enable 4.5.1-11; depends (traitsui ^= 5.0.0, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 3.0.0, kiwisolver ^= 0.1.3)
+- enable 4.5.1-12; depends (traitsui ^= 5.0.0, pyparsing ^= 2.0.3, numpy ^= 1.9.2, pillow ^= 3.1.0, kiwisolver ^= 0.1.3)
+- enable 4.5.1-14; depends (traitsui ^= 5.0.0, pyparsing ^= 2.0.3, numpy ^= 1.10.4, pillow ^= 3.1.0, kiwisolver ^= 0.1.3)
+- enable 4.5.1-15; depends (traitsui ^= 5.0.0, pyparsing ^= 2.0.3, numpy ^= 1.10.4, pillow ^= 3.1.0, kiwisolver ^= 0.1.3)
+- enable 4.5.1-16; depends (traitsui ^= 5.1.0, pyparsing ^= 2.0.3, numpy ^= 1.10.4, pillow ^= 3.1.0, kiwisolver ^= 0.1.3)
+- enaml 0.1a0-1; depends (ply)
+- enaml 0.1-1; depends (traits ^= 4.1.0, ply, casuarius ^= 1.0b1)
+- enaml 0.2.0-1; depends (traits ^= 4.2.0, ply, casuarius ^= 1.0)
+- enaml 0.6.8-1; depends (traits ^= 4.3.0, ply, casuarius ^= 1.1)
+- enaml 0.6.8-2; depends (traits ^= 4.3.0, ply, casuarius ^= 1.1)
+- enaml 0.6.8-3; depends (traits ^= 4.3.0, ply, casuarius ^= 1.1)
+- enaml 0.6.8-5; depends (traits ^= 4.4.0, ply, casuarius ^= 1.1)
+- enaml 0.8.9-1; depends (atom ^= 0.3.5, ply ^= 3.4, casuarius ^= 1.1)
+- enaml 0.9.4-1; depends (atom ^= 0.3.8, ply ^= 3.4, kiwisolver ^= 0.1.2)
+- enaml 0.9.5-1; depends (atom ^= 0.3.9, ply ^= 3.4, kiwisolver ^= 0.1.2)
+- enaml 0.9.8-1; depends (atom ^= 0.3.9, ply ^= 3.4, kiwisolver ^= 0.1.2)
+- enaml 0.9.8-2; depends (atom ^= 0.3.9, ply ^= 3.4, kiwisolver ^= 0.1.3)
+- enaml 0.9.8-3; depends (atom ^= 0.3.9, ply ^= 3.6, kiwisolver ^= 0.1.3)
+- enaml 0.9.8-4; depends (atom ^= 0.3.9, ply ^= 3.8, kiwisolver ^= 0.1.3)
+- enaml 0.9.8-5; depends (atom ^= 0.3.10, ply ^= 3.8, kiwisolver ^= 0.1.3)
+- enclosure 0.4.1-1; depends (pyface ^= 5.0.0, pycrypto ^= 2.6.1, traits ^= 4.5.0, futures ^= 3.0.3, traitsui ^= 5.0.0, apptools ^= 4.3.0, envisage ^= 4.4.0, encore ^= 0.6.0)
+- enclosure 0.4.1-2; depends (pyface ^= 5.0.0, pycrypto ^= 2.6.1, traits ^= 4.5.0, futures ^= 3.0.3, traitsui ^= 5.0.0, apptools ^= 4.4.0, envisage ^= 4.5.1, encore ^= 0.6.0)
+- enclosure 0.4.2-1; depends (pyface ^= 5.0.0, pycrypto ^= 2.6.1, traits ^= 4.5.0, futures ^= 3.0.3, traitsui ^= 5.0.0, apptools ^= 4.4.0, envisage ^= 4.5.1, encore ^= 0.6.0)
+- enclosure 0.4.2-2; depends (pyface ^= 5.0.0, pycrypto ^= 2.6.1, traits ^= 4.5.0, futures ^= 3.0.3, traitsui ^= 5.0.0, apptools ^= 4.4.0, envisage ^= 4.5.1, encore ^= 0.6.0)
+- enclosure 0.4.2-4; depends (pyface ^= 5.1.0, pycrypto ^= 2.6.1, traits ^= 4.5.0, futures ^= 3.0.3, traitsui ^= 5.1.0, apptools ^= 4.4.0, envisage ^= 4.5.1, encore ^= 0.6.0)
+- encore 0.1-1
+- encore 0.2-2
+- encore 0.3-1
+- encore 0.4.0-1
+- encore 0.5.1-1
+- encore 0.5.1-3
+- encore 0.5.1-4
+- encore 0.5.1-5
+- encore 0.6.0-1
+- encore 0.6.0-2
+- encore 0.6.0-3
+- encore 0.6.0-4
+- encore 0.6.0-5
+- encore 0.6.0-6
+- encore 0.6.0-7
+- encore 0.6.0-8
+- encore 0.6.0-9
+- encore 0.6.0-10
+- endist 1.2.2-1; depends (cheetah, distribute)
+- endist 1.2.3-1; depends (cheetah, distribute)
+- enstaller 4.3.0-1
+- enstaller 4.3.1-1
+- enstaller 4.3.2-1
+- enstaller 4.3.3-1
+- enstaller 4.3.4-1
+- enstaller 4.4.0-1
+- enstaller 4.4.1-1
+- enstaller 4.5.0-1
+- enstaller 4.5.1-1
+- enstaller 4.5.2-1
+- enstaller 4.5.3-1
+- enstaller 4.5.5-1
+- enstaller 4.5.5-2
+- enstaller 4.5.6-1
+- enstaller 4.6.0-1
+- enstaller 4.6.1-2
+- enstaller 4.6.2-1
+- enstaller 4.6.3-1
+- enstaller 4.6.4-1
+- enstaller 4.6.5-1
+- enstaller 4.7.3-1
+- enstaller 4.7.4-1
+- enstaller 4.7.5-1
+- enstaller 4.8.1-1
+- enstaller 4.8.3-1
+- enstaller 4.8.4-1
+- enstaller 4.8.5-1
+- enstaller 4.8.6-1
+- enstaller 4.8.7-1
+- enstaller 4.8.8-1
+- enstaller 4.8.9-1
+- enstaller 4.8.10-2
+- enstaller 4.8.11-1
+- enum34 1.0.3-1
+- enum34 1.0.4-1
+- enum34 1.1.1-1
+- enum34 1.1.2-1
+- envisage 4.0.0-1
+- envisage 4.1.0-1
+- envisage 4.2.0-1
+- envisage 4.3.0-1
+- envisage 4.3.0-2; depends (traits ^= 4.3.0)
+- envisage 4.4.0-1; depends (traits ^= 4.4.0)
+- envisage 4.4.0-2; depends (traits ^= 4.5.0)
+- envisage 4.5.1-1; depends (traits ^= 4.5.0, apptools ^= 4.4.0)
+- epd 7.0-1; depends (configobj == 4.7.2-2, epydoc == 3.0.1-5, numexpr == 1.4.2-1, pil == 1.1.7-3, netcdf4 == 0.9.3-2, biopython == 1.56-1, distribute == 0.6.14-2, pygments == 1.4-1, foolscap == 0.6.1-1, pyglet == 1.1.4-2, networkx == 1.4-1, bitarray == 0.3.5-3, libxslt == 1.1.24-5, xlrd == 0.7.1-3, html5lib == 0.90-2, cloud == 2.2.0-1, pyfits == 2.4.0-1, cython == 0.14.1-1, reportlab == 2.5-2, lxml == 2.3-1, docutils == 0.7-2, pyopenssl == 0.11-2, simpy == 2.1.0-2, mkl == 10.3-1, twisted == 10.2.0-1, pyserial == 2.5-2, scons == 2.0.1-2, scikits.statsmodels == 0.2.0-2, paramiko == 1.7.6-4, libxml2 == 2.7.3-3, libpng == 1.2.40-2, sympy == 0.6.7-2, python_dateutil == 1.5-2, numpy == 1.5.1-1, pandas == 0.2-2, pyzmq == 2.0.10-2, xlwt == 0.7.2-3, freetype == 2.4.4-1, sqlalchemy == 0.6.6-1, pyopengl == 3.0.1-2, swig == 1.3.40-2, fwrap == 0.1.1-1, appinst == 2.0.4-1, matplotlib == 1.0.1-1, pytz == 2010o-1, jinja2 == 2.5.5-3, ply == 3.3-3, coverage == 3.4-2, ipython == 0.10.1-2, lib_netcdf4 == 4.1.1-1, zeromq == 2.0.10-1, grin == 1.2.1-2, zope.interface == 3.6.1-2, pyyaml == 3.9-2, sphinx == 1.0.7-1, pycrypto == 2.3-2, pytables == 2.2.1-1, pyflakes == 0.4.0-2, libjpeg == 7.0-2, hdf5 == 1.8.5.1-2, pyproj == 1.8.8-2, scikits.timeseries == 0.91.3-2, pycluster == 1.50-2, pyparsing == 1.5.5-3, scipy == 0.9.0rc2-1, scikits.image == 0.2.2-2, nose == 1.0.0-1, pygarrayimage == 0.0.7-4, h5py == 1.3.1-1, pydot == 1.0.2-5, basemap == 1.0-2, idle == 2.7.1-1, scikits.learn == 0.6-1)
+- epd 7.0-2; depends (configobj == 4.7.2-2, epydoc == 3.0.1-5, numexpr == 1.4.2-1, pil == 1.1.7-3, netcdf4 == 0.9.3-2, biopython == 1.56-1, distribute == 0.6.14-2, pygments == 1.4-1, foolscap == 0.6.1-1, pyglet == 1.1.4-2, networkx == 1.4-1, bitarray == 0.3.5-3, libxslt == 1.1.24-5, xlrd == 0.7.1-3, html5lib == 0.90-2, cloud == 2.2.0-1, pyfits == 2.4.0-1, cython == 0.14.1-1, reportlab == 2.5-2, lxml == 2.3-1, docutils == 0.7-2, pyopenssl == 0.11-2, simpy == 2.1.0-2, mkl == 10.3-1, twisted == 10.2.0-1, pyserial == 2.5-2, scons == 2.0.1-2, scikits.statsmodels == 0.2.0-2, paramiko == 1.7.6-4, libxml2 == 2.7.3-3, libpng == 1.2.40-2, sympy == 0.6.7-2, python_dateutil == 1.5-2, numpy == 1.5.1-2, pandas == 0.2-3, pyzmq == 2.0.10.1-1, xlwt == 0.7.2-3, freetype == 2.4.4-1, sqlalchemy == 0.6.6-1, pyopengl == 3.0.1-2, swig == 1.3.40-2, fwrap == 0.1.1-1, appinst == 2.0.4-1, matplotlib == 1.0.1-1, pytz == 2010o-1, jinja2 == 2.5.5-3, ply == 3.3-3, coverage == 3.4-2, ipython == 0.10.1-2, lib_netcdf4 == 4.1.1-1, zeromq == 2.0.10-1, grin == 1.2.1-2, zope.interface == 3.6.1-2, pyyaml == 3.9-2, sphinx == 1.0.7-1, pycrypto == 2.3-2, pytables == 2.2.1-1, pyflakes == 0.4.0-2, libjpeg == 7.0-2, hdf5 == 1.8.5.1-2, pyproj == 1.8.8-2, scikits.timeseries == 0.91.3-2, pycluster == 1.50-2, pyparsing == 1.5.5-3, scipy == 0.9.0rc2-1, scikits.image == 0.2.2-2, nose == 1.0.0-1, pygarrayimage == 0.0.7-4, h5py == 1.3.1-1, pydot == 1.0.2-5, basemap == 1.0-2, idle == 2.7.1-1, scikits.learn == 0.6-1)
+- epd 7.1-1; depends (epydoc == 3.0.1-5, biopython == 1.57-2, distribute == 0.6.19-1, networkx == 1.5-1, numexpr == 1.4.2-2, graphcanvas == 4.0.0-1, envisage == 4.0.0-1, cython == 0.14.1-1, traitsui == 4.0.0-1, blockcanvas == 4.0.0-1, foolscap == 0.6.1-3, sympy == 0.7.0-1, python_dateutil == 1.5-2, xlwt == 0.7.2-3, freetype == 2.4.4-1, swig == 1.3.40-2, scipy == 0.9.0-2, jinja2 == 2.5.5-3, grin == 1.2.1-2, appinst == 2.1.0-1, qt == 4.7.3-1, pydot == 1.0.25-1, libjpeg == 7.0-2, nose == 1.0.0-2, pygarrayimage == 0.0.7-4, h5py == 1.3.1-2, netcdf4 == 0.9.5-1, pyside == 1.0.3-2, traits == 4.0.0-1, examples == 7.1-1, bitarray == 0.3.5-3, libxslt == 1.1.24-5, mdp == 3.1-1, html5lib == 0.90-2, pyfits == 2.4.0-2, reportlab == 2.5-2, pyopenssl == 0.12-1, doclinks == 7.1-1, docutils == 0.7-2, scikits.statsmodels == 0.2.0-2, libpng == 1.2.40-2, etsproxy == 0.1.0-1, pyopengl == 3.0.1-2, matplotlib == 1.0.1-2, ply == 3.4-1, ipython == 0.11rc1-1, lib_netcdf4 == 4.1.1-1, ets == 4.0.0-1, pyyaml == 3.10-1, pytables == 2.3b1.dev4669-1, hdf5 == 1.8.5.1-2, scikits.timeseries == 0.91.3-3, pyparsing == 1.5.6-1, scikits.image == 0.2.2-3, fwrap == 0.1.1-2, basemap == 1.0.1-1, etsdevtools == 4.0.0-1, pygments == 1.4-1, codetools == 4.0.0-1, cloud == 2.2.4-1, mkl == 10.3-1, twisted == 11.0.0-2, zope.interface == 3.6.3-1, zeromq == 2.1.7-1, numpy == 1.6.0-5, pyzmq == 2.1.7-1, enable == 4.0.0-1, pytz == 2011g-1, scimath == 4.0.0-1, pycrypto == 2.3-2, pyproj == 1.8.9-1, idle == 2.7.2-1, pyglet == 1.1.4-2, configobj == 4.7.2-2, pil == 1.1.7-3, libxml2 == 2.7.3-3, sqlalchemy == 0.7.1-1, pyserial == 2.5-2, paramiko == 1.7.7.1-1, lxml == 2.3-1, chaco == 4.0.0-1, simpy == 2.1.0-2, scons == 2.0.1-2, apptools == 4.0.0-1, pandas == 0.3.0-2, scikits.learn == 0.8-1, coverage == 3.5-1, pyface == 4.0.0-1, sphinx == 1.0.7-1, xlrd == 0.7.1-4, pyflakes == 0.4.0-3, pycluster == 1.50-3)
+- epd 7.1-2; depends (epydoc == 3.0.1-5, biopython == 1.57-3, distribute == 0.6.19-1, networkx == 1.5-1, numexpr == 1.4.2-3, graphcanvas == 4.0.0-1, envisage == 4.0.0-1, cython == 0.14.1-1, traitsui == 4.0.0-1, blockcanvas == 4.0.0-1, foolscap == 0.6.1-3, sympy == 0.7.1-1, python_dateutil == 1.5-2, xlwt == 0.7.2-3, freetype == 2.4.4-1, swig == 1.3.40-2, scipy == 0.9.0-3, jinja2 == 2.5.5-3, grin == 1.2.1-2, appinst == 2.1.0-1, qt == 4.7.3-2, pydot == 1.0.25-1, libjpeg == 7.0-2, nose == 1.0.0-2, pygarrayimage == 0.0.7-4, h5py == 2.0.0-1, netcdf4 == 0.9.5-2, pyside == 1.0.5-1, traits == 4.0.0-2, examples == 7.1-2, bitarray == 0.3.5-3, libxslt == 1.1.24-5, mdp == 3.1-1, html5lib == 0.90-2, pyfits == 2.4.0-3, reportlab == 2.5-2, pyopenssl == 0.12-1, doclinks == 7.1-2, docutils == 0.7-2, scikits.statsmodels == 0.2.0-2, libpng == 1.2.40-2, etsproxy == 0.1.0-1, pyopengl == 3.0.1-2, matplotlib == 1.0.1-3, ply == 3.4-1, ipython == 0.11-1, lib_netcdf4 == 4.1.1-1, ets == 4.0.0-2, pyyaml == 3.10-1, pytables == 2.3b1.dev4669-2, hdf5 == 1.8.5.1-2, scikits.timeseries == 0.91.3-4, pyparsing == 1.5.6-1, scikits.image == 0.2.2-4, fwrap == 0.1.1-2, basemap == 1.0.1-2, etsdevtools == 4.0.0-1, pygments == 1.4-1, codetools == 4.0.0-1, cloud == 2.2.4-1, mkl == 10.3-1, twisted == 11.0.0-2, zope.interface == 3.6.3-1, zeromq == 2.1.7-1, numpy == 1.6.1-1, pyzmq == 2.1.7-1, enable == 4.0.0-2, pytz == 2011g-1, scimath == 4.0.0-2, pycrypto == 2.3-2, pyproj == 1.8.9-1, idle == 2.7.2-2, pyglet == 1.1.4-2, configobj == 4.7.2-2, pil == 1.1.7-3, libxml2 == 2.7.3-3, sqlalchemy == 0.7.1-1, pyserial == 2.5-2, paramiko == 1.7.7.1-1, lxml == 2.3-1, chaco == 4.0.0-2, simpy == 2.1.0-2, scons == 2.0.1-2, apptools == 4.0.0-1, pandas == 0.3.0-3, scikits.learn == 0.8-2, coverage == 3.5-1, pyface == 4.0.0-1, sphinx == 1.0.7-1, xlrd == 0.7.1-4, pyflakes == 0.4.0-3, pycluster == 1.50-4)
+- epd 7.2-1; depends (epydoc == 3.0.1-6, biopython == 1.58-1, distribute == 0.6.24-1, networkx == 1.6-1, numexpr == 2.0-1, graphcanvas == 4.0.0-2, envisage == 4.1.0-1, cython == 0.15.1-1, scons == 2.0.1-2, blockcanvas == 4.0.1-1, foolscap == 0.6.2-1, sympy == 0.7.1-1, python_dateutil == 1.5-2, xlwt == 0.7.2-3, freetype == 2.4.4-1, swig == 1.3.40-2, scipy == 0.10.0-1, jinja2 == 2.6-1, grin == 1.2.1-2, appinst == 2.1.0-1, qt == 4.7.3-2, pydot == 1.0.25-1, libjpeg == 7.0-2, nose == 1.1.2-1, pygarrayimage == 0.0.7-4, h5py == 2.0.0-1, netcdf4 == 0.9.5-2, pyside == 1.0.5-1, traits == 4.1.0-1, examples == 7.2-1, bitarray == 0.3.5-3, libxslt == 1.1.24-5, mdp == 3.2-1, html5lib == 0.90-2, pyfits == 3.0.3-1, reportlab == 2.5-2, pyopenssl == 0.12-1, doclinks == 7.2-1, docutils == 0.8.1-1, scikits.statsmodels == 0.3.1-1, libpng == 1.2.40-2, etsproxy == 0.1.1-1, pyopengl == 3.0.1-2, matplotlib == 1.1.0-1, ply == 3.4-1, ipython == 0.12-1, lib_netcdf4 == 4.1.1-1, gdal == 1.8.1-1, ets == 4.1.0-1, pyyaml == 3.10-1, pytables == 2.3.1-2, hdf5 == 1.8.5.1-2, scikits.timeseries == 0.91.3-4, pyparsing == 1.5.6-1, scikits.image == 0.4.2-1, fwrap == 0.1.1-3, basemap == 1.0.1-3, etsdevtools == 4.0.0-1, pygments == 1.4-1, codetools == 4.0.0-1, cloud == 2.3.9-1, mkl == 10.3-1, twisted == 11.1.0-2, zope.interface == 3.8.0-1, pyhdf == 0.8.3-6, numpy == 1.6.1-2, pyzmq == 2.1.11-1, enable == 4.1.0-1, pytz == 2011n-1, libgdal == 1.8.1-1, scikit_learn == 0.9-1, scimath == 4.0.1-1, pycrypto == 2.4.1-1, pyproj == 1.8.9-1, idle == 2.7.2-2, pyglet == 1.1.4-2, configobj == 4.7.2-2, pil == 1.1.7-3, libxml2 == 2.7.3-3, sqlalchemy == 0.7.1-1, bsdiff4 == 1.0.1-1, pyserial == 2.6-1, apptools == 4.0.1-1, lxml == 2.3.2-1, chaco == 4.1.0-1, simpy == 2.2-1, traitsui == 4.1.0-1, paramiko == 1.7.7.1-1, pandas == 0.4.3-1, tornado == 2.1.1-1, coverage == 3.5.1-1, pyface == 4.1.0-1, sphinx == 1.1.2-1, xlrd == 0.7.1-4, pyflakes == 0.5.0-1, pycluster == 1.50-4, pep8 == 0.6.1-1)
+- epd 7.2-2; depends (epydoc == 3.0.1-6, biopython == 1.58-1, distribute == 0.6.24-1, networkx == 1.6-1, numexpr == 2.0-1, graphcanvas == 4.0.0-2, envisage == 4.1.0-1, cython == 0.15.1-1, scons == 2.0.1-2, blockcanvas == 4.0.1-1, foolscap == 0.6.2-1, sympy == 0.7.1-1, python_dateutil == 1.5-2, xlwt == 0.7.2-3, freetype == 2.4.4-1, swig == 1.3.40-2, scipy == 0.10.0-1, jinja2 == 2.6-1, grin == 1.2.1-2, appinst == 2.1.0-1, qt == 4.7.3-2, pydot == 1.0.25-1, libjpeg == 7.0-2, nose == 1.1.2-1, pygarrayimage == 0.0.7-4, h5py == 2.0.0-1, netcdf4 == 0.9.5-2, pyside == 1.1.0-2, traits == 4.1.0-1, examples == 7.2-1, bitarray == 0.3.5-3, libxslt == 1.1.24-5, mdp == 3.2-1, html5lib == 0.90-2, pyfits == 3.0.3-1, reportlab == 2.5-2, pyopenssl == 0.12-1, doclinks == 7.2-2, docutils == 0.8.1-1, scikits.statsmodels == 0.3.1-1, libpng == 1.2.40-2, etsproxy == 0.1.1-1, pyopengl == 3.0.1-2, matplotlib == 1.1.0-1, ply == 3.4-1, ipython == 0.12-1, lib_netcdf4 == 4.1.1-1, gdal == 1.8.1-2, ets == 4.1.0-1, pyyaml == 3.10-1, pytables == 2.3.1-2, hdf5 == 1.8.5.1-2, scikits.timeseries == 0.91.3-4, pyparsing == 1.5.6-1, scikits.image == 0.4.2-1, fwrap == 0.1.1-3, basemap == 1.0.1-3, etsdevtools == 4.0.0-1, pygments == 1.4-1, codetools == 4.0.0-1, cloud == 2.3.9-1, mkl == 10.3-1, twisted == 11.1.0-2, zope.interface == 3.8.0-1, pyhdf == 0.8.3-6, numpy == 1.6.1-2, pyzmq == 2.1.11-1, _osx64app == 1.0-1, enable == 4.1.0-1, pytz == 2011n-1, libgdal == 1.8.1-1, scikit_learn == 0.9-1, scimath == 4.0.1-1, pycrypto == 2.4.1-1, pyproj == 1.8.9-1, idle == 2.7.2-2, pyglet == 1.1.4-2, configobj == 4.7.2-2, pil == 1.1.7-3, libxml2 == 2.7.3-3, sqlalchemy == 0.7.1-1, bsdiff4 == 1.0.1-1, pyserial == 2.6-1, apptools == 4.0.1-1, lxml == 2.3.2-1, chaco == 4.1.0-1, simpy == 2.2-1, traitsui == 4.1.0-1, paramiko == 1.7.7.1-1, pandas == 0.6.1-1, tornado == 2.1.1-1, coverage == 3.5.1-1, pyface == 4.1.0-1, sphinx == 1.1.2-1, xlrd == 0.7.1-4, pyflakes == 0.5.0-1, pycluster == 1.50-4, pep8 == 0.6.1-1)
+- epd 7.3-1; depends (epydoc == 3.0.1-6, biopython == 1.59-1, distribute == 0.6.26-1, networkx == 1.6-1, numexpr == 2.0.1-1, graphcanvas == 4.0.0-3, envisage == 4.2.0-1, cython == 0.16-1, scons == 2.0.1-2, feedparser == 5.1.1-1, blockcanvas == 4.0.1-1, foolscap == 0.6.3-1, sympy == 0.7.1-1, python_dateutil == 1.5-2, xlwt == 0.7.3-1, freetype == 2.4.4-1, openpyxl == 1.5.8-1, swig == 1.3.40-2, scipy == 0.10.1-1, jinja2 == 2.6-2, grin == 1.2.1-2, appinst == 2.1.1-1, qt == 4.7.3-2, pydot == 1.0.28-1, libjpeg == 7.0-2, nose == 1.1.2-1, pygarrayimage == 0.0.7-4, h5py == 2.0.0-2, netcdf4 == 1.0-1, pyside == 1.1.0-3, traits == 4.2.0-1, examples == 7.3-1, bitarray == 0.8.0-1, libxslt == 1.1.26-1, mdp == 3.2-1, pyparsing == 1.5.6-1, pyfits == 3.0.6-1, reportlab == 2.5-2, pyopenssl == 0.12-1, doclinks == 7.3-1, casuarius == 1.0-1, docutils == 0.8.1-1, libpng == 1.2.40-2, etsproxy == 0.1.1-1, pyopengl == 3.0.1-2, matplotlib == 1.1.0-1, ply == 3.4-1, ipython == 0.12.1-2, lib_netcdf4 == 4.2-2, gdal == 1.8.1-2, ets == 4.2.0-1, pyyaml == 3.10-1, pythondoc == 2.7.3-1, pytables == 2.3.1-4, hdf5 == 1.8.9-1, scikits.timeseries == 0.91.3-4, jsonpickle == 0.4.0-1, scikits.image == 0.5.0-1, fwrap == 0.1.1-3, basemap == 1.0.2-1, shapely == 1.2.14-1, etsdevtools == 4.0.0-1, pygments == 1.4-1, codetools == 4.0.0-1, cloud == 2.4.6-1, mkl == 10.3-1, twisted == 12.0.0-1, html5lib == 0.90-2, blist == 1.3.4-1, libxml2 == 2.7.8-1, pyhdf == 0.8.3-6, numpy == 1.6.1-2, pyzmq == 2.1.11-1, _osx64app == 1.0-1, enable == 4.2.0-1, pytz == 2011n-1, libgdal == 1.8.1-1, scikit_learn == 0.11-1, scimath == 4.1.0-1, pyproj == 1.9.0-1, idle == 2.7.3-1, statsmodels == 0.4.0-1, encore == 0.2-2, pyglet == 1.1.4-2, configobj == 4.7.2-2, pil == 1.1.7-3, enaml == 0.2.0-1, zope.interface == 3.8.0-1, sqlalchemy == 0.7.6-1, bsdiff4 == 1.1.1-1, curl == 7.25.0-2, xlrd == 0.7.6-1, apptools == 4.1.0-1, lxml == 2.3.4-1, chaco == 4.2.0-1, simpy == 2.2-1, pyserial == 2.6-1, traitsui == 4.2.0-1, paramiko == 1.7.7.1-1, pandas == 0.7.3-2, tornado == 2.2-1, coverage == 3.5.1-1, pyface == 4.2.0-1, sphinx == 1.1.2-1, pycrypto == 2.4.1-1, pyflakes == 0.5.0-1, pycluster == 1.50-4, keyring == 0.9-1, pep8 == 1.0.1-1)
+- epd 7.3-2; depends (epydoc == 3.0.1-6, biopython == 1.59-1, distribute == 0.6.26-1, networkx == 1.6-1, numexpr == 2.0.1-1, graphcanvas == 4.0.0-3, envisage == 4.2.0-1, cython == 0.16-1, scons == 2.0.1-2, feedparser == 5.1.1-1, blockcanvas == 4.0.1-1, foolscap == 0.6.3-1, sympy == 0.7.1-1, python_dateutil == 1.5-2, xlwt == 0.7.3-1, freetype == 2.4.4-1, openpyxl == 1.5.8-1, swig == 1.3.40-2, scipy == 0.10.1-1, jinja2 == 2.6-2, grin == 1.2.1-2, appinst == 2.1.2-1, qt == 4.7.3-2, pydot == 1.0.28-1, libjpeg == 7.0-2, nose == 1.1.2-1, pygarrayimage == 0.0.7-4, h5py == 2.0.0-2, kernmagic == 0.1.0-1, netcdf4 == 1.0-1, pyside == 1.1.0-3, traits == 4.2.0-1, examples == 7.3-1, bitarray == 0.8.0-1, libxslt == 1.1.26-1, mdp == 3.2-1, pyparsing == 1.5.6-1, pyfits == 3.0.6-1, reportlab == 2.5-2, pyopenssl == 0.12-1, doclinks == 7.3-1, casuarius == 1.0-1, docutils == 0.8.1-2, libpng == 1.2.40-2, etsproxy == 0.1.1-1, pyopengl == 3.0.1-2, matplotlib == 1.1.0-1, ply == 3.4-1, ipython == 0.12.1-3, lib_netcdf4 == 4.2-2, gdal == 1.8.1-2, ets == 4.2.0-1, pyyaml == 3.10-1, pythondoc == 2.7.3-1, pytables == 2.3.1-4, hdf5 == 1.8.9-1, scikits.timeseries == 0.91.3-4, jsonpickle == 0.4.0-1, scikits.image == 0.5.0-1, fwrap == 0.1.1-3, basemap == 1.0.2-1, shapely == 1.2.14-1, etsdevtools == 4.0.0-1, pygments == 1.4-1, codetools == 4.0.0-1, cloud == 2.4.6-1, mkl == 10.3-1, twisted == 12.0.0-1, html5lib == 0.90-2, blist == 1.3.4-1, libxml2 == 2.7.8-1, pyhdf == 0.8.3-6, numpy == 1.6.1-3, pyzmq == 2.1.11-1, _osx64app == 1.0-1, enable == 4.2.0-1, pytz == 2011n-1, libgdal == 1.8.1-1, scikit_learn == 0.11-1, scimath == 4.1.0-1, pyproj == 1.9.0-1, idle == 2.7.3-1, statsmodels == 0.4.0-1, encore == 0.2-2, pyglet == 1.1.4-2, configobj == 4.7.2-2, pil == 1.1.7-3, enaml == 0.2.0-1, zope.interface == 3.8.0-1, sqlalchemy == 0.7.6-1, bsdiff4 == 1.1.1-1, curl == 7.25.0-3, xlrd == 0.7.6-1, apptools == 4.1.0-1, lxml == 2.3.4-1, chaco == 4.2.0-1, simpy == 2.2-1, pyserial == 2.6-1, traitsui == 4.2.0-1, paramiko == 1.7.7.1-1, pandas == 0.7.3-2, tornado == 2.2-1, coverage == 3.5.1-1, pyface == 4.2.0-1, sphinx == 1.1.2-1, pycrypto == 2.4.1-1, pyflakes == 0.5.0-1, pycluster == 1.50-4, keyring == 0.9-1, pep8 == 1.0.1-1)
+- epddocs 1.0-1
+- epdindex 1.0-1
+- epdindex 1.1-1
+- epdindex 1.2-1
+- epdtests 7.0-1
+- epdtests 7.1-1
+- epdtests 7.2-2
+- epdtests 7.3-1
+- epdtests 7.3-2
+- epydoc 3.0.1-4; depends (docutils ^= 0.7)
+- epydoc 3.0.1-5; depends (docutils ^= 0.7)
+- epydoc 3.0.1-6; depends (docutils ^= 0.8.1)
+- ets 4.0.0-1; depends (pyface == 4.0.0-1, scimath == 4.0.0-1, enable == 4.0.0-1, chaco == 4.0.0-1, etsdevtools == 4.0.0-1, traitsui == 4.0.0-1, blockcanvas == 4.0.0-1, apptools == 4.0.0-1, traits == 4.0.0-1, envisage == 4.0.0-1, graphcanvas == 4.0.0-1, codetools == 4.0.0-1, etsproxy == 0.1.0-1)
+- ets 4.0.0-2; depends (pyface == 4.0.0-1, scimath == 4.0.0-2, enable == 4.0.0-2, chaco == 4.0.0-2, etsdevtools == 4.0.0-1, traitsui == 4.0.0-1, blockcanvas == 4.0.0-1, apptools == 4.0.0-1, traits == 4.0.0-2, envisage == 4.0.0-1, graphcanvas == 4.0.0-1, codetools == 4.0.0-1, etsproxy == 0.1.0-1)
+- ets 4.1.0-1; depends (pyface == 4.1.0-1, scimath == 4.0.1-1, enable == 4.1.0-1, chaco == 4.1.0-1, etsdevtools == 4.0.0-1, traitsui == 4.1.0-1, blockcanvas == 4.0.1-1, apptools == 4.0.1-1, traits == 4.1.0-1, envisage == 4.1.0-1, graphcanvas == 4.0.0-2, codetools == 4.0.0-1, etsproxy == 0.1.1-1)
+- ets 4.2.0-1; depends (pyface == 4.2.0-1, scimath == 4.1.0-1, enable == 4.2.0-1, chaco == 4.2.0-1, etsdevtools == 4.0.0-1, enaml == 0.2.0-1, traitsui == 4.2.0-1, blockcanvas == 4.0.1-1, encore == 0.2-2, apptools == 4.1.0-1, traits == 4.2.0-1, envisage == 4.2.0-1, graphcanvas == 4.0.0-3, codetools == 4.0.0-1, etsproxy == 0.1.1-1)
+- ets 4.3.0-1; depends (pyface == 4.3.0-1, scimath == 4.1.2-1, enable == 4.3.0-1, chaco == 4.3.0-1, etsdevtools == 4.0.2-1, enaml == 0.6.8-1, mayavi == 4.3.0-1, casuarius == 1.1-1, traitsui == 4.3.0-1, blockcanvas == 4.0.3-1, envisage == 4.3.0-1, apptools == 4.2.0-1, traits == 4.3.0-1, graphcanvas == 4.0.2-1, etsproxy == 0.1.2-1, codetools == 4.1.0-1, encore == 0.3-1)
+- ets 4.3.0-2; depends (pyface == 4.3.0-1, scimath == 4.1.2-1, enable == 4.3.0-2, chaco == 4.3.0-1, etsdevtools == 4.0.2-1, enaml == 0.6.8-1, mayavi == 4.3.0-2, casuarius == 1.1-1, traitsui == 4.3.0-1, blockcanvas == 4.0.3-1, envisage == 4.3.0-1, apptools == 4.2.0-1, traits == 4.3.0-1, graphcanvas == 4.0.2-1, etsproxy == 0.1.2-1, codetools == 4.1.0-1, encore == 0.3-1)
+- ets 4.3.0-3; depends (pyface == 4.3.0-2, scimath == 4.1.2-2, enable == 4.3.0-5, chaco == 4.3.0-2, etsdevtools == 4.0.2-1, enaml == 0.6.8-2, mayavi == 4.3.0-3, casuarius == 1.1-1, traitsui == 4.3.0-2, blockcanvas == 4.0.3-1, envisage == 4.3.0-2, apptools == 4.2.0-2, traits == 4.3.0-2, graphcanvas == 4.0.2-1, etsproxy == 0.1.2-1, codetools == 4.1.0-2, encore == 0.3-1)
+- ets 4.3.0-5; depends (pyface == 4.3.0-2, scimath == 4.1.2-3, enable == 4.3.0-8, chaco == 4.3.0-3, etsdevtools == 4.0.2-1, enaml == 0.6.8-3, mayavi == 4.3.0-4, casuarius == 1.1-2, traitsui == 4.3.0-2, blockcanvas == 4.0.3-1, envisage == 4.3.0-2, apptools == 4.2.0-2, traits == 4.3.0-3, graphcanvas == 4.0.2-2, etsproxy == 0.1.2-1, codetools == 4.1.0-2, encore == 0.4.0-1)
+- ets 4.4.1-1; depends (pyface == 4.4.0-1, scimath == 4.1.2-3, enable == 4.3.0-10, chaco == 4.4.1-1, etsdevtools == 4.0.2-1, enaml == 0.6.8-5, mayavi == 4.3.0-5, casuarius == 1.1-3, traitsui == 4.4.0-1, blockcanvas == 4.0.3-1, envisage == 4.4.0-1, apptools == 4.2.0-4, traits == 4.4.0-1, graphcanvas == 4.0.2-2, etsproxy == 0.1.2-1, codetools == 4.2.0-1, encore == 0.4.0-1)
+- ets 4.4.2-1; depends (pyface == 4.4.0-2, encore == 0.5.1-1, scimath == 4.1.2-3, enable == 4.4.1-2, chaco == 4.4.1-2, etsdevtools == 4.0.2-1, mayavi == 4.3.1-1, traitsui == 4.4.0-2, blockcanvas == 4.0.3-1, apptools == 4.2.1-1, traits == 4.5.0-1, envisage == 4.4.0-2, graphcanvas == 4.0.2-3, codetools == 4.2.0-2, etsproxy == 0.1.2-1)
+- ets 4.4.3-1; depends (pyface == 4.4.0-2, encore == 0.5.1-4, scimath == 4.1.2-4, enable == 4.4.1-5, chaco == 4.5.0-1, etsdevtools == 4.0.2-1, mayavi == 4.3.1-2, traitsui == 4.4.0-2, blockcanvas == 4.0.3-1, apptools == 4.2.1-3, traits == 4.5.0-1, envisage == 4.4.0-2, graphcanvas == 4.0.2-5, codetools == 4.2.0-2, etsproxy == 0.1.2-1)
+- ets 4.4.3-2; depends (pyface == 4.4.0-2, encore == 0.5.1-5, scimath == 4.1.2-4, enable == 4.4.1-5, chaco == 4.5.0-1, etsdevtools == 4.0.2-1, mayavi == 4.3.1-2, traitsui == 4.4.0-2, blockcanvas == 4.0.3-1, apptools == 4.2.1-3, traits == 4.5.0-1, envisage == 4.4.0-2, graphcanvas == 4.0.2-5, codetools == 4.2.0-2, etsproxy == 0.1.2-1)
+- ets 4.4.4-1; depends (pyface == 4.4.0-2, encore == 0.6.0-1, scimath == 4.1.2-4, enable == 4.4.1-5, chaco == 4.5.0-1, etsdevtools == 4.0.2-1, mayavi == 4.3.1-2, traitsui == 4.4.0-2, blockcanvas == 4.0.3-1, apptools == 4.2.1-3, traits == 4.5.0-1, envisage == 4.4.0-2, graphcanvas == 4.0.2-5, codetools == 4.2.0-2, etsproxy == 0.1.2-1)
+- ets 4.4.4-2; depends (pyface == 4.5.0-1, encore == 0.6.0-5, scimath == 4.1.2-5, enable == 4.5.1-5, chaco == 4.5.0-3, etsdevtools == 4.0.2-1, mayavi == 4.4.0-4, traitsui == 4.5.1-1, blockcanvas == 4.0.3-1, apptools == 4.3.0-3, traits == 4.5.0-1, envisage == 4.4.0-2, graphcanvas == 4.0.2-6, codetools == 4.2.0-2, etsproxy == 0.1.2-1)
+- ets 4.4.4-3; depends (pyface == 4.5.0-1, encore == 0.6.0-6, scimath == 4.1.2-5, enable == 4.5.1-6, chaco == 4.5.0-3, etsdevtools == 4.0.2-1, mayavi == 4.4.2-1, traitsui == 4.5.1-1, blockcanvas == 4.0.3-1, apptools == 4.3.0-5, traits == 4.5.0-1, envisage == 4.4.0-2, graphcanvas == 4.0.2-6, codetools == 4.2.0-2, etsproxy == 0.1.2-1)
+- etsdevtools 4.0.0-1
+- etsdevtools 4.0.2-1
+- etsproxy 0.1.0-1
+- etsproxy 0.1.1-1
+- etsproxy 0.1.2-1
+- examples 7.1-1; depends (appinst)
+- examples 7.1-2; depends (appinst)
+- examples 7.2-1; depends (appinst)
+- examples 7.3-1; depends (appinst)
+- execnet 1.2.0-1; depends (gevent ^= 1.0.1)
+- execnet 1.4.1-1; depends (apipkg ^= 1.4, gevent ^= 1.0.2)
+- execnet 1.4.1-2; depends (apipkg ^= 1.4, gevent ^= 1.1.0)
+- expat 2.0.1-1
+- expat 2.0.1-2
+- expat 2.0.1-3
+- fabric 1.10.0-1; depends (paramiko ^= 1.15.1)
+- fabric 1.10.1-1; depends (paramiko ^= 1.15.2)
+- fabric 1.10.2-1; depends (paramiko ^= 1.16.0)
+- fabric 1.11.1-1; depends (paramiko ^= 1.16.0)
+- fastnumpy 1.0-2; depends (mkl ^= 10.3, numpy ^= 1.5.1)
+- fastnumpy 1.0-3; depends (mkl ^= 10.3, numpy ^= 1.6.1)
+- fastnumpy 1.0-5; depends (mkl ^= 10.3, numpy ^= 1.7.1)
+- fastnumpy 1.0-6; depends (mkl ^= 10.3, numpy ^= 1.8.0)
+- fastnumpy 1.0-7; depends (mkl ^= 10.3, numpy ^= 1.8.1)
+- fastnumpy 1.0-8; depends (mkl ^= 10.3, numpy ^= 1.9.2)
+- fastnumpy 1.0-9; depends (mkl ^= 11.1.4, numpy ^= 1.9.2)
+- fastnumpy 1.0-10; depends (mkl ^= 11.1.4, numpy ^= 1.10.4)
+- faulthandler 2.3-1
+- faulthandler 2.4-1
+- faulthandler 2.4-2
+- feedparser 5.1-1
+- feedparser 5.1.1-1
+- feedparser 5.1.3-1
+- feedparser 5.2.0-1
+- feedparser 5.2.1-1
+- fiona 1.0.2-1; depends (libpng ^= 1.2.40, six ^= 1.3.0, libgdal ^= 1.10.1)
+- fiona 1.0.2-2; depends (libpng ^= 1.2.40, six ^= 1.4.1, libgdal ^= 1.10.1)
+- fiona 1.0.3-1; depends (libpng ^= 1.2.40, six ^= 1.4.1, libgdal ^= 1.10.1)
+- fiona 1.0.3-2; depends (libpng ^= 1.2.40, six ^= 1.4.1, libgdal ^= 1.10.1)
+- fiona 1.0.3-3; depends (libpng ^= 1.2.40, six ^= 1.4.1, libgdal ^= 1.11.0)
+- fiona 1.0.3-4; depends (libpng ^= 1.2.40, six ^= 1.7.2, libgdal ^= 1.11.0)
+- fiona 1.1.5-1; depends (libpng ^= 1.2.40, six ^= 1.7.2, libgdal ^= 1.11.0)
+- fiona 1.1.5-2; depends (libpng ^= 1.6.12, six ^= 1.7.2, libgdal ^= 1.11.0)
+- fiona 1.1.5-3; depends (libpng ^= 1.6.12, six ^= 1.7.2, libgdal ^= 1.11.0)
+- fiona 1.1.5-4; depends (libpng ^= 1.6.12, six ^= 1.7.3, libgdal ^= 1.11.0)
+- fiona 1.2.0-5; depends (libpng ^= 1.6.12, six ^= 1.7.3, libgdal ^= 1.11.0)
+- fiona 1.2.0-6; depends (libpng ^= 1.6.12, six ^= 1.7.3, libgdal ^= 1.11.0)
+- fiona 1.2.0-7; depends (libpng ^= 1.6.12, six ^= 1.8.0, libgdal ^= 1.11.0)
+- fiona 1.4.8-1; depends (libpng ^= 1.6.12, six ^= 1.8.0, libgdal ^= 1.11.0)
+- fiona 1.4.8-2; depends (libpng ^= 1.6.12, six ^= 1.9.0, libgdal ^= 1.11.0)
+- fiona 1.4.8-4; depends (libpng ^= 1.6.12, six ^= 1.9.0, libgdal ^= 1.11.2)
+- fiona 1.4.8-5; depends (libpng ^= 1.6.12, six ^= 1.9.0, libgdal ^= 1.11.2)
+- fiona 1.4.8-7; depends (libpng ^= 1.6.12, six ^= 1.10.0, libgdal ^= 1.11.2)
+- fiona 1.6.2-1; depends (libpng ^= 1.6.12, six ^= 1.10.0, libgdal ^= 2.0.1)
+- fiona 1.6.2-4; depends (libpng ^= 1.6.12, six ^= 1.10.0, libgdal ^= 2.0.1)
+- fipy 2.1-2; depends (distribute, pysparse ^= 1.2.dev213)
+- fipy 3.1-1; depends (distribute ^= 0.6.49, pysparse ^= 1.2.dev213)
+- fipy 3.1-2; depends (pysparse ^= 1.2.dev213, setuptools ^= 14.3.1)
+- fipy 3.1-3; depends (pysparse ^= 1.2.dev213, setuptools ^= 15.1)
+- fipy 3.1-4; depends (pysparse ^= 1.2.dev213, setuptools ^= 15.2)
+- fipy 3.1-5; depends (pysparse ^= 1.2.dev213, setuptools ^= 16.0)
+- fipy 3.1-6; depends (pysparse ^= 1.2.dev213, setuptools ^= 17.1.1)
+- fipy 3.1-7; depends (pysparse ^= 1.2.dev213, setuptools ^= 18.2)
+- fipy 3.1-8; depends (pysparse ^= 1.2.dev213, setuptools ^= 18.4)
+- fipy 3.1-9; depends (pysparse ^= 1.2.dev213, setuptools ^= 18.7.1)
+- fipy 3.1-10; depends (pysparse ^= 1.2.dev213, setuptools ^= 19.1.1)
+- fipy 3.1-11; depends (pysparse ^= 1.2.dev213, setuptools ^= 19.4)
+- fipy 3.1-12; depends (pysparse ^= 1.2.dev213, setuptools ^= 20.1.1)
+- fipy 3.1-13; depends (pysparse ^= 1.2.dev213, setuptools ^= 20.2.2)
+- fipy 3.1-14; depends (pysparse ^= 1.2.dev213, setuptools ^= 20.3.1)
+- fipy 3.1-15; depends (pysparse ^= 1.2.dev213, setuptools ^= 20.6.7)
+- flake8 2.0.0-1; depends (mccabe ^= 0.2.1, pep8 ^= 1.4.6, pyflakes ^= 0.7.3)
+- flake8 2.0.0-2; depends (mccabe ^= 0.2.1, pep8 ^= 1.4.6, pyflakes ^= 0.7.3)
+- flake8 2.1.0-1; depends (mccabe ^= 0.2.1, pep8 ^= 1.5.7, pyflakes ^= 0.8.1)
+- flake8 2.2.3-1; depends (mccabe ^= 0.2.1, pep8 ^= 1.5.7, pyflakes ^= 0.8.1)
+- flake8 2.2.5-1; depends (mccabe ^= 0.2.1, pep8 ^= 1.5.7, pyflakes ^= 0.8.1)
+- flake8 2.3.0-1; depends (mccabe ^= 0.3, pep8 ^= 1.6.1, pyflakes ^= 0.8.1)
+- flake8 2.3.0-2; depends (mccabe ^= 0.3, pep8 ^= 1.6.2, pyflakes ^= 0.8.1)
+- flake8 2.4.1-1; depends (mccabe ^= 0.3, pep8 ^= 1.6.2, pyflakes ^= 0.9.2)
+- flake8 2.4.1-2; depends (mccabe ^= 0.3, pep8 ^= 1.6.2, pyflakes ^= 1.0.0)
+- flake8 2.4.1-3; depends (mccabe ^= 0.3, pep8 ^= 1.6.2, pyflakes ^= 1.0.0)
+- flake8 2.5.1-1; depends (mccabe ^= 0.3.1, pep8 ^= 1.7.0, pyflakes ^= 1.0.0)
+- flake8 2.5.1-2; depends (mccabe ^= 0.3.1, pep8 ^= 1.7.0, pyflakes ^= 1.1.0)
+- flask 0.10.1-1; depends (itsdangerous ^= 0.23.0, jinja2 ^= 2.6, werkzeug ^= 0.9.4)
+- flask 0.10.1-2; depends (itsdangerous ^= 0.23.0, jinja2 ^= 2.7.1, werkzeug ^= 0.9.4)
+- flask 0.10.1-3; depends (itsdangerous ^= 0.23.0, jinja2 ^= 2.7.3, werkzeug ^= 0.9.4)
+- flask 0.10.1-4; depends (itsdangerous ^= 0.24.0, jinja2 ^= 2.7.3, werkzeug ^= 0.9.6)
+- flask 0.10.1-5; depends (itsdangerous ^= 0.24.0, jinja2 ^= 2.7.3, werkzeug ^= 0.10.1)
+- flask 0.10.1-6; depends (itsdangerous ^= 0.24.0, jinja2 ^= 2.7.3, werkzeug ^= 0.10.4)
+- flask 0.10.1-7; depends (itsdangerous ^= 0.24.0, jinja2 ^= 2.8, werkzeug ^= 0.10.4)
+- flask 0.10.1-8; depends (itsdangerous ^= 0.24.0, jinja2 ^= 2.8, werkzeug ^= 0.11.2)
+- flask 0.10.1-9; depends (itsdangerous ^= 0.24.0, jinja2 ^= 2.8, werkzeug ^= 0.11.3)
+- flask 0.10.1-10; depends (itsdangerous ^= 0.24.0, jinja2 ^= 2.8, werkzeug ^= 0.11.4)
+- flask 0.10.1-11; depends (itsdangerous ^= 0.24.0, jinja2 ^= 2.8, werkzeug ^= 0.11.5)
+- flask_babel 0.9-1; depends (flask ^= 0.10.1, babel ^= 1.3, speaklater ^= 1.3, jinja2 ^= 2.7.3)
+- flask_babel 0.9-2; depends (flask ^= 0.10.1, babel ^= 2.1.1, speaklater ^= 1.3, jinja2 ^= 2.8)
+- flask_babel 0.9-3; depends (flask ^= 0.10.1, babel ^= 2.2.0, speaklater ^= 1.3, jinja2 ^= 2.8)
+- flask_babel 0.9-4; depends (flask ^= 0.10.1, babel ^= 2.3.4, speaklater ^= 1.3, jinja2 ^= 2.8)
+- flask_compress 1.0.2-1; depends (flask ^= 0.10.1)
+- flask_compress 1.2.0-1; depends (flask ^= 0.10.1)
+- flask_compress 1.3.0-1; depends (flask ^= 0.10.1)
+- flask_cors 2.1.2-1; depends (flask ^= 0.10.1, six ^= 1.10.0)
+- flask_login 0.2.11-1
+- flask_restful 0.3.2-1; depends (flask ^= 0.10.1, aniso8601 ^= 0.92, pytz ^= 2014.9.0, six ^= 1.9.0)
+- flask_restful 0.3.2-2; depends (flask ^= 0.10.1, aniso8601 ^= 0.92, pytz ^= 2014.9.0, six ^= 1.10.0)
+- flask_restful 0.3.2-3; depends (flask ^= 0.10.1, aniso8601 ^= 0.92, pytz ^= 2015.7, six ^= 1.10.0)
+- flask_restful 0.3.2-4; depends (flask ^= 0.10.1, aniso8601 ^= 0.92, pytz ^= 2016.3, six ^= 1.10.0)
+- flask_restful_swagger 0.19-1; depends (flask_restful ^= 0.3.2)
+- flask_restplus 0.7.1-1; depends (flask_restful ^= 0.3.2)
+- flask_restplus 0.7.1-2; depends (flask_restful ^= 0.3.2)
+- flask_wtf 0.11-1; depends (flask ^= 0.10.1, wtforms ^= 2.0.2)
+- foolscap 0.5.1-3; depends (pyopenssl ^= 0.11, twisted ^= 10.2.0)
+- foolscap 0.6.1-1; depends (pyopenssl ^= 0.11, twisted ^= 10.2.0)
+- foolscap 0.6.1-2; depends (pyopenssl ^= 0.11, twisted ^= 11.0.0)
+- foolscap 0.6.1-3; depends (pyopenssl ^= 0.12, twisted ^= 11.0.0)
+- foolscap 0.6.2-1; depends (pyopenssl ^= 0.12, twisted ^= 11.1.0)
+- foolscap 0.6.3-1; depends (pyopenssl ^= 0.12, twisted ^= 12.0.0)
+- foolscap 0.6.3-3; depends (pyopenssl ^= 0.13.1, twisted ^= 12.0.0)
+- foolscap 0.6.3-4; depends (pyopenssl ^= 0.13.1, twisted ^= 14.0.0)
+- foolscap 0.7.0-1; depends (pyopenssl ^= 0.13.1, twisted ^= 14.0.2)
+- foolscap 0.7.0-3; depends (pyopenssl ^= 0.14, twisted ^= 14.0.2)
+- foolscap 0.7.0-4; depends (pyopenssl ^= 0.14, twisted ^= 15.1.0)
+- foolscap 0.7.0-5; depends (pyopenssl ^= 0.15.1, twisted ^= 15.1.0)
+- foolscap 0.7.0-6; depends (pyopenssl ^= 0.15.1, twisted ^= 15.2.1)
+- foolscap 0.7.0-7; depends (pyopenssl ^= 0.15.1, twisted ^= 15.4.0)
+- foolscap 0.7.0-8; depends (pyopenssl ^= 0.15.1, twisted ^= 15.5.0)
+- foolscap 0.7.0-9; depends (pyopenssl ^= 16.0.0, twisted ^= 15.5.0)
+- foolscap 0.7.0-10; depends (pyopenssl ^= 16.0.0, twisted ^= 16.0.0)
+- foolscap 0.7.0-11; depends (pyopenssl ^= 16.0.0, twisted ^= 16.1.1)
+- freetype 2.3.11-1
+- freetype 2.4.4-1
+- freetype 2.4.4-4
+- freetype 2.4.4-5
+- freetype 2.5.3-1
+- freetype 2.5.3-2
+- freetype 2.5.3-3; depends (libpng ^= 1.6.12)
+- freetype 2.5.3-4; depends (libpng ^= 1.6.12)
+- funcsigs 0.4-1
+- functools32 3.2.3.2-1
+- future 0.13.1-1
+- future 0.14.1-1
+- future 0.14.2-1
+- future 0.14.3-1
+- future 0.15.2-1
+- futures 2.1.4-1
+- futures 2.1.4-2
+- futures 2.1.6-1
+- futures 2.2.0-1
+- futures 3.0.3-1
+- fwrap 0.1.1-1; depends (cython ^= 0.14.1, numpy ^= 1.5.1)
+- fwrap 0.1.1-2; depends (cython ^= 0.14.1, numpy)
+- fwrap 0.1.1-3; depends (cython, numpy)
+- fwrap 0.1.1-4; depends (cython, numpy)
+- fwrap 0.1.1-5; depends (cython, numpy)
+- fwrap 0.1.1-6; depends (cython, numpy)
+- fwrap 0.1.1-8; depends (cython, numpy)
+- fwrap 0.1.1-9; depends (cython, numpy)
+- fwrap 0.1.1-10; depends (cython, numpy)
+- fwrap 0.1.1-11; depends (cython, numpy)
+- fwrap 0.1.1-12; depends (cython, numpy)
+- fwrap 0.1.1-13; depends (cython, numpy)
+- fwrap 0.1.1-14; depends (cython, numpy)
+- fwrap 0.1.1-15; depends (cython, numpy)
+- fwrap 0.1.1-16; depends (cython, numpy)
+- fwrap 0.1.1-17; depends (cython, numpy)
+- fwrap 0.1.1-18; depends (cython, numpy)
+- gdal 1.7.1-1; depends (libgdal ^= 1.7.2, numpy)
+- gdal 1.8.1-1; depends (libgdal ^= 1.8.1, numpy ^= 1.6.1)
+- gdal 1.8.1-2; depends (libgdal ^= 1.8.1, numpy ^= 1.6.1)
+- gdal 1.9.0-3; depends (libgdal ^= 1.9.0, numpy ^= 1.7.1)
+- gdal 1.10.0-1; depends (libgdal ^= 1.10.0, numpy ^= 1.7.1)
+- gdal 1.10.0-2; depends (libgdal ^= 1.10.1, numpy ^= 1.7.1)
+- gdal 1.10.0-3; depends (libgdal ^= 1.10.1, numpy ^= 1.8.0)
+- gdal 1.10.0-4; depends (libgdal ^= 1.10.1, numpy ^= 1.8.0)
+- gdal 1.10.0-5; depends (libgdal ^= 1.11.0, numpy ^= 1.8.0)
+- gdal 1.10.0-6; depends (libgdal ^= 1.11.0, numpy ^= 1.8.0)
+- gdal 1.11.0-1; depends (libgdal ^= 1.11.0, numpy ^= 1.8.0)
+- gdal 1.11.0-2; depends (libgdal ^= 1.11.0, numpy ^= 1.8.0)
+- gdal 1.11.0-3; depends (libgdal ^= 1.11.0, numpy ^= 1.8.1)
+- gdal 1.11.0-4; depends (libgdal ^= 1.11.0, numpy ^= 1.8.1)
+- gdal 1.11.0-5; depends (libgdal ^= 1.11.0, numpy ^= 1.8.1)
+- gdal 1.11.1-1; depends (libgdal ^= 1.11.0, numpy ^= 1.8.1)
+- gdal 1.11.2-1; depends (libgdal ^= 1.11.2, numpy ^= 1.8.1)
+- gdal 1.11.2-2; depends (libgdal ^= 1.11.2, numpy ^= 1.9.2)
+- gdal 1.11.2-4; depends (libgdal ^= 1.11.2, numpy ^= 1.9.2)
+- gdal 2.0.1-1; depends (libgdal ^= 2.0.1, numpy ^= 1.9.2)
+- gdal 2.0.1-4; depends (libgdal ^= 2.0.1, numpy ^= 1.10.4)
+- gdata 2.0.18-1
+- geojson 1.0.8-1
+- geos 3.4.2-1
+- geos 3.5.0-1
+- gevent 0.13.8-1; depends (greenlet ^= 0.4.1, libevent ^= 2.0.21)
+- gevent 1.0.0-1; depends (greenlet ^= 0.4.2)
+- gevent 1.0.1-1; depends (greenlet ^= 0.4.2)
+- gevent 1.0.1-2; depends (greenlet ^= 0.4.4)
+- gevent 1.0.1-4; depends (greenlet ^= 0.4.5)
+- gevent 1.0.1-5; depends (greenlet ^= 0.4.6)
+- gevent 1.0.2-1; depends (greenlet ^= 0.4.9)
+- gevent 1.1.0-1; depends (greenlet ^= 0.4.9)
+- gevent_websocket 0.9.3-1
+- gevent_websocket 0.9.5-1; depends (gevent ^= 1.1.0)
+- ggplot 0.6.8-1; depends (six ^= 1.10.0, patsy ^= 0.4.1, brewer2mpl ^= 1.4.0, scipy ^= 0.16.1, matplotlib ^= 1.5.1, statsmodels ^= 0.6.1, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- ggplot 0.6.8-2; depends (six ^= 1.10.0, patsy ^= 0.4.1, brewer2mpl ^= 1.4.0, scipy ^= 0.17.0, matplotlib ^= 1.5.1, statsmodels ^= 0.6.1, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- ggplot 0.6.8-3; depends (six ^= 1.10.0, patsy ^= 0.4.1, brewer2mpl ^= 1.4.0, scipy ^= 0.17.0, matplotlib ^= 1.5.1, statsmodels ^= 0.6.1, numpy ^= 1.9.2, pandas ^= 0.18.0)
+- ggplot 0.6.8-4; depends (six ^= 1.10.0, patsy ^= 0.4.1, brewer2mpl ^= 1.4.0, scipy ^= 0.17.0, matplotlib ^= 1.5.1, statsmodels ^= 0.6.1, numpy ^= 1.10.4, pandas ^= 0.18.0)
+- gitdb 0.6.4-1; depends (smmap ^= 0.9.0)
+- gitpython 1.0.0-1; depends (gitdb ^= 0.6.4)
+- googlecl 0.9.12-1
+- graphcanvas 4.0.0-1; depends (enable ^= 4.0.0, networkx ^= 1.5)
+- graphcanvas 4.0.0-2; depends (enable ^= 4.1.0, networkx ^= 1.6)
+- graphcanvas 4.0.0-3; depends (enable ^= 4.2.0, networkx ^= 1.6)
+- graphcanvas 4.0.2-1; depends (enable ^= 4.3.0, networkx ^= 1.6)
+- graphcanvas 4.0.2-2; depends (enable ^= 4.3.0, networkx ^= 1.8.1)
+- graphcanvas 4.0.2-3; depends (enable ^= 4.4.1, networkx ^= 1.8.1)
+- graphcanvas 4.0.2-4; depends (enable ^= 4.4.1, networkx ^= 1.9)
+- graphcanvas 4.0.2-5; depends (enable ^= 4.4.1, networkx ^= 1.9.1)
+- graphcanvas 4.0.2-6; depends (enable ^= 4.5.1, networkx ^= 1.9.1)
+- graphcanvas 4.0.2-7; depends (enable ^= 4.5.1, networkx ^= 1.10)
+- graphcanvas 4.0.2-8; depends (enable ^= 4.5.1, networkx ^= 1.11)
+- greenlet 0.4.1-1
+- greenlet 0.4.2-1
+- greenlet 0.4.4-1
+- greenlet 0.4.4-2
+- greenlet 0.4.5-1
+- greenlet 0.4.6-1
+- greenlet 0.4.9-1
+- grib_api 1.9.9-1
+- grin 1.2.1-2
+- gunicorn 18.0-1; depends (gevent ^= 1.0.0, greenlet ^= 0.4.2)
+- gunicorn 19.1.0-1; depends (gevent ^= 1.0.1, greenlet ^= 0.4.2)
+- gunicorn 19.1.1-1; depends (gevent ^= 1.0.1, greenlet ^= 0.4.4)
+- gunicorn 19.1.1-3; depends (gevent ^= 1.0.1, greenlet ^= 0.4.5)
+- gunicorn 19.3.0-1; depends (gevent ^= 1.0.1, greenlet ^= 0.4.5)
+- gunicorn 19.3.0-2; depends (gevent ^= 1.0.1, greenlet ^= 0.4.6)
+- gunicorn 19.3.0-3; depends (gevent ^= 1.0.1, greenlet ^= 0.4.6)
+- gunicorn 19.3.0-4; depends (gevent ^= 1.0.1, greenlet ^= 0.4.6)
+- gunicorn 19.4.1-1; depends (gevent ^= 1.0.2, greenlet ^= 0.4.9)
+- gunicorn 19.4.1-2; depends (gevent ^= 1.1.0, greenlet ^= 0.4.9)
+- h5py 1.3.1-1; depends (numpy ^= 1.5.1)
+- h5py 1.3.1-2; depends (numpy ^= 1.6.0)
+- h5py 2.0.0-1; depends (numpy ^= 1.6.1, hdf5 ^= 1.8.5.1)
+- h5py 2.0.0-2; depends (numpy ^= 1.6.1, hdf5 ^= 1.8.9)
+- h5py 2.1.3-2; depends (numpy ^= 1.7.1, hdf5 ^= 1.8.9)
+- h5py 2.2.0-1; depends (numpy ^= 1.7.1, hdf5 ^= 1.8.11)
+- h5py 2.2.0-2; depends (numpy ^= 1.8.0, hdf5 ^= 1.8.11)
+- h5py 2.2.1-1; depends (numpy ^= 1.8.0, hdf5 ^= 1.8.11)
+- h5py 2.3.0-1; depends (numpy ^= 1.8.0, hdf5 ^= 1.8.11)
+- h5py 2.3.0-2; depends (numpy ^= 1.8.1, hdf5 ^= 1.8.11)
+- h5py 2.3.1-1; depends (numpy ^= 1.8.1, hdf5 ^= 1.8.11)
+- h5py 2.4.0-1; depends (numpy ^= 1.8.1, hdf5 ^= 1.8.11)
+- h5py 2.4.0-2; depends (numpy ^= 1.8.1, hdf5 ^= 1.8.14)
+- h5py 2.5.0-1; depends (numpy ^= 1.8.1, hdf5 ^= 1.8.14)
+- h5py 2.5.0-2; depends (numpy ^= 1.9.2, hdf5 ^= 1.8.14)
+- h5py 2.5.0-3; depends (numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- h5py 2.5.0-4; depends (numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- h5py 2.5.0-5; depends (numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- h5py 2.5.0-6; depends (numpy ^= 1.9.2, hdf5 ^= 1.8.16)
+- h5py 2.5.0-7; depends (numpy ^= 1.10.4, hdf5 ^= 1.8.16)
+- h5py 2.6.0-1; depends (numpy ^= 1.10.4, hdf5 ^= 1.8.16)
+- h5py 2.6.0-2; depends (numpy ^= 1.10.4, hdf5 ^= 1.8.16)
+- haas 0.6.0-1; depends (enum34 ^= 1.0.4, stevedore ^= 1.1.0)
+- haas 0.6.0-2; depends (enum34 ^= 1.0.4, stevedore ^= 1.2.0)
+- haas 0.6.0-3; depends (enum34 ^= 1.0.4, six ^= 1.9.0, stevedore ^= 1.2.0)
+- haas 0.6.2-1; depends (enum34 ^= 1.0.4, six ^= 1.9.0, stevedore ^= 1.2.0)
+- haas 0.6.2-2; depends (enum34 ^= 1.0.4, six ^= 1.9.0, stevedore ^= 1.2.0)
+- haas 0.6.2-3; depends (enum34 ^= 1.0.4, six ^= 1.10.0, stevedore ^= 1.2.0)
+- haas 0.6.2-4; depends (enum34 ^= 1.1.1, six ^= 1.10.0, stevedore ^= 1.2.0)
+- haas 0.6.2-5; depends (enum34 ^= 1.1.2, six ^= 1.10.0, stevedore ^= 1.2.0)
+- haas 0.6.2-6; depends (enum34 ^= 1.1.2, six ^= 1.10.0, stevedore ^= 1.2.0)
+- hatcher 0.4.2-1; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.3.3, six ^= 1.8.0, requests ^= 2.5.0, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.4.2-2; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.3.3, six ^= 1.8.0, requests ^= 2.5.1, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.4.2-3; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.3.3, six ^= 1.9.0, requests ^= 2.5.1, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.4.2-4; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.3.3, six ^= 1.9.0, requests ^= 2.5.3, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.5.0-1; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.3.3, six ^= 1.9.0, requests ^= 2.5.3, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.5.0-2; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.3.3, six ^= 1.9.0, requests ^= 2.6.0, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.6.0-1; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.3.3, six ^= 1.9.0, requests ^= 2.6.0, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.6.0-2; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.5.0, six ^= 1.9.0, requests ^= 2.6.0, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.7.0-1; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.5.0, six ^= 1.9.0, requests ^= 2.6.0, click ^= 3.3, tabulate ^= 0.7.3)
+- hatcher 0.7.3-1; depends (pyyaml ^= 3.11, clint ^= 0.4.1, okonomiyaki ^= 0.5.0, six ^= 1.9.0, requests ^= 2.6.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.0-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.5.0, six ^= 1.9.0, requests ^= 2.6.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.1-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.5.1, six ^= 1.9.0, requests ^= 2.6.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.1-2; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.5.1, six ^= 1.9.0, requests ^= 2.6.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.1-3; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.5.1, six ^= 1.9.0, requests ^= 2.6.2, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.2-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.5.1, six ^= 1.9.0, requests ^= 2.6.2, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.2-2; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.5.1, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.3-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.5.1, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.4-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.7.0, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.4-2; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.8.0, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.5-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.9.0, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.7-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.9.0, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.0, tabulate ^= 0.7.3)
+- hatcher 0.8.7-2; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.9.0, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.8.8-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.12.0, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.8.8-2; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.13.0, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.8.8-3; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.13.1, six ^= 1.9.0, requests ^= 2.7.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.8.8-4; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.13.1, six ^= 1.9.0, requests ^= 2.8.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.8.8-5; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.13.1, six ^= 1.9.0, requests ^= 2.8.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.8.8-6; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.13.1, six ^= 1.10.0, requests ^= 2.8.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.9.0-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.13.1, six ^= 1.10.0, requests ^= 2.8.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.9.1-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.14.0, six ^= 1.10.0, requests ^= 2.8.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.9.1-2; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.14.0, six ^= 1.10.0, requests ^= 2.9.0, click ^= 4.1, tabulate ^= 0.7.3)
+- hatcher 0.9.2-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.14.0, six ^= 1.10.0, requests ^= 2.9.0, click ^= 6.2, tabulate ^= 0.7.3)
+- hatcher 0.9.2-2; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.14.0, six ^= 1.10.0, requests ^= 2.9.1, click ^= 6.2, tabulate ^= 0.7.3)
+- hatcher 0.9.2-3; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.14.1, six ^= 1.10.0, requests ^= 2.9.1, click ^= 6.2, tabulate ^= 0.7.3)
+- hatcher 0.10.0-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.14.1, six ^= 1.10.0, tzlocal ^= 1.2, requests ^= 2.9.1, click ^= 6.2, tabulate ^= 0.7.3)
+- hatcher 0.10.0-2; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.14.1, six ^= 1.10.0, tzlocal ^= 1.2, requests ^= 2.9.1, click ^= 6.3, tabulate ^= 0.7.3)
+- hatcher 0.10.0-3; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.14.1, six ^= 1.10.0, tzlocal ^= 1.2, requests ^= 2.9.1, click ^= 6.6, tabulate ^= 0.7.3)
+- hatcher 0.10.1-1; depends (pyyaml ^= 3.11, okonomiyaki ^= 0.15.0, six ^= 1.10.0, tzlocal ^= 1.2, requests ^= 2.9.1, click ^= 6.6, tabulate ^= 0.7.3)
+- hdf 4.2.6-1
+- hdf5 1.8.3-1
+- hdf5 1.8.4-1
+- hdf5 1.8.5.1-1
+- hdf5 1.8.5.1-2
+- hdf5 1.8.9-1
+- hdf5 1.8.9-4
+- hdf5 1.8.11-1
+- hdf5 1.8.14-1
+- hdf5 1.8.15.1-1
+- hdf5 1.8.15.1-2
+- hdf5 1.8.16-1
+- hdf5 1.8.16-2
+- heapdict 1.0.0-1
+- heapdict 1.0.0-2
+- hello_world 1.0-1
+- holoviews 1.4.3-1; depends (numpy ^= 1.9.2, param ^= 1.3.2)
+- holoviews 1.4.3-2; depends (numpy ^= 1.10.4, param ^= 1.3.2)
+- html5lib 0.90-2
+- html5lib 0.95-1
+- html5lib 0.999-1
+- htmltemplate 1.5.0-1
+- htmltemplate 1.5.0-2
+- httpbin 0.4.0-1; depends (flask ^= 0.10.1, markupsafe ^= 0.23, itsdangerous ^= 0.24.0, six ^= 1.10.0, decorator ^= 4.0.4)
+- httpbin 0.4.0-2; depends (flask ^= 0.10.1, markupsafe ^= 0.23, itsdangerous ^= 0.24.0, six ^= 1.10.0, decorator ^= 4.0.6)
+- httpbin 0.4.0-3; depends (flask ^= 0.10.1, markupsafe ^= 0.23, itsdangerous ^= 0.24.0, six ^= 1.10.0, decorator ^= 4.0.9)
+- httpretty 0.8.10-1
+- humanize 0.5.1-1
+- hypothesis 1.12.0-1
+- hypothesis 3.1.3-1
+- idle 2.7.1-1; depends (appinst)
+- idle 2.7.2-1; depends (appinst)
+- idle 2.7.2-2; depends (appinst)
+- idle 2.7.3-1; depends (appinst)
+- idna 2.0-1
+- imagesize 0.7.1-1
+- into 0.1.3-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, datashape ^= 0.4.2, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.15.2)
+- into 0.1.4-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, datashape ^= 0.4.2, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.15.2)
+- into 0.1.4-2; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, datashape ^= 0.4.2, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.15.2)
+- into 0.2.1-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, datashape ^= 0.4.2, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.15.2)
+- into 0.2.2-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, datashape ^= 0.4.3, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.15.2)
+- into 0.2.2-2; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, datashape ^= 0.4.3, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.15.2)
+- into 0.2.2-3; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.8, datashape ^= 0.4.3, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.16.0)
+- into 0.2.2-4; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.9, datashape ^= 0.4.3, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.16.0)
+- ipaddress 1.0.7-1
+- ipaddress 1.0.15-1
+- ipykernel 4.0.3-2; depends (ipython4 ^= 4.0.0, traitlets ^= 4.0.0, jupyter_client ^= 4.0.0)
+- ipykernel 4.1.0-1; depends (ipython4 ^= 4.0.0, traitlets ^= 4.0.0, jupyter_client ^= 4.0.0)
+- ipykernel 4.1.0-2; depends (ipython4 ^= 4.0.0, traitlets ^= 4.0.0, jupyter_client ^= 4.0.0)
+- ipykernel 4.1.0-3; depends (ipython4 ^= 4.0.0, traitlets ^= 4.0.0, jupyter_client ^= 4.0.0)
+- ipykernel 4.1.0-4; depends (ipython4 ^= 4.0.0, traitlets ^= 4.0.0, jupyter_client ^= 4.0.0)
+- ipykernel 4.2.0-1; depends (ipython4 ^= 4.0.1, traitlets ^= 4.0.0, jupyter_client ^= 4.1.1)
+- ipykernel 4.2.2-1; depends (ipython4 ^= 4.0.1, traitlets ^= 4.1.0, jupyter_client ^= 4.1.1)
+- ipykernel 4.3.1-1; depends (ipython4 ^= 4.1.2, traitlets ^= 4.1.0, jupyter_client ^= 4.2.1)
+- ipykernel 4.3.1-3; depends (ipython4 ^= 4.1.2, traitlets ^= 4.2.1, jupyter_client ^= 4.2.2)
+- ipyparallel 4.0.2-1; depends (ipython4 ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.1.0, decorator ^= 4.0.2, ipython_genutils ^= 0.1.0, pyzmq ^= 14.7.0)
+- ipyparallel 4.1.0-1; depends (ipython4 ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.0, decorator ^= 4.0.4, ipython_genutils ^= 0.1.0, pyzmq ^= 14.7.0)
+- ipyparallel 4.1.0-2; depends (ipython4 ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.0, decorator ^= 4.0.4, ipython_genutils ^= 0.1.0, pyzmq ^= 15.1.0)
+- ipyparallel 4.1.0-3; depends (ipython4 ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.2, decorator ^= 4.0.6, ipython_genutils ^= 0.1.0, pyzmq ^= 15.1.0)
+- ipyparallel 5.0.1-2; depends (ipython4 ^= 4.1.2, jupyter_client ^= 4.2.1, ipykernel ^= 4.3.1, tornado ^= 4.3, futures ^= 3.0.3, decorator ^= 4.0.9, ipython_genutils ^= 0.1.0, pyzmq ^= 15.1.0)
+- ipyparallel 5.0.1-3; depends (ipython4 ^= 4.1.2, jupyter_client ^= 4.2.1, ipykernel ^= 4.3.1, tornado ^= 4.3, futures ^= 3.0.3, decorator ^= 4.0.9, ipython_genutils ^= 0.1.0, pyzmq ^= 15.2.0)
+- ipyparallel 5.0.1-4; depends (ipython4 ^= 4.1.2, jupyter_client ^= 4.2.2, ipykernel ^= 4.3.1, tornado ^= 4.3, futures ^= 3.0.3, decorator ^= 4.0.9, ipython_genutils ^= 0.1.0, pyzmq ^= 15.2.0)
+- ipython 0.10.1-2; depends (appinst)
+- ipython 0.10.2-1; depends (appinst)
+- ipython 0.10.2-2; depends (appinst)
+- ipython 0.11rc1-1; depends (appinst)
+- ipython 0.11rc4-1; depends (appinst)
+- ipython 0.11-1; depends (appinst)
+- ipython 0.12rc1-1; depends (appinst)
+- ipython 0.12-1; depends (appinst)
+- ipython 0.12-2; depends (appinst)
+- ipython 0.12.1-1; depends (appinst)
+- ipython 0.12.1-2; depends (appinst)
+- ipython 0.12.1-3; depends (appinst)
+- ipython 0.13.1-1; depends (appinst)
+- ipython 0.13.1-2; depends (appinst)
+- ipython 1.0.0-1; depends (tornado ^= 2.2, appinst, pygments ^= 1.6.0, jinja2 ^= 2.6, pyzmq ^= 2.2.0)
+- ipython 1.0.0-2; depends (tornado ^= 2.2, appinst, pygments ^= 1.6.0, jinja2 ^= 2.6, pyzmq ^= 2.2.0)
+- ipython 1.1.0-1; depends (tornado ^= 2.2, appinst, pygments ^= 1.6.0, jinja2 ^= 2.6, pyzmq ^= 2.2.0)
+- ipython 1.1.0-2; depends (tornado ^= 3.1.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.6, pyzmq ^= 2.2.0)
+- ipython 1.1.0-3; depends (tornado ^= 3.1.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.1, pyzmq ^= 2.2.0)
+- ipython 1.1.0-6; depends (tornado ^= 3.1.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.1, pyzmq ^= 2.2.0)
+- ipython 1.2.1-2; depends (tornado ^= 3.1.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.1, pyzmq ^= 2.2.0)
+- ipython 1.2.1-3; depends (tornado ^= 3.1.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.1, pyzmq ^= 14.1.1)
+- ipython 2.0.0-1; depends (tornado ^= 3.1.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.1, pyzmq ^= 14.1.1)
+- ipython 2.1.0-1; depends (tornado ^= 3.1.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.1, pyzmq ^= 14.1.1)
+- ipython 2.1.0-2; depends (tornado ^= 3.1.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.3, pyzmq ^= 14.1.1)
+- ipython 2.1.0-3; depends (tornado ^= 3.2.2, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.3, pyzmq ^= 14.1.1)
+- ipython 2.1.0-6; depends (tornado ^= 3.2.2, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.3, pyzmq ^= 14.3.1)
+- ipython 2.2.0-1; depends (tornado ^= 3.2.2, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.3, pyzmq ^= 14.3.1)
+- ipython 2.2.0-2; depends (tornado ^= 4.0.1, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.3, pyzmq ^= 14.3.1)
+- ipython 2.2.0-3; depends (tornado ^= 4.0.2, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.3, pyzmq ^= 14.3.1)
+- ipython 2.3.0-1; depends (tornado ^= 4.0.2, appinst, pygments ^= 1.6.0, jinja2 ^= 2.7.3, pyzmq ^= 14.3.1)
+- ipython 2.3.1-1; depends (tornado ^= 4.0.2, appinst, pygments ^= 2.0.1, jinja2 ^= 2.7.3, pyzmq ^= 14.3.1)
+- ipython 2.3.1-2; depends (tornado ^= 4.0.2, appinst, pygments ^= 2.0.1, jinja2 ^= 2.7.3, pyzmq ^= 14.4.1)
+- ipython 2.3.1-3; depends (tornado ^= 4.0.2, appinst, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.4.1)
+- ipython 2.3.1-4; depends (tornado ^= 4.0.2, appinst, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.5.0)
+- ipython 2.4.1-1; depends (tornado ^= 4.1, appinst, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.5.0)
+- ipython 3.0.0-1; depends (mistune ^= 0.5, appinst, tornado ^= 4.1, pygments ^= 2.0.2, jinja2 ^= 2.7.3, jsonschema ^= 2.4.0, terminado ^= 0.5, pyzmq ^= 14.5.0)
+- ipython 3.0.0-2; depends (mistune ^= 0.5, appinst, tornado ^= 4.1, pygments ^= 2.0.2, jinja2 ^= 2.7.3, jsonschema ^= 2.4.0, terminado ^= 0.5, pyzmq ^= 14.5.0)
+- ipython 3.0.0-3; depends (mistune ^= 0.5.1, appinst, tornado ^= 4.1, pygments ^= 2.0.2, jinja2 ^= 2.7.3, jsonschema ^= 2.4.0, terminado ^= 0.5, pyzmq ^= 14.5.0)
+- ipython 3.1.0-1; depends (mistune ^= 0.5.1, appinst, tornado ^= 4.1, pygments ^= 2.0.2, jinja2 ^= 2.7.3, jsonschema ^= 2.4.0, terminado ^= 0.5, pyzmq ^= 14.5.0)
+- ipython 3.1.0-2; depends (mistune ^= 0.5.1, appinst, tornado ^= 4.1, pygments ^= 2.0.2, jinja2 ^= 2.7.3, jsonschema ^= 2.4.0, terminado ^= 0.5, pyzmq ^= 14.6.0)
+- ipython 3.2.0-1; depends (mistune ^= 0.6, appinst, tornado ^= 4.2, pygments ^= 2.0.2, jinja2 ^= 2.7.3, jsonschema ^= 2.4.0, terminado ^= 0.5, pyzmq ^= 14.7.0)
+- ipython 3.2.1-1; depends (mistune ^= 0.6, appinst, tornado ^= 4.2, pygments ^= 2.0.2, jinja2 ^= 2.7.3, jsonschema ^= 2.4.0, terminado ^= 0.5, pyzmq ^= 14.7.0)
+- ipython 4.0.0-2; depends (jupyter ^= 1.0.0)
+- ipython 4.0.0-3; depends (jupyter ^= 1.0.0)
+- ipython 4.0.0-4; depends (jupyter ^= 1.0.0)
+- ipython 4.0.0-5; depends (jupyter ^= 1.0.0)
+- ipython 4.0.0-6; depends (jupyter ^= 1.0.0)
+- ipython 4.0.0-7; depends (jupyter ^= 1.0.0)
+- ipython 4.0.0-8; depends (jupyter ^= 1.0.0)
+- ipython4 4.0.0-2; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, traitlets ^= 4.0.0, pickleshare ^= 0.5, decorator ^= 4.0.2)
+- ipython4 4.0.0-3; depends (pickleshare ^= 0.5, appinst, traitlets ^= 4.0.0, simplegeneric ^= 0.8.1, decorator ^= 4.0.2)
+- ipython4 4.0.0-4; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, traitlets ^= 4.0.0, pickleshare ^= 0.5, decorator ^= 4.0.2)
+- ipython4 4.0.0-5; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, traitlets ^= 4.0.0, pickleshare ^= 0.5, decorator ^= 4.0.2)
+- ipython4 4.0.0-7; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, appnope ^= 0.1.0, traitlets ^= 4.0.0, pickleshare ^= 0.5, decorator ^= 4.0.2)
+- ipython4 4.0.0-8; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, appnope ^= 0.1.0, traitlets ^= 4.0.0, pickleshare ^= 0.5, decorator ^= 4.0.2)
+- ipython4 4.0.0-9; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, appnope ^= 0.1.0, traitlets ^= 4.0.0, pickleshare ^= 0.5, decorator ^= 4.0.2)
+- ipython4 4.0.1-1; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, appnope ^= 0.1.0, traitlets ^= 4.0.0, pickleshare ^= 0.5, decorator ^= 4.0.4)
+- ipython4 4.0.1-2; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, appnope ^= 0.1.0, traitlets ^= 4.1.0, pickleshare ^= 0.5, decorator ^= 4.0.6)
+- ipython4 4.1.2-1; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, appnope ^= 0.1.0, traitlets ^= 4.1.0, pickleshare ^= 0.5, decorator ^= 4.0.9)
+- ipython4 4.1.2-2; depends (appinst, pexpect ^= 3.3, simplegeneric ^= 0.8.1, appnope ^= 0.1.0, traitlets ^= 4.2.1, pickleshare ^= 0.5, decorator ^= 4.0.9)
+- ipython_genutils 0.1.0-1
+- ipywidgets 4.0.2-2; depends (ipython4 ^= 4.0.0, ipython_genutils ^= 0.1.0, ipykernel ^= 4.0.3, notebook ^= 4.0.4, traitlets ^= 4.0.0)
+- ipywidgets 4.0.3-1; depends (ipython4 ^= 4.0.0, ipython_genutils ^= 0.1.0, ipykernel ^= 4.0.3, notebook ^= 4.0.5, traitlets ^= 4.0.0)
+- ipywidgets 4.0.3-2; depends (ipython4 ^= 4.0.0, ipython_genutils ^= 0.1.0, ipykernel ^= 4.1.0, notebook ^= 4.0.5, traitlets ^= 4.0.0)
+- ipywidgets 4.1.1-1; depends (ipython4 ^= 4.0.1, ipython_genutils ^= 0.1.0, ipykernel ^= 4.2.0, notebook ^= 4.0.6, traitlets ^= 4.0.0)
+- ipywidgets 4.1.1-2; depends (ipython4 ^= 4.0.1, ipython_genutils ^= 0.1.0, ipykernel ^= 4.2.2, notebook ^= 4.1.0, traitlets ^= 4.1.0)
+- ipywidgets 4.1.1-3; depends (ipython4 ^= 4.1.2, ipython_genutils ^= 0.1.0, ipykernel ^= 4.3.1, notebook ^= 4.1.0, traitlets ^= 4.1.0)
+- ipywidgets 4.1.1-4; depends (ipython4 ^= 4.1.2, ipython_genutils ^= 0.1.0, ipykernel ^= 4.3.1, notebook ^= 4.1.0, traitlets ^= 4.2.1)
+- iris 1.6.1-1; depends (pil ^= 1.1.7, netcdf4 ^= 1.0.7, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.3.1, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.2, cartopy ^= 0.10.0, numpy ^= 1.8.0, pandas ^= 0.13.1, gdal ^= 1.10.0, shapely ^= 1.2.17)
+- iris 1.6.1-2; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.0, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.3.1, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.2, cartopy ^= 0.10.0, numpy ^= 1.8.0, pandas ^= 0.14.0, gdal ^= 1.11.0, shapely ^= 1.2.17)
+- iris 1.6.1-3; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.0, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.3.1, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.10.0, numpy ^= 1.8.0, pandas ^= 0.14.0, gdal ^= 1.11.0, shapely ^= 1.2.17)
+- iris 1.6.1-4; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.0, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.3.1, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.10.0, numpy ^= 1.8.0, pandas ^= 0.14.0, gdal ^= 1.11.0, shapely ^= 1.3.2)
+- iris 1.6.1-6; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.0, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.3.1, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.10.0, numpy ^= 1.8.0, pandas ^= 0.14.1, gdal ^= 1.11.0, shapely ^= 1.3.2)
+- iris 1.6.1-8; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.0, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.10.0, numpy ^= 1.8.1, pandas ^= 0.14.1, gdal ^= 1.11.0, shapely ^= 1.3.2)
+- iris 1.6.1-9; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.10.0, numpy ^= 1.8.1, pandas ^= 0.14.1, gdal ^= 1.11.0, shapely ^= 1.3.2)
+- iris 1.7.1-1; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.0, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.14.1, gdal ^= 1.11.0, shapely ^= 1.3.2)
+- iris 1.7.1-2; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.0, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.14.1, gdal ^= 1.11.0, shapely ^= 1.4.1)
+- iris 1.7.1-3; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.0, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.15.0, gdal ^= 1.11.0, shapely ^= 1.4.1)
+- iris 1.7.1-4; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.2, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.15.0, gdal ^= 1.11.0, shapely ^= 1.4.1)
+- iris 1.7.1-5; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.2, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.15.0, gdal ^= 1.11.1, shapely ^= 1.4.1)
+- iris 1.7.1-7; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.2, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.15.1, gdal ^= 1.11.1, shapely ^= 1.5.1)
+- iris 1.7.1-8; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.11, expat ^= 2.0.1, matplotlib ^= 1.4.2, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.15.2, gdal ^= 1.11.1, shapely ^= 1.5.1)
+- iris 1.7.3-1; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.2, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.0, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.15.2, gdal ^= 1.11.1, shapely ^= 1.5.1)
+- iris 1.7.3-2; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.2, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.1rc1, pygrib ^= 1.9.9, cartopy ^= 0.11.0, numpy ^= 1.8.1, pandas ^= 0.15.2, gdal ^= 1.11.1, shapely ^= 1.5.1)
+- iris 1.7.3-3; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.2, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.14.1rc1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.8.1, pandas ^= 0.15.2, gdal ^= 1.11.1, shapely ^= 1.5.1)
+- iris 1.7.3-4; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.2, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.8.1, pandas ^= 0.15.2, gdal ^= 1.11.1, shapely ^= 1.5.1)
+- iris 1.7.3-5; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.8.1, pandas ^= 0.15.2, gdal ^= 1.11.1, shapely ^= 1.5.1)
+- iris 1.7.3-6; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.8.1, pandas ^= 0.15.2, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-7; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.8.1, pandas ^= 0.16.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-8; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.7.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.8.1, pandas ^= 0.16.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-9; depends (pil ^= 1.1.7, netcdf4 ^= 1.1.7.1, libudunits ^= 2.2.17, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pandas ^= 0.16.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-10; depends (netcdf4 ^= 1.1.7.1, libudunits ^= 2.2.17, pandas ^= 0.16.0, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.8.1, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-11; depends (netcdf4 ^= 1.1.7.1, libudunits ^= 2.2.17, pandas ^= 0.16.0, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.8.1, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-12; depends (netcdf4 ^= 1.1.7.1, libudunits ^= 2.2.17, pandas ^= 0.16.1, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.8.1, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-13; depends (netcdf4 ^= 1.1.7.1, libudunits ^= 2.2.17, pandas ^= 0.16.2, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.8.1, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-14; depends (netcdf4 ^= 1.1.7.1, libudunits ^= 2.2.17, pandas ^= 0.16.2, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.9.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-15; depends (netcdf4 ^= 1.2.0, libudunits ^= 2.2.17, pandas ^= 0.16.2, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.15.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.9.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-16; depends (netcdf4 ^= 1.2.0, libudunits ^= 2.2.17, pandas ^= 0.16.2, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.0, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.9.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-17; depends (netcdf4 ^= 1.2.0, libudunits ^= 2.2.17, pandas ^= 0.16.2, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.0, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.9.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-19; depends (netcdf4 ^= 1.2.0, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.4.3, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.9.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-20; depends (netcdf4 ^= 1.2.0, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.5.0, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.9.0, gdal ^= 1.11.2, shapely ^= 1.5.1)
+- iris 1.7.3-21; depends (netcdf4 ^= 1.2.0, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.5.0, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.1, pygrib ^= 1.9.9, cartopy ^= 0.11.2, numpy ^= 1.9.2, pillow ^= 2.9.0, gdal ^= 2.0.1, shapely ^= 1.5.1)
+- iris 1.8.1-1; depends (netcdf4 ^= 1.2.0, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.5.0, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.1, pygrib ^= 1.9.9, cartopy ^= 0.13.0, numpy ^= 1.9.2, pillow ^= 2.9.0, gdal ^= 2.0.1, shapely ^= 1.5.13)
+- iris 1.8.1-2; depends (netcdf4 ^= 1.2.0, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.5.0, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.1, pygrib ^= 1.9.9, cartopy ^= 0.13.0, numpy ^= 1.9.2, pillow ^= 3.0.0, gdal ^= 2.0.1, shapely ^= 1.5.13)
+- iris 1.8.1-3; depends (netcdf4 ^= 1.2.2, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.5.0, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.1, pygrib ^= 1.9.9, cartopy ^= 0.13.0, numpy ^= 1.9.2, pillow ^= 3.0.0, gdal ^= 2.0.1, shapely ^= 1.5.13)
+- iris 1.8.1-4; depends (netcdf4 ^= 1.2.2, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.5.1, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.1, pygrib ^= 1.9.9, cartopy ^= 0.13.0, numpy ^= 1.9.2, pillow ^= 3.0.0, gdal ^= 2.0.1, shapely ^= 1.5.13)
+- iris 1.8.1-5; depends (netcdf4 ^= 1.2.2, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.5.1, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.16.1, pygrib ^= 1.9.9, cartopy ^= 0.13.0, numpy ^= 1.9.2, pillow ^= 3.1.0, gdal ^= 2.0.1, shapely ^= 1.5.13)
+- iris 1.8.1-6; depends (netcdf4 ^= 1.2.2, libudunits ^= 2.2.17, pandas ^= 0.17.1, expat ^= 2.0.1, matplotlib ^= 1.5.1, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.17.0, pygrib ^= 1.9.9, cartopy ^= 0.13.0, numpy ^= 1.9.2, pillow ^= 3.1.0, gdal ^= 2.0.1, shapely ^= 1.5.13)
+- iris 1.8.1-7; depends (netcdf4 ^= 1.2.2, libudunits ^= 2.2.17, pandas ^= 0.18.0, expat ^= 2.0.1, matplotlib ^= 1.5.1, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.17.0, pygrib ^= 1.9.9, cartopy ^= 0.13.0, numpy ^= 1.9.2, pillow ^= 3.1.0, gdal ^= 2.0.1, shapely ^= 1.5.13)
+- iris 1.8.1-8; depends (netcdf4 ^= 1.2.2, libudunits ^= 2.2.17, pandas ^= 0.18.0, expat ^= 2.0.1, matplotlib ^= 1.5.1, biggus ^= 0.7.0, pyke ^= 1.1.1, scipy ^= 0.17.0, pygrib ^= 1.9.9, cartopy ^= 0.13.0, numpy ^= 1.10.4, pillow ^= 3.1.0, gdal ^= 2.0.1, shapely ^= 1.5.13)
+- iso8601 0.1.10-1
+- iso8601 0.1.11-1
+- isodate 0.5.1-1
+- itsdangerous 0.23.0-1
+- itsdangerous 0.24.0-1
+- jasper 1.9-1
+- jdcal 1.0.0-1
+- jdcal 1.2-1
+- jedi 0.9.0-1
+- jedi 0.9.0-2
+- jinja2 2.5.5-2; depends (pygments ^= 1.3.1)
+- jinja2 2.5.5-3; depends (pygments ^= 1.4)
+- jinja2 2.6-1; depends (pygments ^= 1.4)
+- jinja2 2.6-2
+- jinja2 2.7.1-1; depends (markupsafe ^= 0.18)
+- jinja2 2.7.3-1; depends (markupsafe ^= 0.18)
+- jinja2 2.7.3-2; depends (markupsafe ^= 0.23)
+- jinja2 2.8-1; depends (markupsafe ^= 0.23)
+- joblib 0.8.4-1
+- joblib 0.9.4-1
+- jsonpickle 0.3.1-1
+- jsonpickle 0.4.0-1
+- jsonschema 2.4.0-1
+- jupyter 1.0.0-1; depends (ipykernel ^= 4.0.3, notebook ^= 4.0.4, nbconvert ^= 4.0.0, jupyter_console ^= 4.0.2, qtconsole ^= 4.0.1, ipywidgets ^= 4.0.2)
+- jupyter 1.0.0-3; depends (ipykernel ^= 4.0.3, notebook ^= 4.0.5, nbconvert ^= 4.0.0, jupyter_console ^= 4.0.2, qtconsole ^= 4.0.1, ipywidgets ^= 4.0.3)
+- jupyter 1.0.0-4; depends (ipykernel ^= 4.1.0, notebook ^= 4.0.5, nbconvert ^= 4.0.0, jupyter_console ^= 4.0.2, qtconsole ^= 4.0.1, ipywidgets ^= 4.0.3)
+- jupyter 1.0.0-5; depends (ipykernel ^= 4.1.0, notebook ^= 4.0.5, nbconvert ^= 4.0.0, jupyter_console ^= 4.0.2, qtconsole ^= 4.0.1, ipywidgets ^= 4.0.3)
+- jupyter 1.0.0-6; depends (ipykernel ^= 4.2.0, notebook ^= 4.0.6, nbconvert ^= 4.1.0, jupyter_console ^= 4.0.3, qtconsole ^= 4.1.1, ipywidgets ^= 4.1.1)
+- jupyter 1.0.0-7; depends (ipykernel ^= 4.2.2, notebook ^= 4.1.0, nbconvert ^= 4.1.0, jupyter_console ^= 4.1.0, qtconsole ^= 4.1.1, ipywidgets ^= 4.1.1)
+- jupyter 1.0.0-9; depends (ipykernel ^= 4.3.1, notebook ^= 4.1.0, nbconvert ^= 4.1.0, jupyter_console ^= 4.1.1, qtconsole ^= 4.2.0, ipywidgets ^= 4.1.1)
+- jupyter 1.0.0-10; depends (ipykernel ^= 4.3.1, notebook ^= 4.1.0, nbconvert ^= 4.1.0, jupyter_console ^= 4.1.1, qtconsole ^= 4.2.0, ipywidgets ^= 4.1.1)
+- jupyter 1.0.0-11; depends (ipykernel ^= 4.3.1, notebook ^= 4.1.0, nbconvert ^= 4.1.0, jupyter_console ^= 4.1.1, qtconsole ^= 4.2.0, ipywidgets ^= 4.1.1)
+- jupyter 1.0.0-12; depends (ipykernel ^= 4.3.1, notebook ^= 4.1.0, nbconvert ^= 4.1.0, jupyter_console ^= 4.1.1, qtconsole ^= 4.2.1, ipywidgets ^= 4.1.1)
+- jupyter_client 4.0.0-1; depends (jupyter_core ^= 4.0.4, pyzmq ^= 14.7.0, traitlets ^= 4.0.0)
+- jupyter_client 4.0.0-2; depends (jupyter_core ^= 4.0.6, pyzmq ^= 14.7.0, traitlets ^= 4.0.0)
+- jupyter_client 4.1.1-1; depends (jupyter_core ^= 4.0.6, pyzmq ^= 14.7.0, traitlets ^= 4.0.0)
+- jupyter_client 4.1.1-2; depends (jupyter_core ^= 4.0.6, pyzmq ^= 15.1.0, traitlets ^= 4.0.0)
+- jupyter_client 4.1.1-3; depends (jupyter_core ^= 4.0.6, pyzmq ^= 15.1.0, traitlets ^= 4.1.0)
+- jupyter_client 4.2.1-1; depends (jupyter_core ^= 4.0.6, pyzmq ^= 15.1.0, traitlets ^= 4.1.0)
+- jupyter_client 4.2.1-2; depends (jupyter_core ^= 4.1.0, pyzmq ^= 15.1.0, traitlets ^= 4.1.0)
+- jupyter_client 4.2.1-3; depends (jupyter_core ^= 4.1.0, pyzmq ^= 15.2.0, traitlets ^= 4.1.0)
+- jupyter_client 4.2.2-1; depends (jupyter_core ^= 4.1.0, pyzmq ^= 15.2.0, traitlets ^= 4.2.1)
+- jupyter_console 4.0.2-2; depends (ipython4 ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.0.3)
+- jupyter_console 4.0.2-3; depends (ipython4 ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.1.0)
+- jupyter_console 4.0.3-1; depends (ipython4 ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.0)
+- jupyter_console 4.1.0-1; depends (ipython4 ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.2)
+- jupyter_console 4.1.1-1; depends (ipython4 ^= 4.1.2, jupyter_client ^= 4.2.1, ipykernel ^= 4.3.1)
+- jupyter_console 4.1.1-2; depends (ipython4 ^= 4.1.2, jupyter_client ^= 4.2.2, ipykernel ^= 4.3.1)
+- jupyter_core 4.0.4-1; depends (traitlets ^= 4.0.0)
+- jupyter_core 4.0.6-1; depends (traitlets ^= 4.0.0)
+- jupyter_core 4.0.6-2; depends (traitlets ^= 4.0.0)
+- jupyter_core 4.0.6-3; depends (traitlets ^= 4.0.0)
+- jupyter_core 4.0.6-4; depends (traitlets ^= 4.0.0)
+- jupyter_core 4.0.6-5; depends (traitlets ^= 4.1.0)
+- jupyter_core 4.0.6-6; depends (traitlets ^= 4.1.0)
+- jupyter_core 4.1.0-1; depends (traitlets ^= 4.1.0)
+- jupyter_core 4.1.0-2; depends (traitlets ^= 4.2.1)
+- kernmagic 0.1.0-1; depends (ipython ^= 0.12.1)
+- kernmagic 0.2.0-1; depends (ipython ^= 0.13.1)
+- kernmagic 0.2.0-2; depends (ipython ^= 1.0.0)
+- kernmagic 0.2.0-4; depends (ipython ^= 3.1.0)
+- kernmagic 0.2.0-5; depends (ipython ^= 3.2.0)
+- kernmagic 0.2.0-6; depends (ipython ^= 3.2.1)
+- kernmagic 0.2.0-7; depends (ipython4 ^= 4.0.0)
+- kernmagic 0.2.0-8; depends (ipython4 ^= 4.0.1)
+- kernmagic 0.2.0-9; depends (ipython4 ^= 4.1.2)
+- keyring 0.5.1-1
+- keyring 0.6.2-1
+- keyring 0.7.1-1
+- keyring 0.9-1
+- keyring 0.9.2-1
+- keyring 3.7.0-1
+- keyring 4.0-1
+- keyring 4.0-3
+- keyring 4.0-4
+- keyring 4.0-5
+- kiwisolver 0.1.2-1
+- kiwisolver 0.1.3-1
+- kiwisolver 0.1.3-2
+- kombu 3.0.21-2; depends (anyjson ^= 0.3.3, amqp ^= 1.4.5)
+- kombu 3.0.21-3; depends (anyjson ^= 0.3.3, amqp ^= 1.4.5)
+- larry 0.4.0-2; depends (h5py ^= 1.3.1, numpy ^= 1.5.1)
+- larry 0.4.0-3; depends (h5py ^= 1.3.1, numpy ^= 1.6.0)
+- larry 0.6.0-3; depends (h5py ^= 2.1.3, bottleneck ^= 0.6.0, numpy ^= 1.7.1)
+- larry 0.6.0-4; depends (h5py ^= 2.2.0, bottleneck ^= 0.7.0, numpy ^= 1.7.1)
+- larry 0.6.0-5; depends (h5py ^= 2.2.0, bottleneck ^= 0.7.0, numpy ^= 1.8.0)
+- larry 0.6.0-6; depends (h5py ^= 2.2.1, bottleneck ^= 0.7.0, numpy ^= 1.8.0)
+- larry 0.6.0-8; depends (h5py ^= 2.3.0, bottleneck ^= 0.7.0, numpy ^= 1.8.1)
+- larry 0.6.0-9; depends (h5py ^= 2.3.1, bottleneck ^= 0.7.0, numpy ^= 1.8.1)
+- larry 0.6.0-10; depends (h5py ^= 2.4.0, bottleneck ^= 0.7.0, numpy ^= 1.8.1)
+- larry 0.6.0-11; depends (h5py ^= 2.5.0, bottleneck ^= 0.7.0, numpy ^= 1.8.1)
+- larry 0.6.0-12; depends (h5py ^= 2.5.0, bottleneck ^= 0.7.0, numpy ^= 1.9.2)
+- larry 0.6.0-13; depends (h5py ^= 2.5.0, bottleneck ^= 1.0.0, numpy ^= 1.9.2)
+- larry 0.6.0-14; depends (h5py ^= 2.5.0, bottleneck ^= 1.0.0, numpy ^= 1.10.4)
+- larry 0.6.0-15; depends (h5py ^= 2.6.0, bottleneck ^= 1.0.0, numpy ^= 1.10.4)
+- lazy_object_proxy 1.2.1-1
+- lib_netcdf4 4.0.1-1
+- lib_netcdf4 4.1.1-1
+- lib_netcdf4 4.1.1-2; depends (curl ^= 7.25.0)
+- lib_netcdf4 4.2-1; depends (curl ^= 7.25.0, hdf5 ^= 1.8.9)
+- lib_netcdf4 4.2-2; depends (curl ^= 7.25.0, hdf5 ^= 1.8.9)
+- lib_netcdf4 4.3.0-1; depends (curl ^= 7.25.0, hdf5 ^= 1.8.9)
+- lib_netcdf4 4.3.0-2; depends (curl ^= 7.25.0, hdf5 ^= 1.8.9)
+- lib_netcdf4 4.3.0-3; depends (curl ^= 7.25.0, hdf5 ^= 1.8.9)
+- lib_netcdf4 4.3.0-4; depends (curl ^= 7.25.0, hdf5 ^= 1.8.11)
+- lib_netcdf4 4.3.2-1; depends (curl ^= 7.37.0, hdf5 ^= 1.8.11)
+- lib_netcdf4 4.3.2-2; depends (curl ^= 7.38.0, hdf5 ^= 1.8.11)
+- lib_netcdf4 4.3.2-3; depends (curl ^= 7.38.0, hdf5 ^= 1.8.14)
+- lib_netcdf4 4.3.3.1-1; depends (curl ^= 7.43.0, hdf5 ^= 1.8.15.1)
+- lib_netcdf4 4.3.3.1-3; depends (curl ^= 7.43.0, hdf5 ^= 1.8.15.1)
+- lib_netcdf4 4.3.3.1-4; depends (curl ^= 7.43.0, hdf5 ^= 1.8.16)
+- libblosc 1.3.5-1
+- libblosc 1.4.1-1
+- libdynd 0.6.6-1
+- libevent 2.0.21-1
+- libffi 3.0.13-2
+- libgdal 1.7.2-1; depends (expat ^= 2.0.1)
+- libgdal 1.8.1-1
+- libgdal 1.9.0-2
+- libgdal 1.9.0-3
+- libgdal 1.10.0-1; depends (curl ^= 7.25.0, hdf5 ^= 1.8.9)
+- libgdal 1.10.0-2; depends (libxml2 ^= 2.7.8, curl ^= 7.25.0, expat ^= 2.0.1, hdf5 ^= 1.8.9)
+- libgdal 1.10.1-1; depends (libxml2 ^= 2.7.8, curl ^= 7.25.0, expat ^= 2.0.1, hdf5 ^= 1.8.9)
+- libgdal 1.10.1-2; depends (libxml2 ^= 2.7.8, curl ^= 7.25.0, expat ^= 2.0.1, hdf5 ^= 1.8.11)
+- libgdal 1.10.1-4; depends (libxml2 ^= 2.7.8, curl ^= 7.25.0, expat ^= 2.0.1, hdf5 ^= 1.8.11)
+- libgdal 1.11.0-1; depends (libxml2 ^= 2.7.8, curl ^= 7.25.0, expat ^= 2.0.1, hdf5 ^= 1.8.11, lib_netcdf4 ^= 4.3.0)
+- libgdal 1.11.0-2; depends (libxml2 ^= 2.7.8, curl ^= 7.25.0, expat ^= 2.0.1, hdf5 ^= 1.8.11, lib_netcdf4 ^= 4.3.0)
+- libgdal 1.11.0-3; depends (libxml2 ^= 2.7.8, curl ^= 7.25.0, expat ^= 2.0.1, hdf5 ^= 1.8.11, lib_netcdf4 ^= 4.3.0)
+- libgdal 1.11.0-4; depends (libxml2 ^= 2.7.8, curl ^= 7.37.0, expat ^= 2.0.1, hdf5 ^= 1.8.11, lib_netcdf4 ^= 4.3.2)
+- libgdal 1.11.0-5; depends (libxml2 ^= 2.7.8, curl ^= 7.38.0, expat ^= 2.0.1, hdf5 ^= 1.8.11, lib_netcdf4 ^= 4.3.2)
+- libgdal 1.11.0-6; depends (libxml2 ^= 2.9.2, curl ^= 7.38.0, expat ^= 2.0.1, hdf5 ^= 1.8.11, lib_netcdf4 ^= 4.3.2)
+- libgdal 1.11.0-7; depends (hdf5 ^= 1.8.11, libxml2 ^= 2.9.2, expat ^= 2.0.1, libpng ^= 1.6.12, lib_netcdf4 ^= 4.3.2, curl ^= 7.38.0)
+- libgdal 1.11.0-8; depends (hdf5 ^= 1.8.14, libxml2 ^= 2.9.2, expat ^= 2.0.1, libpng ^= 1.6.12, lib_netcdf4 ^= 4.3.2, curl ^= 7.38.0)
+- libgdal 1.11.2-1; depends (hdf5 ^= 1.8.14, libxml2 ^= 2.9.2, expat ^= 2.0.1, libpng ^= 1.6.12, lib_netcdf4 ^= 4.3.2, curl ^= 7.38.0)
+- libgdal 1.11.2-2; depends (hdf5 ^= 1.8.15.1, libxml2 ^= 2.9.2, expat ^= 2.0.1, libpng ^= 1.6.12, lib_netcdf4 ^= 4.3.3.1, curl ^= 7.43.0)
+- libgdal 2.0.1-1; depends (hdf5 ^= 1.8.15.1, libxml2 ^= 2.9.2, expat ^= 2.0.1, libpng ^= 1.6.12, lib_netcdf4 ^= 4.3.3.1, curl ^= 7.43.0)
+- libgdal 2.0.1-2; depends (hdf5 ^= 1.8.15.1, libxml2 ^= 2.9.2, expat ^= 2.0.1, libpng ^= 1.6.12, lib_netcdf4 ^= 4.3.3.1, curl ^= 7.43.0)
+- libgdal 2.0.1-3; depends (hdf5 ^= 1.8.16, libxml2 ^= 2.9.2, expat ^= 2.0.1, libpng ^= 1.6.12, lib_netcdf4 ^= 4.3.3.1, curl ^= 7.43.0)
+- libgit2 0.23.4-3
+- libgit2 0.23.4-4; depends (curl ^= 7.43.0)
+- libjpeg 7.0-2
+- libjpeg 7.0-3
+- libopenjpeg 2.1.0-1; depends (libpng ^= 1.6.12)
+- libopenjpeg 2.1.0-2; depends (libpng ^= 1.6.12)
+- libpng 1.2.40-2
+- libpng 1.2.40-5
+- libpng 1.6.12-1
+- libpng 1.6.12-2
+- libpng 1.6.12-3
+- libpq 9.5.1-1
+- libproj 4.8.0-1
+- libproj 4.8.0-2
+- libproj 4.8.0-3
+- libsodium 1.0.3-1
+- libudunits 2.2.11-1; depends (expat ^= 2.0.1)
+- libudunits 2.2.17-2; depends (expat ^= 2.0.1)
+- libxml2 2.7.3-3
+- libxml2 2.7.8-1
+- libxml2 2.7.8-2
+- libxml2 2.7.8-3
+- libxml2 2.9.2-1
+- libxml2 2.9.2-2
+- libxslt 1.1.24-5; depends (libxml2 ^= 2.7.3)
+- libxslt 1.1.26-1; depends (libxml2 ^= 2.7.8)
+- libxslt 1.1.26-2; depends (libxml2 ^= 2.7.8)
+- libxslt 1.1.26-3; depends (libxml2 ^= 2.7.8)
+- libxslt 1.1.28-1; depends (libxml2 ^= 2.9.2)
+- libxslt 1.1.28-2; depends (libxml2 ^= 2.9.2)
+- libxslt 1.1.28-3; depends (libxml2 ^= 2.9.2)
+- line_profiler 1.0-1
+- linecache2 1.0.0-1
+- llvm 3.2-1
+- llvm 3.3-1
+- llvm 3.5.1-1
+- llvm 3.6.1-1
+- llvm 3.7.1-1
+- llvmlite 0.2.2-1; depends (enum34 ^= 1.0.4)
+- llvmlite 0.4.0-1; depends (enum34 ^= 1.0.4)
+- llvmlite 0.5.0-1; depends (enum34 ^= 1.0.4)
+- llvmlite 0.6.0-1; depends (enum34 ^= 1.0.4)
+- llvmlite 0.7.0-1; depends (enum34 ^= 1.0.4)
+- llvmlite 0.8.0-1; depends (enum34 ^= 1.0.4)
+- llvmlite 0.8.0-2; depends (enum34 ^= 1.1.1)
+- llvmlite 0.8.0-3; depends (enum34 ^= 1.1.2)
+- llvmlite 0.9.0-1; depends (enum34 ^= 1.1.2)
+- llvmlite 0.10.0-1; depends (enum34 ^= 1.1.2)
+- llvmmath 0.1.0-1; depends (llvmpy ^= 0.11.3, numpy ^= 1.7.1)
+- llvmmath 0.1.1-1; depends (llvmpy ^= 0.11.3, numpy ^= 1.7.1)
+- llvmmath 0.1.1-2; depends (llvmpy ^= 0.12.0, numpy ^= 1.7.1)
+- llvmmath 0.1.1-3; depends (llvmpy ^= 0.12.0, numpy ^= 1.8.0)
+- llvmmath 0.1.1-4; depends (llvmpy ^= 0.12.1, numpy ^= 1.8.0)
+- llvmmath 0.1.1-5; depends (llvmpy ^= 0.12.6, numpy ^= 1.8.0)
+- llvmmath 0.1.1-6; depends (llvmpy ^= 0.12.6, numpy ^= 1.8.1)
+- llvmmath 0.1.2-1; depends (llvmpy ^= 0.12.7, numpy ^= 1.8.1)
+- llvmpy 0.11.3-1
+- llvmpy 0.12.0-1
+- llvmpy 0.12.1-1
+- llvmpy 0.12.6-1
+- llvmpy 0.12.7-1
+- lmfit 0.9.2-1; depends (scipy ^= 0.16.1, numpy ^= 1.9.2)
+- lmfit 0.9.2-2; depends (scipy ^= 0.17.0, numpy ^= 1.9.2)
+- lmfit 0.9.2-3; depends (scipy ^= 0.17.0, numpy ^= 1.10.4)
+- locket 0.2.0-1
+- lockfile 0.10.2-1; depends (pbr ^= 1.2.0)
+- lockfile 0.10.2-2; depends (pbr ^= 1.8.1)
+- lockfile 0.12.2-1; depends (pbr ^= 1.8.1)
+- logbook 0.9.0-1
+- luigi 2.0.1-1; depends (python_daemon ^= 2.1.1, tornado ^= 4.3)
+- lxml 2.2.8-2; depends (libxml2 ^= 2.7.3, libxslt ^= 1.1.24)
+- lxml 2.3-1; depends (libxml2 ^= 2.7.3, libxslt ^= 1.1.24)
+- lxml 2.3.1-1; depends (libxml2 ^= 2.7.3, libxslt ^= 1.1.24)
+- lxml 2.3.2-1; depends (libxml2 ^= 2.7.3, libxslt ^= 1.1.24)
+- lxml 2.3.3-1; depends (libxml2 ^= 2.7.3, libxslt ^= 1.1.24)
+- lxml 2.3.3-2; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 2.3.4-1; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 2.3.4-3; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 2.3.4-4; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 2.3.4-6; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 3.2.3-1; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 3.3.5-1; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 3.3.6-1; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 3.4.0-1; depends (libxml2 ^= 2.7.8, libxslt ^= 1.1.26)
+- lxml 3.4.0-2; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.4.1-1; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.4.2-1; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.4.3-1; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.4.4-1; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.4.4-2; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.4.4-3; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.5.0-1; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.6.0-1; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- lxml 3.6.0-2; depends (libxml2 ^= 2.9.2, libxslt ^= 1.1.28)
+- m2crypto 0.22.3-1
+- mahotas 1.3.0-1; depends (numpy ^= 1.9.2)
+- mahotas 1.3.0-2; depends (numpy ^= 1.9.2)
+- mahotas 1.3.0-3; depends (numpy ^= 1.9.2)
+- mahotas 1.3.0-4; depends (numpy ^= 1.9.2)
+- mahotas 1.3.0-5; depends (numpy ^= 1.9.2)
+- mahotas 1.3.0-6; depends (numpy ^= 1.9.2)
+- mahotas 1.3.0-7; depends (numpy ^= 1.9.2)
+- mahotas 1.3.0-8; depends (numpy ^= 1.10.4)
+- markdown 2.6.5-1
+- markupsafe 0.18-1
+- markupsafe 0.18-2
+- markupsafe 0.23-1
+- matplotlib 1.0.0-2; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.5.1)
+- matplotlib 1.0.1-1; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.5.1)
+- matplotlib 1.0.1-2; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.6.0)
+- matplotlib 1.0.1-3; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.6.1)
+- matplotlib 1.1.0-1; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.6.1)
+- matplotlib 1.1.0-2; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.6.1)
+- matplotlib 1.2.0-4; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.6.1)
+- matplotlib 1.2.0-7; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.7.1)
+- matplotlib 1.2.1-1; depends (configobj, freetype ^= 2.4.4, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.7.1)
+- matplotlib 1.3.0-1; depends (configobj, freetype ^= 2.4.4, tornado ^= 2.2, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.7.1, pyparsing ^= 1.5.6)
+- matplotlib 1.3.0-2; depends (configobj, freetype ^= 2.4.4, tornado ^= 3.1.1, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.7.1, pyparsing ^= 1.5.6)
+- matplotlib 1.3.1-1; depends (configobj, freetype ^= 2.4.4, tornado ^= 3.1.1, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.7.1, pyparsing ^= 1.5.6)
+- matplotlib 1.3.1-2; depends (configobj, freetype ^= 2.4.4, tornado ^= 3.1.1, pytz, libpng ^= 1.2.40, python_dateutil, numpy ^= 1.8.0, pyparsing ^= 1.5.6)
+- matplotlib 1.3.1-3; depends (configobj, freetype ^= 2.4.4, tornado ^= 3.1.1, pytz ^= 2013.8.0, libpng ^= 1.2.40, python_dateutil ^= 2.2.0, numpy ^= 1.8.0, pyparsing ^= 1.5.6)
+- matplotlib 1.3.1-4; depends (configobj ^= 5.0.5, freetype ^= 2.4.4, tornado ^= 3.1.1, pytz ^= 2013.8.0, libpng ^= 1.2.40, python_dateutil ^= 2.2.0, numpy ^= 1.8.0, pyparsing ^= 2.0.2)
+- matplotlib 1.3.1-5; depends (configobj ^= 5.0.5, freetype ^= 2.5.3, tornado ^= 3.1.1, pytz ^= 2013.8.0, libpng ^= 1.2.40, python_dateutil ^= 2.2.0, numpy ^= 1.8.0, pyparsing ^= 2.0.2)
+- matplotlib 1.3.1-6; depends (configobj ^= 5.0.5, freetype ^= 2.5.3, tornado ^= 3.1.1, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.0, pyparsing ^= 2.0.2)
+- matplotlib 1.3.1-7; depends (configobj ^= 5.0.5, freetype ^= 2.5.3, tornado ^= 3.2.2, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.0, pyparsing ^= 2.0.2)
+- matplotlib 1.3.1-8; depends (configobj ^= 5.0.5, freetype ^= 2.5.3, tornado ^= 3.2.2, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.0, pyparsing ^= 2.0.2)
+- matplotlib 1.3.1-9; depends (configobj ^= 5.0.5, freetype ^= 2.5.3, tornado ^= 3.2.2, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.0-1; depends (configobj ^= 5.0.5, freetype ^= 2.5.3, tornado ^= 4.0.1, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.0-2; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.0.1, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.0-3; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.0.2, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.0-4; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.0.2, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.2-1; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.0.2, pytz ^= 2013.8.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.2-2; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.0.2, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.2-3; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.1, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.3-1; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.1, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.2)
+- matplotlib 1.4.3-2; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.1, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pyparsing ^= 2.0.3)
+- matplotlib 1.4.3-3; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.1, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.8.1, pyparsing ^= 2.0.3)
+- matplotlib 1.4.3-4; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.1, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pyparsing ^= 2.0.3)
+- matplotlib 1.4.3-5; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.2, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pyparsing ^= 2.0.3)
+- matplotlib 1.4.3-6; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.2, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pyparsing ^= 2.0.3)
+- matplotlib 1.4.3-7; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.2.1, pytz ^= 2014.9.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pyparsing ^= 2.0.3)
+- matplotlib 1.5.0-1; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.2.1, pyparsing ^= 2.0.3, pytz ^= 2014.9.0, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, cycler ^= 0.9.0)
+- matplotlib 1.5.0-2; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.3, pyparsing ^= 2.0.3, pytz ^= 2014.9.0, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, cycler ^= 0.9.0)
+- matplotlib 1.5.0-3; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.3, pyparsing ^= 2.0.3, pytz ^= 2014.9.0, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, cycler ^= 0.9.0)
+- matplotlib 1.5.0-4; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.3, pyparsing ^= 2.0.3, pytz ^= 2015.7, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, cycler ^= 0.9.0)
+- matplotlib 1.5.1-1; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.3, pyparsing ^= 2.0.3, pytz ^= 2015.7, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, cycler ^= 0.9.0)
+- matplotlib 1.5.1-2; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.3, pyparsing ^= 2.0.3, pytz ^= 2015.7, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, cycler ^= 0.10.0)
+- matplotlib 1.5.1-3; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.3, pyparsing ^= 2.0.3, pytz ^= 2015.7, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.5.1, numpy ^= 1.9.2, cycler ^= 0.10.0)
+- matplotlib 1.5.1-4; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.3, pyparsing ^= 2.0.3, pytz ^= 2015.7, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.5.1, numpy ^= 1.10.4, cycler ^= 0.10.0)
+- matplotlib 1.5.1-5; depends (configobj ^= 5.0.6, freetype ^= 2.5.3, tornado ^= 4.3, pyparsing ^= 2.0.3, pytz ^= 2016.3, wxpython ^= 3.0.2.0, libpng ^= 1.6.12, python_dateutil ^= 2.5.2, numpy ^= 1.10.4, cycler ^= 0.10.0)
+- matplotlib_tests 1.5.0-1; depends (matplotlib ^= 1.5.0)
+- matplotlib_tests 1.5.0-2; depends (matplotlib ^= 1.5.1)
+- matplotlib_tests 1.5.1-1; depends (matplotlib ^= 1.5.1)
+- mayavi 4.2.0-1; depends (apptools ^= 4.1.0, traitsui ^= 4.2.0, appinst, vtk ^= 5.6.0, envisage ^= 4.2.0)
+- mayavi 4.3.0-1; depends (apptools ^= 4.2.0, traitsui ^= 4.3.0, appinst, vtk ^= 5.6.0, envisage ^= 4.3.0)
+- mayavi 4.3.0-2
+- mayavi 4.3.0-3; depends (apptools ^= 4.2.0, traitsui ^= 4.3.0, appinst, vtk ^= 5.6.0, envisage ^= 4.3.0)
+- mayavi 4.3.0-4; depends (apptools ^= 4.2.0, traitsui ^= 4.3.0, appinst, vtk ^= 5.6.0, envisage ^= 4.3.0)
+- mayavi 4.3.0-5; depends (apptools ^= 4.2.0, traitsui ^= 4.4.0, appinst, vtk ^= 5.6.0, envisage ^= 4.4.0)
+- mayavi 4.3.1-1; depends (apptools ^= 4.2.1, traitsui ^= 4.4.0, appinst, vtk ^= 5.10.1, envisage ^= 4.4.0)
+- mayavi 4.3.1-2; depends (apptools ^= 4.2.1, traitsui ^= 4.4.0, appinst, vtk ^= 5.10.1, envisage ^= 4.4.0)
+- mayavi 4.4.0-1; depends (apptools ^= 4.2.1, traitsui ^= 4.4.0, appinst, vtk ^= 5.10.1, envisage ^= 4.4.0)
+- mayavi 4.4.0-2; depends (apptools ^= 4.3.0, traitsui ^= 4.4.0, appinst, vtk ^= 5.10.1, envisage ^= 4.4.0)
+- mayavi 4.4.0-3; depends (apptools ^= 4.3.0, traitsui ^= 4.4.0, appinst, vtk ^= 5.10.1, envisage ^= 4.4.0)
+- mayavi 4.4.0-4; depends (apptools ^= 4.3.0, traitsui ^= 4.5.1, appinst, vtk ^= 5.10.1, envisage ^= 4.4.0)
+- mayavi 4.4.2-1; depends (apptools ^= 4.3.0, traitsui ^= 4.5.1, appinst, vtk ^= 6.2.0, envisage ^= 4.4.0)
+- mayavi 4.4.3-1; depends (apptools ^= 4.3.0, traitsui ^= 4.5.1, appinst, vtk ^= 6.3.0, envisage ^= 4.4.0)
+- mayavi 4.4.3-2; depends (apptools ^= 4.3.0, traitsui ^= 5.0.0, appinst, vtk ^= 6.3.0, envisage ^= 4.4.0)
+- mayavi 4.4.3-3; depends (appinst, vtk ^= 6.3.0, six ^= 1.10.0, traitsui ^= 5.0.0, envisage ^= 4.4.0, setuptools ^= 20.1.1, numpy ^= 1.9.2, apptools ^= 4.3.0)
+- mayavi 4.4.3-4; depends (appinst, vtk ^= 6.3.0, six ^= 1.10.0, traitsui ^= 5.0.0, envisage ^= 4.5.1, setuptools ^= 20.1.1, numpy ^= 1.9.2, apptools ^= 4.4.0)
+- mayavi 4.4.3-5; depends (appinst, vtk ^= 6.3.0, six ^= 1.10.0, traitsui ^= 5.0.0, envisage ^= 4.5.1, setuptools ^= 20.2.2, numpy ^= 1.9.2, apptools ^= 4.4.0)
+- mayavi 4.4.3-6; depends (appinst, vtk ^= 6.3.0, six ^= 1.10.0, traitsui ^= 5.0.0, envisage ^= 4.5.1, setuptools ^= 20.3.1, numpy ^= 1.9.2, apptools ^= 4.4.0)
+- mayavi 4.4.3-7; depends (appinst, vtk ^= 6.3.0, six ^= 1.10.0, traitsui ^= 5.0.0, envisage ^= 4.5.1, setuptools ^= 20.3.1, numpy ^= 1.10.4, apptools ^= 4.4.0)
+- mayavi 4.4.3-8; depends (appinst, vtk ^= 6.3.0, six ^= 1.10.0, traitsui ^= 5.0.0, envisage ^= 4.5.1, setuptools ^= 20.6.7, numpy ^= 1.10.4, apptools ^= 4.4.0)
+- mayavi 4.4.3-9; depends (appinst, vtk ^= 6.3.0, six ^= 1.10.0, traitsui ^= 5.1.0, envisage ^= 4.5.1, setuptools ^= 20.6.7, numpy ^= 1.10.4, apptools ^= 4.4.0)
+- mccabe 0.2.1-1
+- mccabe 0.2.1-2
+- mccabe 0.3-1
+- mccabe 0.3.1-1
+- mdp 3.1-1; depends (numpy)
+- mdp 3.2-1; depends (numpy)
+- mdp 3.3-1; depends (numpy ^= 1.6.1)
+- mdp 3.3-2; depends (numpy ^= 1.7.1)
+- mdp 3.3-3; depends (numpy ^= 1.7.1)
+- mdp 3.3-4; depends (numpy ^= 1.8.0)
+- mdp 3.3-6; depends (numpy ^= 1.8.1)
+- mdp 3.3-7; depends (numpy ^= 1.8.1)
+- mdp 3.3-8; depends (numpy ^= 1.8.1)
+- mdp 3.3-9; depends (numpy ^= 1.8.1)
+- mdp 3.3-10; depends (numpy ^= 1.9.2)
+- mdp 3.3-11; depends (numpy ^= 1.9.2)
+- mdp 3.5-1; depends (future ^= 0.15.2, numpy ^= 1.9.2)
+- mdp 3.5-2; depends (future ^= 0.15.2, numpy ^= 1.10.4)
+- meld3 0.6.10-1
+- meld3 1.0.0-1
+- meld3 1.0.2-1
+- memory_profiler 0.30-1; depends (psutil ^= 1.2.1)
+- memory_profiler 0.31.0-1; depends (psutil ^= 2.1.1)
+- memory_profiler 0.31.0-2; depends (psutil ^= 2.2.0)
+- memory_profiler 0.31.0-3; depends (psutil ^= 2.2.1)
+- memory_profiler 0.33-1; depends (psutil ^= 3.2.1)
+- memory_profiler 0.33-2; depends (psutil ^= 3.3.0)
+- memory_profiler 0.41-1; depends (psutil ^= 3.3.0)
+- meta 0.4.2.dev-1
+- meta 0.4.2.dev-2
+- meta 0.4.2.dev2-1
+- mistune 0.5-1
+- mistune 0.5.1-1
+- mistune 0.6-1
+- mistune 0.6-2
+- mistune 0.7.1-1
+- mkl 10.2-1
+- mkl 10.2-2
+- mkl 10.3-1
+- mkl 10.3-2
+- mkl 11.1.4-1
+- mkl_service 1.0-1; depends (mkl ^= 10.3)
+- mkl_service 1.0-2; depends (mkl ^= 11.1.4)
+- mlab 1.1.4-1; depends (scipy ^= 0.14.0, numpy ^= 1.8.1)
+- mlab 1.1.4-2; depends (scipy ^= 0.14.1rc1, numpy ^= 1.8.1)
+- mlab 1.1.4-3; depends (scipy ^= 0.15.1, numpy ^= 1.8.1)
+- mlab 1.1.4-4; depends (scipy ^= 0.15.1, numpy ^= 1.9.2)
+- mlab 1.1.4-5; depends (scipy ^= 0.16.0, numpy ^= 1.9.2)
+- mlab 1.1.4-6; depends (scipy ^= 0.16.1, numpy ^= 1.9.2)
+- mlab 1.1.4-7; depends (scipy ^= 0.17.0, numpy ^= 1.9.2)
+- mlab 1.1.4-8; depends (scipy ^= 0.17.0, numpy ^= 1.10.4)
+- mock 1.0.1-1
+- mock 1.3.0-1; depends (six ^= 1.9.0, funcsigs ^= 0.4, pbr ^= 1.8.1)
+- mock 1.3.0-2; depends (six ^= 1.10.0, funcsigs ^= 0.4, pbr ^= 1.8.1)
+- mock 1.3.0-3; depends (six ^= 1.10.0, funcsigs ^= 0.4, pbr ^= 1.8.1)
+- moto 0.4.6-1; depends (boto ^= 2.38.0, flask ^= 0.10.1, httpretty ^= 0.8.10, six ^= 1.9.0, xmltodict ^= 0.9.2, jinja2 ^= 2.7.3, requests ^= 2.7.0)
+- moto 0.4.6-2; depends (boto ^= 2.38.0, flask ^= 0.10.1, httpretty ^= 0.8.10, six ^= 1.9.0, xmltodict ^= 0.9.2, jinja2 ^= 2.8, requests ^= 2.7.0)
+- moto 0.4.6-3; depends (boto ^= 2.38.0, flask ^= 0.10.1, httpretty ^= 0.8.10, six ^= 1.9.0, xmltodict ^= 0.9.2, jinja2 ^= 2.8, requests ^= 2.8.0)
+- moto 0.4.6-4; depends (boto ^= 2.38.0, flask ^= 0.10.1, httpretty ^= 0.8.10, six ^= 1.10.0, xmltodict ^= 0.9.2, jinja2 ^= 2.8, requests ^= 2.8.0)
+- moto 0.4.6-5; depends (boto ^= 2.38.0, flask ^= 0.10.1, httpretty ^= 0.8.10, six ^= 1.10.0, xmltodict ^= 0.9.2, jinja2 ^= 2.8, requests ^= 2.9.0)
+- moto 0.4.6-6; depends (boto ^= 2.38.0, flask ^= 0.10.1, httpretty ^= 0.8.10, six ^= 1.10.0, xmltodict ^= 0.9.2, jinja2 ^= 2.8, requests ^= 2.9.1)
+- moto 0.4.6-7; depends (boto ^= 2.39.0, flask ^= 0.10.1, httpretty ^= 0.8.10, six ^= 1.10.0, xmltodict ^= 0.9.2, jinja2 ^= 2.8, requests ^= 2.9.1)
+- mpmath 0.19-1
+- msgpack 0.3.0-1
+- msgpack 0.3.0-2
+- msgpack 0.4.0-1
+- msgpack 0.4.2-4
+- msgpack_python 0.4.5-1
+- msgpack_python 0.4.6-1
+- msgpack_python 0.4.6-2
+- msgpack_python 0.4.6-3
+- msgpack_python 0.4.6-4
+- msgpack_python 0.4.6-5
+- multimethods 1.0.0-1
+- multipledispatch 0.4.7-1
+- multipledispatch 0.4.8-1
+- multiprocess 0.70.3-1; depends (dill ^= 0.2.4)
+- nbconvert 4.0.0-1; depends (mistune ^= 0.7.1, nbformat ^= 4.0.0, pygments ^= 2.0.2, jupyter_core ^= 4.0.4, traitlets ^= 4.0.0, jinja2 ^= 2.7.3)
+- nbconvert 4.0.0-2; depends (mistune ^= 0.7.1, nbformat ^= 4.0.0, pygments ^= 2.0.2, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, jinja2 ^= 2.7.3)
+- nbconvert 4.0.0-3; depends (mistune ^= 0.7.1, nbformat ^= 4.0.0, pygments ^= 2.0.2, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, jinja2 ^= 2.7.3)
+- nbconvert 4.0.0-4; depends (mistune ^= 0.7.1, nbformat ^= 4.0.0, pygments ^= 2.0.2, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, jinja2 ^= 2.8)
+- nbconvert 4.0.0-5; depends (mistune ^= 0.7.1, nbformat ^= 4.0.0, pygments ^= 2.0.2, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, jinja2 ^= 2.8)
+- nbconvert 4.1.0-1; depends (mistune ^= 0.7.1, nbformat ^= 4.0.1, pygments ^= 2.0.2, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, jinja2 ^= 2.8)
+- nbconvert 4.1.0-2; depends (mistune ^= 0.7.1, nbformat ^= 4.0.1, pygments ^= 2.0.2, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, jinja2 ^= 2.8)
+- nbconvert 4.1.0-3; depends (mistune ^= 0.7.1, nbformat ^= 4.0.1, pygments ^= 2.0.2, jupyter_core ^= 4.0.6, traitlets ^= 4.1.0, jinja2 ^= 2.8)
+- nbconvert 4.1.0-4; depends (mistune ^= 0.7.1, nbformat ^= 4.0.1, pygments ^= 2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.1.0, jinja2 ^= 2.8)
+- nbconvert 4.1.0-5; depends (mistune ^= 0.7.1, nbformat ^= 4.0.1, pygments ^= 2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.1.0, jinja2 ^= 2.8)
+- nbconvert 4.1.0-6; depends (mistune ^= 0.7.1, nbformat ^= 4.0.1, pygments ^= 2.1, jupyter_core ^= 4.1.0, traitlets ^= 4.1.0, jinja2 ^= 2.8)
+- nbconvert 4.1.0-8; depends (mistune ^= 0.7.1, nbformat ^= 4.0.1, pygments ^= 2.1, jupyter_core ^= 4.1.0, traitlets ^= 4.2.1, jinja2 ^= 2.8)
+- nbconvert 4.1.0-9; depends (mistune ^= 0.7.1, nbformat ^= 4.0.1, pygments ^= 2.1.3, jupyter_core ^= 4.1.0, traitlets ^= 4.2.1, jinja2 ^= 2.8)
+- nbformat 4.0.0-1; depends (jupyter_core ^= 4.0.4, ipython_genutils ^= 0.1.0, traitlets ^= 4.0.0, jsonschema ^= 2.4.0)
+- nbformat 4.0.0-2; depends (jupyter_core ^= 4.0.6, ipython_genutils ^= 0.1.0, traitlets ^= 4.0.0, jsonschema ^= 2.4.0)
+- nbformat 4.0.1-1; depends (jupyter_core ^= 4.0.6, ipython_genutils ^= 0.1.0, traitlets ^= 4.0.0, jsonschema ^= 2.4.0)
+- nbformat 4.0.1-2; depends (jupyter_core ^= 4.0.6, ipython_genutils ^= 0.1.0, traitlets ^= 4.1.0, jsonschema ^= 2.4.0)
+- nbformat 4.0.1-3; depends (jupyter_core ^= 4.1.0, ipython_genutils ^= 0.1.0, traitlets ^= 4.1.0, jsonschema ^= 2.4.0)
+- nbformat 4.0.1-4; depends (jupyter_core ^= 4.1.0, ipython_genutils ^= 0.1.0, traitlets ^= 4.2.1, jsonschema ^= 2.4.0)
+- ndg_httpsclient 0.3.2-1; depends (pyopenssl ^= 0.13.1, pyasn1 ^= 0.1.7)
+- ndg_httpsclient 0.3.2-2; depends (pyopenssl ^= 0.14, pyasn1 ^= 0.1.7)
+- ndg_httpsclient 0.3.3-1; depends (pyopenssl ^= 0.14, pyasn1 ^= 0.1.7)
+- ndg_httpsclient 0.3.3-2; depends (pyopenssl ^= 0.15.1, pyasn1 ^= 0.1.7)
+- ndg_httpsclient 0.3.3-3; depends (pyopenssl ^= 0.15.1, pyasn1 ^= 0.1.9)
+- ndg_httpsclient 0.3.3-4; depends (pyopenssl ^= 16.0.0, pyasn1 ^= 0.1.9)
+- netcdf4 0.9.3-2; depends (lib_netcdf4 == 4.1.1-1, numpy ^= 1.5.1, hdf5 ^= 1.8.5.1)
+- netcdf4 0.9.4-1; depends (lib_netcdf4 == 4.1.1-1, numpy ^= 1.6.0, hdf5 ^= 1.8.5.1)
+- netcdf4 0.9.5-1; depends (lib_netcdf4 == 4.1.1-1, numpy ^= 1.6.0, hdf5 ^= 1.8.5.1)
+- netcdf4 0.9.5-2; depends (lib_netcdf4 == 4.1.1-1, numpy ^= 1.6.1, hdf5 ^= 1.8.5.1)
+- netcdf4 0.9.8-1; depends (lib_netcdf4 == 4.1.1-1, numpy ^= 1.6.1, hdf5 ^= 1.8.5.1)
+- netcdf4 1.0-1; depends (lib_netcdf4 ^= 4.2, numpy ^= 1.6.1, hdf5 ^= 1.8.9)
+- netcdf4 1.0-4; depends (lib_netcdf4 ^= 4.3.0, numpy ^= 1.7.1, hdf5 ^= 1.8.9)
+- netcdf4 1.0.5-1; depends (lib_netcdf4 ^= 4.3.0, numpy ^= 1.7.1, hdf5 ^= 1.8.11)
+- netcdf4 1.0.5-2; depends (lib_netcdf4 ^= 4.3.0, numpy ^= 1.8.0, hdf5 ^= 1.8.11)
+- netcdf4 1.0.7-1; depends (lib_netcdf4 ^= 4.3.0, numpy ^= 1.8.0, hdf5 ^= 1.8.11)
+- netcdf4 1.1.0-1; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.8.0, hdf5 ^= 1.8.11)
+- netcdf4 1.1.0-2; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.8.1, hdf5 ^= 1.8.11)
+- netcdf4 1.1.1-1; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.8.1, hdf5 ^= 1.8.11)
+- netcdf4 1.1.1-2; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.8.1, hdf5 ^= 1.8.11)
+- netcdf4 1.1.1-3; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.8.1, hdf5 ^= 1.8.14)
+- netcdf4 1.1.7.1-1; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.8.1, hdf5 ^= 1.8.14)
+- netcdf4 1.1.7.1-2; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.9.2, hdf5 ^= 1.8.14)
+- netcdf4 1.1.7.1-3; depends (lib_netcdf4 ^= 4.3.3.1, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- netcdf4 1.2.0-1; depends (lib_netcdf4 ^= 4.3.3.1, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- netcdf4 1.2.2-1; depends (lib_netcdf4 ^= 4.3.3.1, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- netcdf4 1.2.2-2; depends (lib_netcdf4 ^= 4.3.3.1, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- netcdf4 1.2.2-3; depends (lib_netcdf4 ^= 4.3.3.1, numpy ^= 1.9.2, hdf5 ^= 1.8.16)
+- netcdf4 1.2.2-4; depends (lib_netcdf4 ^= 4.3.3.1, numpy ^= 1.10.4, hdf5 ^= 1.8.16)
+- networkx 1.3-2; depends (numpy)
+- networkx 1.4-1; depends (numpy)
+- networkx 1.5-1; depends (numpy)
+- networkx 1.6-1; depends (numpy)
+- networkx 1.6-2; depends (numpy)
+- networkx 1.8.1-1; depends (numpy)
+- networkx 1.8.1-2; depends (numpy)
+- networkx 1.8.1-3; depends (numpy)
+- networkx 1.9-1; depends (numpy, decorator ^= 3.4.0)
+- networkx 1.9.1-1; depends (numpy ^= 1.8.1, decorator ^= 3.4.0)
+- networkx 1.9.1-2; depends (numpy ^= 1.8.1, decorator ^= 3.4.2)
+- networkx 1.9.1-3; depends (numpy ^= 1.9.2, decorator ^= 3.4.2)
+- networkx 1.10-1; depends (numpy ^= 1.9.2, decorator ^= 4.0.2)
+- networkx 1.10-2; depends (numpy ^= 1.9.2, decorator ^= 4.0.4)
+- networkx 1.10-3; depends (numpy ^= 1.9.2, decorator ^= 4.0.6)
+- networkx 1.11-1; depends (numpy ^= 1.9.2, decorator ^= 4.0.6)
+- networkx 1.11-2; depends (numpy ^= 1.9.2, decorator ^= 4.0.9)
+- networkx 1.11-3; depends (numpy ^= 1.10.4, decorator ^= 4.0.9)
+- ninja 1.6.0-1
+- nltk 2.0.1rc1-1; depends (pyyaml ^= 3.9)
+- nltk 2.0.1rc1-2; depends (pyyaml)
+- nltk 2.0.1-1; depends (pyyaml, numpy)
+- nltk 2.0.1-2; depends (pyyaml, numpy)
+- nltk 2.0.1-3; depends (pyyaml, numpy)
+- nltk 2.0.1-4; depends (pyyaml, numpy)
+- nltk 3.0.0b1-1; depends (pyyaml, numpy)
+- nltk 3.0.0b2-2; depends (pyyaml, numpy)
+- nltk 3.0.0-1; depends (pyyaml, numpy)
+- nltk 3.0.1-1; depends (pyyaml, numpy)
+- nltk 3.0.2-1; depends (pyyaml, numpy)
+- nltk 3.0.2-2; depends (pyyaml, numpy)
+- nltk 3.0.3-1; depends (pyyaml, numpy)
+- nltk 3.1-1; depends (pyyaml, numpy)
+- nltk 3.2-1; depends (pyyaml ^= 3.11, numpy ^= 1.9.2)
+- nltk 3.2-2; depends (pyyaml ^= 3.11, numpy ^= 1.10.4)
+- nose 0.11.4-2
+- nose 1.0.0-1
+- nose 1.0.0-2
+- nose 1.1.2-1
+- nose 1.2.1-1
+- nose 1.3.0-1
+- nose 1.3.3-1
+- nose 1.3.4-1
+- nose 1.3.7-1
+- notebook 4.0.4-1; depends (nbformat ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.0.3, tornado ^= 4.2, jupyter_core ^= 4.0.4, traitlets ^= 4.0.0, nbconvert ^= 4.0.0, terminado ^= 0.5, jinja2 ^= 2.7.3, ipython_genutils ^= 0.1.0)
+- notebook 4.0.5-2; depends (nbformat ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.0.3, tornado ^= 4.2, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.0.0, terminado ^= 0.5, jinja2 ^= 2.7.3, ipython_genutils ^= 0.1.0)
+- notebook 4.0.5-3; depends (nbformat ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.0.3, tornado ^= 4.2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.0.0, terminado ^= 0.5, jinja2 ^= 2.7.3, ipython_genutils ^= 0.1.0)
+- notebook 4.0.5-4; depends (nbformat ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.0.3, tornado ^= 4.2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.0.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.0.5-5; depends (nbformat ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.1.0, tornado ^= 4.2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.0.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.0.5-6; depends (nbformat ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.1.0, tornado ^= 4.2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.0.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.0.5-7; depends (nbformat ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.1.0, tornado ^= 4.2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.0.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.0.5-8; depends (nbformat ^= 4.0.0, jupyter_client ^= 4.0.0, ipykernel ^= 4.1.0, tornado ^= 4.2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.0.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.0.6-1; depends (nbformat ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.0, tornado ^= 4.2.1, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.1.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.0.6-2; depends (nbformat ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.0, tornado ^= 4.3, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.1.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.0.6-3; depends (nbformat ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.0, tornado ^= 4.3, jupyter_core ^= 4.0.6, traitlets ^= 4.0.0, nbconvert ^= 4.1.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.1.0-1; depends (nbformat ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.2, tornado ^= 4.3, jupyter_core ^= 4.0.6, traitlets ^= 4.1.0, nbconvert ^= 4.1.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.1.0-2; depends (nbformat ^= 4.0.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.2, tornado ^= 4.3, jupyter_core ^= 4.0.6, traitlets ^= 4.1.0, nbconvert ^= 4.1.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.1.0-3; depends (nbformat ^= 4.0.1, jupyter_client ^= 4.2.1, ipykernel ^= 4.3.1, tornado ^= 4.3, jupyter_core ^= 4.0.6, traitlets ^= 4.1.0, nbconvert ^= 4.1.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.1.0-4; depends (nbformat ^= 4.0.1, jupyter_client ^= 4.2.1, ipykernel ^= 4.3.1, tornado ^= 4.3, jupyter_core ^= 4.1.0, traitlets ^= 4.1.0, nbconvert ^= 4.1.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- notebook 4.1.0-6; depends (nbformat ^= 4.0.1, jupyter_client ^= 4.2.2, ipykernel ^= 4.3.1, tornado ^= 4.3, jupyter_core ^= 4.1.0, traitlets ^= 4.2.1, nbconvert ^= 4.1.0, terminado ^= 0.5, jinja2 ^= 2.8, ipython_genutils ^= 0.1.0)
+- numba 0.9.0-1; depends (llvmpy ^= 0.11.3, meta ^= 0.4.2.dev, numpy ^= 1.7.1, llvmmath ^= 0.1.0)
+- numba 0.9.0-2; depends (llvmpy ^= 0.11.3, meta ^= 0.4.2.dev, numpy ^= 1.7.1, llvmmath ^= 0.1.0)
+- numba 0.10.0-1; depends (llvmpy ^= 0.11.3, meta ^= 0.4.2.dev, numpy ^= 1.7.1, llvmmath ^= 0.1.1)
+- numba 0.10.2-1; depends (llvmpy ^= 0.12.0, meta ^= 0.4.2.dev, numpy ^= 1.7.1, llvmmath ^= 0.1.1)
+- numba 0.10.2-3; depends (llvmpy ^= 0.12.0, meta ^= 0.4.2.dev, numpy ^= 1.8.0, llvmmath ^= 0.1.1)
+- numba 0.11.1-1; depends (llvmpy ^= 0.12.1, meta ^= 0.4.2.dev, numpy ^= 1.8.0, llvmmath ^= 0.1.1)
+- numba 0.13.0-1; depends (llvmpy ^= 0.12.1, meta ^= 0.4.2.dev, numpy ^= 1.8.0, llvmmath ^= 0.1.1)
+- numba 0.13.2-1; depends (llvmpy ^= 0.12.6, meta ^= 0.4.2.dev, numpy ^= 1.8.0, llvmmath ^= 0.1.1)
+- numba 0.13.2-4; depends (llvmpy ^= 0.12.6, meta ^= 0.4.2.dev, numpy ^= 1.8.1, llvmmath ^= 0.1.1)
+- numba 0.13.4-1; depends (llvmpy ^= 0.12.7, meta ^= 0.4.2.dev, numpy ^= 1.8.1, llvmmath ^= 0.1.2)
+- numba 0.14.0-1; depends (llvmpy ^= 0.12.7, meta ^= 0.4.2.dev, numpy ^= 1.8.1, llvmmath ^= 0.1.2)
+- numba 0.14.0-2; depends (llvmpy ^= 0.12.7, meta ^= 0.4.2.dev2, numpy ^= 1.8.1, llvmmath ^= 0.1.2)
+- numba 0.15.1-1; depends (llvmpy ^= 0.12.7, meta ^= 0.4.2.dev2, numpy ^= 1.8.1, llvmmath ^= 0.1.2)
+- numba 0.17.0-1; depends (funcsigs ^= 0.4, llvmlite ^= 0.2.2, numpy ^= 1.8.1)
+- numba 0.18.1-1; depends (funcsigs ^= 0.4, llvmlite ^= 0.4.0, numpy ^= 1.8.1)
+- numba 0.18.2-1; depends (funcsigs ^= 0.4, llvmlite ^= 0.4.0, numpy ^= 1.8.1)
+- numba 0.18.2-2; depends (funcsigs ^= 0.4, llvmlite ^= 0.4.0, numpy ^= 1.9.2)
+- numba 0.19.2-1; depends (funcsigs ^= 0.4, llvmlite ^= 0.5.0, numpy ^= 1.9.2)
+- numba 0.20.0-1; depends (funcsigs ^= 0.4, llvmlite ^= 0.6.0, numpy ^= 1.9.2)
+- numba 0.21.0-1; depends (singledispatch ^= 3.4.0.3, funcsigs ^= 0.4, llvmlite ^= 0.7.0, numpy ^= 1.9.2)
+- numba 0.21.0-2; depends (singledispatch ^= 3.4.0.3, funcsigs ^= 0.4, llvmlite ^= 0.7.0, numpy ^= 1.9.2)
+- numba 0.22.1-1; depends (singledispatch ^= 3.4.0.3, funcsigs ^= 0.4, llvmlite ^= 0.8.0, numpy ^= 1.9.2)
+- numba 0.23.0-1; depends (singledispatch ^= 3.4.0.3, funcsigs ^= 0.4, llvmlite ^= 0.8.0, numpy ^= 1.9.2)
+- numba 0.23.1-1; depends (singledispatch ^= 3.4.0.3, funcsigs ^= 0.4, llvmlite ^= 0.8.0, numpy ^= 1.9.2)
+- numba 0.24.0-1; depends (singledispatch ^= 3.4.0.3, funcsigs ^= 0.4, llvmlite ^= 0.9.0, numpy ^= 1.9.2)
+- numba 0.25.0-1; depends (singledispatch ^= 3.4.0.3, funcsigs ^= 0.4, llvmlite ^= 0.10.0, numpy ^= 1.9.2)
+- numba 0.25.0-2; depends (singledispatch ^= 3.4.0.3, funcsigs ^= 0.4, llvmlite ^= 0.10.0, numpy ^= 1.10.4)
+- numexpr 1.4.1-2; depends (mkl ^= 10.3, numpy ^= 1.5.1)
+- numexpr 1.4.2-1; depends (mkl ^= 10.3, numpy ^= 1.5.1)
+- numexpr 1.4.2-2; depends (mkl ^= 10.3, numpy ^= 1.6.0)
+- numexpr 1.4.2-3; depends (mkl ^= 10.3, numpy ^= 1.6.1)
+- numexpr 2.0-1; depends (mkl ^= 10.3, numpy ^= 1.6.1)
+- numexpr 2.0.1-1; depends (mkl ^= 10.3, numpy ^= 1.6.1)
+- numexpr 2.0.1-3; depends (mkl ^= 10.3, numpy ^= 1.7.1)
+- numexpr 2.2.2-1; depends (mkl ^= 10.3, numpy ^= 1.7.1)
+- numexpr 2.2.2-2; depends (mkl ^= 10.3, numpy ^= 1.8.0)
+- numexpr 2.4.0-1; depends (mkl ^= 10.3, numpy ^= 1.8.0)
+- numexpr 2.4.0-2; depends (mkl ^= 10.3, numpy ^= 1.8.1)
+- numexpr 2.4.0-3; depends (mkl ^= 10.3, numpy ^= 1.9.2)
+- numexpr 2.4.0-4; depends (mkl ^= 11.1.4, numpy ^= 1.9.2)
+- numexpr 2.5-1; depends (mkl ^= 11.1.4, numpy ^= 1.9.2)
+- numexpr 2.5.1-1; depends (mkl ^= 11.1.4, numpy ^= 1.9.2)
+- numexpr 2.5.1-2; depends (mkl ^= 11.1.4, numpy ^= 1.10.4)
+- numexpr 2.5.2-1; depends (mkl ^= 11.1.4, numpy ^= 1.10.4)
+- numpy 1.5.1-1; depends (mkl == 10.3-1)
+- numpy 1.5.1-2; depends (mkl == 10.3-1)
+- numpy 1.6.0b2-1; depends (mkl == 10.3-1)
+- numpy 1.6.0-1; depends (mkl == 10.3-1)
+- numpy 1.6.0-2; depends (mkl == 10.3-1)
+- numpy 1.6.0-3; depends (mkl == 10.3-1)
+- numpy 1.6.0-4; depends (mkl == 10.3-1)
+- numpy 1.6.0-5; depends (mkl == 10.3-1)
+- numpy 1.6.1-1; depends (mkl == 10.3-1)
+- numpy 1.6.1-2; depends (mkl == 10.3-1)
+- numpy 1.6.1-3; depends (mkl == 10.3-1)
+- numpy 1.6.1-5; depends (mkl == 10.3-1)
+- numpy 1.7.1-1; depends (mkl == 10.3-1)
+- numpy 1.7.1-2; depends (mkl == 10.3-1)
+- numpy 1.7.1-3; depends (mkl == 10.3-1)
+- numpy 1.8.0-1; depends (mkl == 10.3-1)
+- numpy 1.8.0-2; depends (mkl == 10.3-1)
+- numpy 1.8.0-3; depends (mkl == 10.3-1)
+- numpy 1.8.1-1; depends (mkl == 10.3-1)
+- numpy 1.8.1-2; depends (mkl == 10.3-1)
+- numpy 1.8.1-3; depends (mkl == 10.3-1)
+- numpy 1.9.2-1; depends (mkl == 10.3-1)
+- numpy 1.9.2-2; depends (mkl ^= 10.3)
+- numpy 1.9.2-3; depends (mkl ^= 11.1.4)
+- numpy 1.10.4-1; depends (mkl ^= 11.1.4)
+- numpydoc 0.5-1; depends (numpy ^= 1.8.1, sphinx ^= 1.2.3, matplotlib ^= 1.4.2)
+- numpydoc 0.5-2; depends (numpy ^= 1.8.1, sphinx ^= 1.2.3, matplotlib ^= 1.4.3)
+- numpydoc 0.5-3; depends (numpy ^= 1.8.1, sphinx ^= 1.3.1, matplotlib ^= 1.4.3)
+- numpydoc 0.5-4; depends (numpy ^= 1.9.2, sphinx ^= 1.3.1, matplotlib ^= 1.4.3)
+- numpydoc 0.5-5; depends (numpy ^= 1.9.2, sphinx ^= 1.3.1, matplotlib ^= 1.5.0)
+- numpydoc 0.5-6; depends (numpy ^= 1.9.2, sphinx ^= 1.3.1, matplotlib ^= 1.5.1)
+- numpydoc 0.5-7; depends (numpy ^= 1.9.2, sphinx ^= 1.3.5, matplotlib ^= 1.5.1)
+- numpydoc 0.5-8; depends (numpy ^= 1.10.4, sphinx ^= 1.3.5, matplotlib ^= 1.5.1)
+- numpydoc 0.5-9; depends (numpy ^= 1.10.4, sphinx ^= 1.4.1, matplotlib ^= 1.5.1)
+- odo 0.3.1-1; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 0.9.9, datashape ^= 0.4.4, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.2.0, numpy ^= 1.8.1, pandas ^= 0.16.0)
+- odo 0.3.1-2; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.0, datashape ^= 0.4.4, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.8.1, pandas ^= 0.16.0)
+- odo 0.3.1-3; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.1, datashape ^= 0.4.4, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.8.1, pandas ^= 0.16.0)
+- odo 0.3.1-4; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.1, datashape ^= 0.4.4, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.0)
+- odo 0.3.2-2; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, datashape ^= 0.4.5, pytables ^= 3.1.1, toolz ^= 0.7.1, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.1)
+- odo 0.3.2-3; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, datashape ^= 0.4.5, pytables ^= 3.1.1, toolz ^= 0.7.2, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.1)
+- odo 0.3.2-4; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, datashape ^= 0.4.5, pytables ^= 3.1.1, toolz ^= 0.7.2, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.2-5; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.4, datashape ^= 0.4.5, pytables ^= 3.2.0, toolz ^= 0.7.2, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.2-6; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.6, datashape ^= 0.4.5, pytables ^= 3.2.0, toolz ^= 0.7.2, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.2-7; depends (multipledispatch ^= 0.4.7, sqlalchemy ^= 1.0.6, datashape ^= 0.4.5, pytables ^= 3.2.0, toolz ^= 0.7.2, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.3-1; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.6, datashape ^= 0.4.6, pytables ^= 3.2.0, toolz ^= 0.7.4, networkx ^= 1.9.1, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.3-2; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.6, datashape ^= 0.4.6, pytables ^= 3.2.0, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.3-3; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, datashape ^= 0.4.6, pytables ^= 3.2.0, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.4-1; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, datashape ^= 0.4.7, pytables ^= 3.2.0, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.4-2; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, datashape ^= 0.4.7, pytables ^= 3.2.0, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.4-3; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, datashape ^= 0.4.7, pytables ^= 3.2.0, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.16.2)
+- odo 0.3.4-4; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, datashape ^= 0.4.7, pytables ^= 3.2.0, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.3.4-5; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, datashape ^= 0.4.7, pytables ^= 3.2.0, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.3.4-6; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.8, datashape ^= 0.4.7, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.3.4-7; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, datashape ^= 0.4.7, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.3.4-8; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, datashape ^= 0.5.0, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.3.4-9; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, datashape ^= 0.5.0, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.4.2-1; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.10, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.4.2-2; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.10, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.11, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.4.2-3; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.11, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.17.1)
+- odo 0.4.2-4; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.11, python_dateutil ^= 2.4.2, numpy ^= 1.9.2, pandas ^= 0.18.0)
+- odo 0.4.2-5; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.11, python_dateutil ^= 2.5.1, numpy ^= 1.9.2, pandas ^= 0.18.0)
+- odo 0.4.2-6; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.11, python_dateutil ^= 2.5.1, numpy ^= 1.10.4, pandas ^= 0.18.0)
+- odo 0.4.2-7; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.11, python_dateutil ^= 2.5.1, numpy ^= 1.10.4, pandas ^= 0.18.0)
+- odo 0.4.2-8; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.11, python_dateutil ^= 2.5.1, numpy ^= 1.10.4, pandas ^= 0.18.0)
+- odo 0.4.2-9; depends (multipledispatch ^= 0.4.8, sqlalchemy ^= 1.0.12, datashape ^= 0.5.1, pytables ^= 3.2.2, toolz ^= 0.7.4, networkx ^= 1.11, python_dateutil ^= 2.5.2, numpy ^= 1.10.4, pandas ^= 0.18.0)
+- okonomiyaki 0.2.1-1
+- okonomiyaki 0.3.1-1
+- okonomiyaki 0.3.2-1
+- okonomiyaki 0.3.3-1
+- okonomiyaki 0.3.3-2
+- okonomiyaki 0.5.0-1
+- okonomiyaki 0.5.0-2; depends (six ^= 1.9.0)
+- okonomiyaki 0.5.1-1; depends (six ^= 1.9.0)
+- okonomiyaki 0.7.0-1; depends (six ^= 1.9.0)
+- okonomiyaki 0.7.0-2; depends (six ^= 1.9.0, zipfile2 ^= 0.0.6)
+- okonomiyaki 0.8.0-1; depends (six ^= 1.9.0, zipfile2 ^= 0.0.6)
+- okonomiyaki 0.8.0-2; depends (six ^= 1.9.0, zipfile2 ^= 0.0.7)
+- okonomiyaki 0.9.0-1; depends (six ^= 1.9.0, zipfile2 ^= 0.0.7)
+- okonomiyaki 0.9.0-3; depends (six ^= 1.9.0, zipfile2 ^= 0.0.8)
+- okonomiyaki 0.12.0-1; depends (six ^= 1.9.0, zipfile2 ^= 0.0.11, attrs ^= 15.1.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.13.0-1; depends (six ^= 1.9.0, zipfile2 ^= 0.0.11, attrs ^= 15.1.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.13.1-1; depends (six ^= 1.9.0, zipfile2 ^= 0.0.11, attrs ^= 15.1.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.13.1-2; depends (six ^= 1.9.0, zipfile2 ^= 0.0.11, attrs ^= 15.1.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.13.1-3; depends (six ^= 1.10.0, zipfile2 ^= 0.0.11, attrs ^= 15.1.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.13.1-4; depends (six ^= 1.10.0, zipfile2 ^= 0.0.11, attrs ^= 15.1.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.14.0-1; depends (six ^= 1.10.0, zipfile2 ^= 0.0.11, attrs ^= 15.1.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.14.0-2; depends (six ^= 1.10.0, zipfile2 ^= 0.0.11, attrs ^= 15.2.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.14.1-1; depends (six ^= 1.10.0, zipfile2 ^= 0.0.11, attrs ^= 15.2.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.14.1-2; depends (six ^= 1.10.0, zipfile2 ^= 0.0.12, attrs ^= 15.2.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.15.0-1; depends (six ^= 1.10.0, zipfile2 ^= 0.0.12, attrs ^= 15.2.0, jsonschema ^= 2.4.0)
+- okonomiyaki 0.15.0-2; depends (enum34 ^= 1.1.2, six ^= 1.10.0, zipfile2 ^= 0.0.12, attrs ^= 15.2.0, jsonschema ^= 2.4.0)
+- opencv 2.4.2-1
+- opencv 2.4.5-2; depends (numpy ^= 1.7.1)
+- opencv 2.4.5-3; depends (numpy ^= 1.8.0)
+- opencv 2.4.5-4; depends (numpy ^= 1.8.0)
+- opencv 2.4.5-5; depends (numpy ^= 1.8.1)
+- opencv 2.4.9-1; depends (numpy ^= 1.8.1)
+- opencv 2.4.9-2; depends (numpy ^= 1.9.2)
+- opencv 2.4.9-4; depends (numpy ^= 1.10.4)
+- openopt 0.28-2; depends (numpy)
+- openpyxl 1.5.8-1
+- openpyxl 1.8.5-1
+- openpyxl 2.0.3-1; depends (jdcal ^= 1.0.0)
+- openpyxl 2.3.0-1; depends (jdcal ^= 1.0.0)
+- openpyxl 2.3.1-1; depends (jdcal ^= 1.0.0, lxml ^= 3.4.4)
+- openpyxl 2.3.1-2; depends (jdcal ^= 1.2, lxml ^= 3.4.4)
+- openpyxl 2.3.1-3; depends (jdcal ^= 1.2, lxml ^= 3.5.0)
+- openpyxl 2.3.4-1; depends (jdcal ^= 1.2, lxml ^= 3.6.0)
+- owslib 0.8.8-1; depends (python_dateutil ^= 2.2.0, lxml ^= 3.3.6, pytz ^= 2013.8.0)
+- owslib 0.8.8-2; depends (python_dateutil ^= 2.2.0, lxml ^= 3.4.0, pytz ^= 2013.8.0)
+- owslib 0.8.8-3; depends (python_dateutil ^= 2.2.0, lxml ^= 3.4.0, pytz ^= 2014.9.0)
+- owslib 0.8.8-4; depends (python_dateutil ^= 2.2.0, lxml ^= 3.4.1, pytz ^= 2014.9.0)
+- owslib 0.8.8-5; depends (python_dateutil ^= 2.2.0, lxml ^= 3.4.2, pytz ^= 2014.9.0)
+- owslib 0.8.8-6; depends (python_dateutil ^= 2.4.2, lxml ^= 3.4.2, pytz ^= 2014.9.0)
+- owslib 0.8.8-7; depends (python_dateutil ^= 2.4.2, lxml ^= 3.4.3, pytz ^= 2014.9.0)
+- owslib 0.8.8-8; depends (python_dateutil ^= 2.4.2, lxml ^= 3.4.4, pytz ^= 2014.9.0)
+- owslib 0.8.8-9; depends (python_dateutil ^= 2.4.2, lxml ^= 3.4.4, pytz ^= 2015.7)
+- owslib 0.8.8-10; depends (python_dateutil ^= 2.4.2, lxml ^= 3.5.0, pytz ^= 2015.7)
+- owslib 0.8.8-11; depends (python_dateutil ^= 2.4.2, lxml ^= 3.6.0, pytz ^= 2015.7)
+- owslib 0.8.8-12; depends (python_dateutil ^= 2.5.1, lxml ^= 3.6.0, pytz ^= 2015.7)
+- owslib 0.8.8-13; depends (python_dateutil ^= 2.5.2, lxml ^= 3.6.0, pytz ^= 2016.3)
+- pandas 0.2-2; depends (python_dateutil, numpy ^= 1.5.1, scikits.statsmodels)
+- pandas 0.2-3; depends (python_dateutil, numpy ^= 1.5.1, scikits.statsmodels)
+- pandas 0.3.0-1; depends (python_dateutil, numpy ^= 1.5.1, scikits.statsmodels)
+- pandas 0.3.0-2; depends (python_dateutil, numpy ^= 1.6.0, scikits.statsmodels)
+- pandas 0.3.0-3; depends (python_dateutil, numpy ^= 1.6.1, scikits.statsmodels)
+- pandas 0.4.3-1; depends (python_dateutil, numpy ^= 1.6.1, scikits.statsmodels)
+- pandas 0.6.1-1; depends (python_dateutil, numpy ^= 1.6.1, scikits.statsmodels)
+- pandas 0.7.0-1; depends (python_dateutil, numpy ^= 1.6.1, scikits.statsmodels)
+- pandas 0.7.1-1; depends (python_dateutil, numpy ^= 1.6.1, scikits.statsmodels)
+- pandas 0.7.2-1; depends (python_dateutil, numpy ^= 1.6.1, scikits.statsmodels)
+- pandas 0.7.3-1; depends (python_dateutil, numpy ^= 1.6.1, scikits.statsmodels)
+- pandas 0.7.3-2; depends (statsmodels, python_dateutil, numpy ^= 1.6.1)
+- pandas 0.8.0rc2-1; depends (statsmodels, python_dateutil, numpy ^= 1.6.1)
+- pandas 0.9.0-1; depends (statsmodels, python_dateutil, numpy ^= 1.6.1)
+- pandas 0.9.1-1; depends (python_dateutil, numpy ^= 1.6.1)
+- pandas 0.10.0-1; depends (python_dateutil, numpy ^= 1.6.1)
+- pandas 0.10.1-1; depends (python_dateutil, numpy ^= 1.6.1)
+- pandas 0.11.0-1; depends (python_dateutil, numpy ^= 1.6.1)
+- pandas 0.11.0-2; depends (python_dateutil, numpy ^= 1.7.1)
+- pandas 0.11.0-3; depends (python_dateutil, numpy ^= 1.7.1)
+- pandas 0.12.0-1; depends (python_dateutil, numpy ^= 1.7.1)
+- pandas 0.12.0-2; depends (python_dateutil, pytz ^= 2011n, numpy ^= 1.7.1)
+- pandas 0.12.0-3; depends (python_dateutil, pytz ^= 2011n, numpy ^= 1.8.0)
+- pandas 0.12.0-4; depends (python_dateutil ^= 2.2.0, pytz ^= 2013.8.0, numpy ^= 1.8.0)
+- pandas 0.13.1-1; depends (python_dateutil ^= 2.2.0, pytz ^= 2013.8.0, numpy ^= 1.8.0)
+- pandas 0.14.0-1; depends (python_dateutil ^= 2.2.0, pytz ^= 2013.8.0, numpy ^= 1.8.0)
+- pandas 0.14.1-1; depends (python_dateutil ^= 2.2.0, pytz ^= 2013.8.0, numpy ^= 1.8.0)
+- pandas 0.14.1-2; depends (python_dateutil ^= 2.2.0, pytz ^= 2013.8.0, numpy ^= 1.8.1)
+- pandas 0.14.1-3; depends (python_dateutil ^= 2.2.0, distribute ^= 0.6.49, numpy ^= 1.8.1, pytz ^= 2013.8.0)
+- pandas 0.15.0-1; depends (python_dateutil ^= 2.2.0, distribute ^= 0.6.49, numpy ^= 1.8.1, pytz ^= 2013.8.0)
+- pandas 0.15.0-2; depends (python_dateutil ^= 2.2.0, distribute ^= 0.6.49, numpy ^= 1.8.1, pytz ^= 2014.9.0)
+- pandas 0.15.1-1; depends (python_dateutil ^= 2.2.0, distribute ^= 0.6.49, numpy ^= 1.8.1, pytz ^= 2014.9.0)
+- pandas 0.15.2-1; depends (python_dateutil ^= 2.2.0, distribute ^= 0.6.49, numpy ^= 1.8.1, pytz ^= 2014.9.0)
+- pandas 0.15.2-2; depends (python_dateutil ^= 2.2.0, pytz ^= 2014.9.0, numpy ^= 1.8.1, setuptools ^= 14.3.1)
+- pandas 0.16.0-1; depends (python_dateutil ^= 2.2.0, pytz ^= 2014.9.0, numpy ^= 1.8.1, setuptools ^= 14.3.1)
+- pandas 0.16.0-2; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.8.1, setuptools ^= 14.3.1)
+- pandas 0.16.0-3; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.8.1, setuptools ^= 15.1)
+- pandas 0.16.0-4; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 15.1)
+- pandas 0.16.0-5; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 15.2)
+- pandas 0.16.1-1; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 15.2)
+- pandas 0.16.1-2; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 16.0)
+- pandas 0.16.1-3; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 17.1.1)
+- pandas 0.16.2-1; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 17.1.1)
+- pandas 0.16.2-2; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 18.2)
+- pandas 0.16.2-3; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 18.4)
+- pandas 0.17.1-1; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 18.4)
+- pandas 0.17.1-2; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 18.7.1)
+- pandas 0.17.1-3; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 18.7.1)
+- pandas 0.17.1-4; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 18.7.1)
+- pandas 0.17.1-5; depends (python_dateutil ^= 2.4.2, pytz ^= 2014.9.0, numpy ^= 1.9.2, setuptools ^= 19.1.1)
+- pandas 0.17.1-6; depends (python_dateutil ^= 2.4.2, pytz ^= 2015.7, numpy ^= 1.9.2, setuptools ^= 19.1.1)
+- pandas 0.17.1-7; depends (python_dateutil ^= 2.4.2, pytz ^= 2015.7, numpy ^= 1.9.2, setuptools ^= 19.4)
+- pandas 0.17.1-8; depends (python_dateutil ^= 2.4.2, pytz ^= 2015.7, numpy ^= 1.9.2, setuptools ^= 20.1.1)
+- pandas 0.17.1-9; depends (python_dateutil ^= 2.4.2, pytz ^= 2015.7, numpy ^= 1.9.2, setuptools ^= 20.2.2)
+- pandas 0.18.0-1; depends (python_dateutil ^= 2.4.2, pytz ^= 2015.7, numpy ^= 1.9.2, setuptools ^= 20.2.2)
+- pandas 0.18.0-2; depends (python_dateutil ^= 2.4.2, pytz ^= 2015.7, numpy ^= 1.9.2, setuptools ^= 20.3.1)
+- pandas 0.18.0-3; depends (python_dateutil ^= 2.5.1, pytz ^= 2015.7, numpy ^= 1.9.2, setuptools ^= 20.3.1)
+- pandas 0.18.0-4; depends (python_dateutil ^= 2.5.1, pytz ^= 2015.7, numpy ^= 1.10.4, setuptools ^= 20.3.1)
+- pandas 0.18.0-5; depends (python_dateutil ^= 2.5.1, pytz ^= 2015.7, numpy ^= 1.10.4, setuptools ^= 20.6.7)
+- pandas 0.18.0-6; depends (python_dateutil ^= 2.5.1, pytz ^= 2015.7, numpy ^= 1.10.4, setuptools ^= 20.6.7)
+- pandas 0.18.0-7; depends (python_dateutil ^= 2.5.2, pytz ^= 2016.3, numpy ^= 1.10.4, setuptools ^= 20.6.7)
+- pandas_datareader 0.2.1-1; depends (requests ^= 2.8.0, requests_file ^= 1.4, pandas ^= 0.17.1)
+- pandas_datareader 0.2.1-2; depends (requests ^= 2.9.0, requests_file ^= 1.4, pandas ^= 0.17.1)
+- pandas_datareader 0.2.1-3; depends (requests ^= 2.9.1, requests_file ^= 1.4, pandas ^= 0.17.1)
+- pandas_datareader 0.2.1-4; depends (requests ^= 2.9.1, requests_file ^= 1.4, pandas ^= 0.18.0)
+- pandasql 0.3.1-1; depends (sqlparse ^= 0.1.8, pandas ^= 0.12.0)
+- pandasql 0.3.1-2; depends (sqlparse ^= 0.1.8, pandas ^= 0.13.1)
+- pandasql 0.4.3-1; depends (sqlparse ^= 0.1.11, pandas ^= 0.14.0)
+- pandasql 0.4.3-2; depends (sqlparse ^= 0.1.11, pandas ^= 0.14.1)
+- pandasql 0.6.1-1; depends (pandas ^= 0.14.1)
+- pandasql 0.6.1-2; depends (pandas ^= 0.15.0)
+- pandasql 0.6.1-3; depends (pandas ^= 0.15.1)
+- pandasql 0.6.1-4; depends (pandas ^= 0.15.2)
+- pandasql 0.6.1-5; depends (pandas ^= 0.16.0)
+- pandasql 0.6.2-1; depends (pandas ^= 0.16.0)
+- pandasql 0.6.2-2; depends (pandas ^= 0.16.1)
+- pandasql 0.6.2-3; depends (pandas ^= 0.16.2)
+- pandasql 0.6.3-1; depends (pandas ^= 0.16.2)
+- pandasql 0.6.3-2; depends (pandas ^= 0.17.1)
+- pandasql 0.6.3-3; depends (pandas ^= 0.18.0)
+- param 1.3.2-1
+- paramiko 1.7.6-4; depends (pycrypto)
+- paramiko 1.7.7.1-1; depends (pycrypto)
+- paramiko 1.10.1-2; depends (pycrypto ^= 2.6.1)
+- paramiko 1.14.0-1; depends (ecdsa ^= 0.11.0, pycrypto ^= 2.6.1)
+- paramiko 1.15.1-1; depends (ecdsa ^= 0.11.0, pycrypto ^= 2.6.1)
+- paramiko 1.15.2-1; depends (ecdsa ^= 0.11.0, pycrypto ^= 2.6.1)
+- paramiko 1.15.2-2; depends (ecdsa ^= 0.13, pycrypto ^= 2.6.1)
+- paramiko 1.16.0-1; depends (ecdsa ^= 0.13, pycrypto ^= 2.6.1)
+- parse 1.6.6-1
+- parse_type 0.3.4-1; depends (enum34 ^= 1.1.2, parse ^= 1.6.6, six ^= 1.10.0)
+- partd 0.3.2-1; depends (locket ^= 0.2.0)
+- passlib 1.6.2-1; depends (bcrypt ^= 1.0.2)
+- passlib 1.6.5-1; depends (bcrypt ^= 2.0.0)
+- paste 1.7.5.1-1
+- pastedeploy 1.5.2-1; depends (paste ^= 1.7.5.1)
+- path.py 8.1.1-1
+- path.py 8.1.1-2
+- patsy 0.2.0-1
+- patsy 0.3.0-1
+- patsy 0.4.0-1; depends (six ^= 1.9.0, numpy ^= 1.9.2)
+- patsy 0.4.0-2; depends (six ^= 1.10.0, numpy ^= 1.9.2)
+- patsy 0.4.1-1; depends (six ^= 1.10.0, numpy ^= 1.9.2)
+- patsy 0.4.1-2; depends (six ^= 1.10.0, numpy ^= 1.10.4)
+- pbr 0.10.0-1
+- pbr 0.10.0-2; depends (distribute ^= 0.6.49)
+- pbr 0.10.0-3; depends (setuptools ^= 14.3.1)
+- pbr 0.10.0-4; depends (setuptools ^= 15.1)
+- pbr 0.10.0-5; depends (setuptools ^= 15.2)
+- pbr 0.10.0-6; depends (setuptools ^= 16.0)
+- pbr 0.10.0-7; depends (setuptools ^= 17.1.1)
+- pbr 1.2.0-1; depends (setuptools ^= 17.1.1)
+- pbr 1.2.0-2; depends (setuptools ^= 18.2)
+- pbr 1.8.1-1; depends (setuptools ^= 18.2)
+- pbr 1.8.1-2; depends (setuptools ^= 18.4)
+- pbr 1.8.1-3; depends (setuptools ^= 18.7.1)
+- pbr 1.8.1-4; depends (setuptools ^= 19.1.1)
+- pbr 1.8.1-5; depends (setuptools ^= 19.4)
+- pbr 1.8.1-6; depends (setuptools ^= 20.1.1)
+- pbr 1.8.1-7; depends (setuptools ^= 20.2.2)
+- pbr 1.8.1-8; depends (setuptools ^= 20.3.1)
+- pbr 1.8.1-9; depends (setuptools ^= 20.6.7)
+- pep8 0.6.1-1
+- pep8 1.0.1-1
+- pep8 1.4.6-1
+- pep8 1.4.6-2
+- pep8 1.5.7-1
+- pep8 1.6.1-1
+- pep8 1.6.2-1
+- pep8 1.7.0-1
+- pexpect 3.3-1
+- pexpect 3.3-2
+- pickleshare 0.5-1; depends (path.py ^= 8.1.1)
+- pil 1.1.7-3; depends (libjpeg ^= 7.0, freetype ^= 2.4.4)
+- pil 1.1.7-10; depends (libjpeg ^= 7.0, freetype ^= 2.4.4)
+- pil 1.1.7-12; depends (libjpeg ^= 7.0, freetype ^= 2.4.4)
+- pil 1.1.7-13; depends (libjpeg ^= 7.0, freetype ^= 2.5.3)
+- pil 1.1.7-14; depends (libjpeg ^= 7.0, freetype ^= 2.5.3)
+- pil_remove 1.0.0-1
+- pil_remove 1.0.0-2
+- pillow 2.8.1-1; depends (libjpeg ^= 7.0, freetype ^= 2.5.3, pil_remove ^= 1.0.0)
+- pillow 2.9.0-1; depends (libjpeg ^= 7.0, freetype ^= 2.5.3, pil_remove ^= 1.0.0)
+- pillow 2.9.0-2; depends (libjpeg ^= 7.0, libopenjpeg ^= 2.1.0, freetype ^= 2.5.3, pil_remove ^= 1.0.0)
+- pillow 2.9.0-3; depends (libjpeg ^= 7.0, libopenjpeg ^= 2.1.0, freetype ^= 2.5.3, pil_remove ^= 1.0.0)
+- pillow 3.0.0-1; depends (libjpeg ^= 7.0, libopenjpeg ^= 2.1.0, freetype ^= 2.5.3, pil_remove ^= 1.0.0)
+- pillow 3.1.0-1; depends (libjpeg ^= 7.0, libopenjpeg ^= 2.1.0, freetype ^= 2.5.3, pil_remove ^= 1.0.0)
+- pip 1.5.6-1
+- pip 6.0.6-1
+- pip 6.0.8-1
+- pip 6.1.1-1
+- pip 7.0.1-1
+- pip 7.0.3-1
+- pip 7.1.0-1
+- pip 7.1.2-1
+- pip 8.0.0-1
+- pip 8.0.2-1
+- pip 8.0.3-1
+- pip 8.1.0-1
+- pip 8.1.1-1
+- pip 8.1.2-1
+- plotly 1.3.0-1; depends (requests ^= 2.4.3, six ^= 1.8.0, matplotlib ^= 1.4.0)
+- plotly 1.3.0-2; depends (requests ^= 2.4.3, six ^= 1.8.0, matplotlib ^= 1.4.2)
+- plotly 1.3.0-3; depends (requests ^= 2.5.0, six ^= 1.8.0, matplotlib ^= 1.4.2)
+- plotly 1.4.14-1; depends (requests ^= 2.5.0, six ^= 1.8.0, matplotlib ^= 1.4.2)
+- plotly 1.4.14-2; depends (requests ^= 2.5.1, six ^= 1.8.0, matplotlib ^= 1.4.2)
+- plotly 1.4.14-3; depends (requests ^= 2.5.1, six ^= 1.9.0, matplotlib ^= 1.4.2)
+- plotly 1.4.14-4; depends (requests ^= 2.5.1, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- plotly 1.4.14-5; depends (requests ^= 2.5.3, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- plotly 1.4.14-6; depends (requests ^= 2.6.0, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- plotly 1.4.14-7; depends (requests ^= 2.6.2, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- plotly 1.4.14-8; depends (requests ^= 2.7.0, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- plotly 1.4.14-9; depends (requests ^= 2.8.0, six ^= 1.9.0, matplotlib ^= 1.4.3)
+- plotly 1.4.14-10; depends (requests ^= 2.8.0, six ^= 1.10.0, matplotlib ^= 1.4.3)
+- plotly 1.4.14-11; depends (requests ^= 2.8.0, six ^= 1.10.0, matplotlib ^= 1.5.0)
+- plotly 1.4.14-12; depends (requests ^= 2.9.0, six ^= 1.10.0, matplotlib ^= 1.5.0)
+- plotly 1.4.14-13; depends (requests ^= 2.9.0, six ^= 1.10.0, matplotlib ^= 1.5.1)
+- plotly 1.4.14-14; depends (requests ^= 2.9.1, six ^= 1.10.0, matplotlib ^= 1.5.1)
+- plotly 1.9.6-1; depends (requests ^= 2.9.1, pytz ^= 2015.7, six ^= 1.10.0)
+- plotly 1.9.6-2; depends (requests ^= 2.9.1, pytz ^= 2016.3, six ^= 1.10.0)
+- plotly 1.9.10-1; depends (requests ^= 2.9.1, pytz ^= 2016.3, six ^= 1.10.0)
+- ply 3.3-3
+- ply 3.4-1
+- ply 3.6-1
+- ply 3.8-1
+- pretend 1.0.8-1
+- prettyplotlib 0.1.3-2; depends (brewer2mpl ^= 1.3.1, matplotlib ^= 1.3.1)
+- prettyplotlib 0.1.7-1; depends (brewer2mpl ^= 1.4.0, matplotlib ^= 1.3.1)
+- prettyplotlib 0.1.7-2; depends (brewer2mpl ^= 1.4.0, matplotlib ^= 1.4.0)
+- prettyplotlib 0.1.7-3; depends (brewer2mpl ^= 1.4.0, matplotlib ^= 1.4.2)
+- prettyplotlib 0.1.7-4; depends (brewer2mpl ^= 1.4.0, matplotlib ^= 1.4.3)
+- prettyplotlib 0.1.7-5; depends (brewer2mpl ^= 1.4.0, matplotlib ^= 1.5.0)
+- prettyplotlib 0.1.7-6; depends (brewer2mpl ^= 1.4.0, matplotlib ^= 1.5.1)
+- progressbar 2.3-1
+- protobuf 2.4.1-2
+- protobuf 2.6.1-1
+- protobuf 2.6.1-2
+- protobuf_python 2.4.1-1; depends (protobuf ^= 2.4.1)
+- protobuf_python 2.6.1-1; depends (protobuf ^= 2.6.1)
+- psutil 0.2.0-1
+- psutil 0.2.1-1
+- psutil 0.4.1-1
+- psutil 1.0.1-1
+- psutil 1.2.1-2
+- psutil 2.1.1-1
+- psutil 2.2.0-1
+- psutil 2.2.1-1
+- psutil 3.2.1-1
+- psutil 3.3.0-1
+- ptyprocess 0.4-1
+- py 1.4.14-1
+- py 1.4.18-1
+- py 1.4.20-1
+- py 1.4.24-1
+- py 1.4.25-1
+- py 1.4.25-2
+- py 1.4.26-1
+- py 1.4.26-2
+- py 1.4.30-1
+- py 1.4.30-2
+- py 1.4.31-1
+- pyamg 2.1.0-1; depends (scipy ^= 0.14.0, numpy ^= 1.8.1)
+- pyamg 2.1.0-2; depends (scipy ^= 0.14.1rc1, numpy ^= 1.8.1)
+- pyamg 2.2.0-1; depends (scipy ^= 0.14.1rc1, numpy ^= 1.8.1)
+- pyamg 2.2.0-2; depends (scipy ^= 0.15.1, numpy ^= 1.8.1)
+- pyamg 2.2.1-1; depends (scipy ^= 0.15.1, numpy ^= 1.8.1)
+- pyamg 2.2.1-2; depends (scipy ^= 0.15.1, numpy ^= 1.9.2)
+- pyamg 2.2.1-3; depends (scipy ^= 0.16.0, numpy ^= 1.9.2)
+- pyamg 2.2.1-4; depends (scipy ^= 0.16.1, numpy ^= 1.9.2)
+- pyamg 2.2.1-5; depends (scipy ^= 0.17.0, numpy ^= 1.9.2)
+- pyamg 2.2.1-6; depends (scipy ^= 0.17.0, numpy ^= 1.10.4)
+- pyasn1 0.1.7-2
+- pyasn1 0.1.9-1
+- pyasn1_modules 0.0.8-1
+- pyaudio 0.2.4-3
+- pycluster 1.50-2; depends (numpy ^= 1.5.1)
+- pycluster 1.50-3; depends (numpy ^= 1.6.0)
+- pycluster 1.50-4; depends (numpy ^= 1.6.1)
+- pycluster 1.50-5; depends (numpy ^= 1.7.1)
+- pycluster 1.50-6; depends (numpy ^= 1.8.0)
+- pycluster 1.50-7; depends (numpy ^= 1.8.1)
+- pycluster 1.50-8; depends (numpy ^= 1.9.2)
+- pycluster 1.50-9; depends (numpy ^= 1.10.4)
+- pycparser 2.10.0-1
+- pycparser 2.12-1
+- pycparser 2.13-1
+- pycparser 2.14-1
+- pycparser 2.14-2
+- pycrypto 2.3-2
+- pycrypto 2.4.1-1
+- pycrypto 2.6.1-1
+- pycurl 7.19.5-1; depends (curl ^= 7.38.0)
+- pycurl 7.19.5-2; depends (curl ^= 7.43.0)
+- pydicom 0.9.9-1
+- pydot 1.0.2-5; depends (pyparsing ^= 1.5.5)
+- pydot 1.0.25-1; depends (pyparsing ^= 1.5.5)
+- pydot 1.0.28-1; depends (pyparsing)
+- pydot 1.0.28-2; depends (pyparsing ^= 2.0.2)
+- pydot 1.0.28-3; depends (pyparsing ^= 2.0.3)
+- pyephem 3.7.3.4-2
+- pyephem 3.7.4.1-1
+- pyephem 3.7.5.1-1
+- pyephem 3.7.5.3-1
+- pyface 4.0.0-1
+- pyface 4.1.0-1
+- pyface 4.2.0-1
+- pyface 4.3.0-1
+- pyface 4.3.0-2; depends (traits ^= 4.3.0)
+- pyface 4.4.0-1; depends (traits ^= 4.4.0)
+- pyface 4.4.0-2; depends (traits ^= 4.5.0)
+- pyface 4.5.0-1; depends (traits ^= 4.5.0)
+- pyface 4.5.2-1; depends (traits ^= 4.5.0)
+- pyface 5.0.0-1; depends (traits ^= 4.5.0)
+- pyface 5.0.0-2; depends (traits ^= 4.5.0)
+- pyface 5.0.0-3; depends (traits ^= 4.5.0, pygments ^= 2.1)
+- pyface 5.1.0-1; depends (traits ^= 4.5.0, pygments ^= 2.1)
+- pyface 5.1.0-2; depends (traits ^= 4.5.0, pygments ^= 2.1.3)
+- pyfits 2.4.0-1; depends (numpy ^= 1.5.1)
+- pyfits 2.4.0-2; depends (numpy ^= 1.6.0)
+- pyfits 2.4.0-3; depends (numpy ^= 1.6.1)
+- pyfits 3.0.3-1; depends (numpy ^= 1.6.1)
+- pyfits 3.0.6-1; depends (numpy ^= 1.6.1)
+- pyfits 3.0.6-2; depends (numpy ^= 1.7.1)
+- pyfits 3.0.6-3; depends (numpy ^= 1.8.0)
+- pyfits 3.0.6-4; depends (numpy ^= 1.8.1)
+- pyfits 3.3-1; depends (numpy ^= 1.8.1)
+- pyflakes 0.4.0-2
+- pyflakes 0.4.0-3
+- pyflakes 0.5.0-1
+- pyflakes 0.7.3-1
+- pyflakes 0.7.3-2
+- pyflakes 0.8.1-1
+- pyflakes 0.9.2-1
+- pyflakes 1.0.0-1
+- pyflakes 1.1.0-1
+- pygarrayimage 0.0.7-4; depends (numpy, pil, pyglet)
+- pygarrayimage 0.0.7-5; depends (numpy, pil, pyglet)
+- pygarrayimage 0.0.7-6; depends (numpy, pil, pyglet)
+- pygarrayimage 0.0.7-7; depends (numpy, pil, pyglet)
+- pygarrayimage 0.0.7-8; depends (numpy, pil, pyglet)
+- pygarrayimage 0.0.7-9; depends (numpy, pillow, pyglet)
+- pygarrayimage 0.0.7-10; depends (numpy, pillow, pyglet)
+- pygarrayimage 0.0.7-11; depends (numpy, pillow, pyglet)
+- pygarrayimage 0.0.7-12; depends (numpy, pillow, pyglet)
+- pygarrayimage 0.0.7-13; depends (numpy, pillow, pyglet)
+- pygit2 0.23.3-2; depends (libgit2 ^= 0.23.4, cffi ^= 1.4.2)
+- pygit2 0.23.3-3; depends (libgit2 ^= 0.23.4, cffi ^= 1.5.2)
+- pyglet 1.1.4-2
+- pygments 1.3.1-2
+- pygments 1.4-1
+- pygments 1.6.0-1
+- pygments 2.0.1-1
+- pygments 2.0.2-1
+- pygments 2.1-1
+- pygments 2.1.3-1
+- pygrib 1.9.1-1; depends (libpng ^= 1.2.40, numpy ^= 1.6.1, pyproj ^= 1.8.9)
+- pygrib 1.9.2-1; depends (libpng ^= 1.2.40, numpy ^= 1.6.1, pyproj ^= 1.8.9)
+- pygrib 1.9.2-2; depends (libpng ^= 1.2.40, numpy ^= 1.7.1, pyproj ^= 1.9.3)
+- pygrib 1.9.2-3; depends (libpng ^= 1.2.40, numpy ^= 1.8.0, pyproj ^= 1.9.3)
+- pygrib 1.9.9-1; depends (libpng ^= 1.6.12, numpy ^= 1.8.0, pyproj ^= 1.9.3)
+- pygrib 1.9.9-3; depends (libpng ^= 1.6.12, numpy ^= 1.8.1, pyproj ^= 1.9.3)
+- pygrib 1.9.9-4; depends (libpng ^= 1.6.12, numpy ^= 1.9.2, pyproj ^= 1.9.3)
+- pygrib 1.9.9-5; depends (libpng ^= 1.6.12, numpy ^= 1.9.2, pyproj ^= 1.9.4)
+- pygrib 1.9.9-6; depends (libpng ^= 1.6.12, numpy ^= 1.10.4, pyproj ^= 1.9.4)
+- pyhdf 0.8.3-6; depends (libjpeg ^= 7.0, numpy ^= 1.6.1)
+- pyhdf 0.8.3-8; depends (libjpeg ^= 7.0, numpy ^= 1.7.1)
+- pyhdf 0.8.3-11; depends (libjpeg ^= 7.0, numpy ^= 1.8.0)
+- pyhdf 0.8.3-12; depends (libjpeg ^= 7.0, numpy ^= 1.8.1)
+- pyke 1.1.1-1; depends (doctest_tools ^= 1.0a3, htmltemplate ^= 1.5.0)
+- pylint 0.23.0-1; depends (logilab_common, logilab_astng)
+- pylint 0.24.0-1; depends (logilab_common, logilab_astng)
+- pylint 0.25.0-1; depends (logilab_common, logilab_astng)
+- pylint 0.25.1-1; depends (logilab_common, logilab_astng)
+- pymc 2.1b0-1; depends (numpy ^= 1.5.1)
+- pymc 2.1b0-2; depends (numpy ^= 1.6.0)
+- pymc 2.1b0-3; depends (numpy)
+- pymc 2.2.0-2; depends (numpy ^= 1.7.1)
+- pymc 2.2.0-3; depends (numpy ^= 1.8.0)
+- pymc 2.3.2-1; depends (scipy ^= 0.14.0, numpy ^= 1.8.0)
+- pymc 2.3.2-3; depends (scipy ^= 0.14.0, numpy ^= 1.8.1)
+- pymc 2.3.3-1; depends (scipy ^= 0.14.0, numpy ^= 1.8.1)
+- pymc 2.3.3-2; depends (scipy ^= 0.14.0, numpy ^= 1.8.1)
+- pymc 2.3.3-3; depends (scipy ^= 0.14.1rc1, numpy ^= 1.8.1)
+- pymc 2.3.3-4; depends (scipy ^= 0.15.1, numpy ^= 1.8.1)
+- pymc 2.3.4-1; depends (scipy ^= 0.15.1, numpy ^= 1.8.1)
+- pymc 2.3.4-2; depends (scipy ^= 0.15.1, numpy ^= 1.8.1)
+- pymc 2.3.4-3; depends (scipy ^= 0.15.1, numpy ^= 1.9.2)
+- pymc 2.3.4-4; depends (scipy ^= 0.16.0, numpy ^= 1.9.2)
+- pymc 2.3.6-1; depends (scipy ^= 0.16.0, numpy ^= 1.9.2)
+- pymc 2.3.6-2; depends (scipy ^= 0.16.1, numpy ^= 1.9.2)
+- pymc 2.3.6-3; depends (scipy ^= 0.16.1, numpy ^= 1.9.2)
+- pymc 2.3.6-4; depends (mkl ^= 10.3, scipy ^= 0.16.1, numpy ^= 1.9.2)
+- pymc 2.3.6-5; depends (mkl ^= 10.3, scipy ^= 0.16.1, numpy ^= 1.9.2)
+- pymc 2.3.6-6; depends (mkl ^= 10.3, scipy ^= 0.17.0, numpy ^= 1.9.2)
+- pymc 2.3.6-7; depends (mkl ^= 11.1.4, scipy ^= 0.17.0, numpy ^= 1.9.2)
+- pymc 2.3.6-8; depends (mkl ^= 11.1.4, scipy ^= 0.17.0, numpy ^= 1.10.4)
+- pymongo 2.7.2-1
+- pymongo 2.8-1
+- pymysql 0.6.2-1
+- pymysql 0.6.3-1
+- pymysql 0.6.6-1
+- pymysql 0.6.7-1
+- pyodbc 2.1.8-1
+- pyodbc 3.0.6-1
+- pyodbc 3.0.7-1
+- pyodbc 3.0.7-2
+- pyodbc 3.0.10-1; depends (unixodbc ^= 2.3.2)
+- pyopengl 3.0.1-2
+- pyopengl 3.1.0-1
+- pyopenssl 0.11-2
+- pyopenssl 0.12-1
+- pyopenssl 0.13.1-1
+- pyopenssl 0.13.1-2
+- pyopenssl 0.14-1; depends (six ^= 1.8.0, cryptography ^= 0.6.1)
+- pyopenssl 0.14-2; depends (six ^= 1.9.0, cryptography ^= 0.6.1)
+- pyopenssl 0.14-3; depends (six ^= 1.9.0, cryptography ^= 0.8.1)
+- pyopenssl 0.14-4; depends (six ^= 1.9.0, cryptography ^= 0.8.2)
+- pyopenssl 0.15.1-1; depends (six ^= 1.9.0, cryptography ^= 0.8.2)
+- pyopenssl 0.15.1-2; depends (six ^= 1.9.0, cryptography ^= 0.9.1)
+- pyopenssl 0.15.1-3; depends (six ^= 1.9.0, cryptography ^= 0.9.3)
+- pyopenssl 0.15.1-4; depends (six ^= 1.10.0, cryptography ^= 0.9.3)
+- pyopenssl 0.15.1-5; depends (six ^= 1.10.0, cryptography ^= 1.1.1)
+- pyopenssl 0.15.1-6; depends (six ^= 1.10.0, cryptography ^= 1.2.1)
+- pyopenssl 0.15.1-7; depends (six ^= 1.10.0, cryptography ^= 1.2.3)
+- pyopenssl 0.15.1-8; depends (six ^= 1.10.0, cryptography ^= 1.3)
+- pyopenssl 16.0.0-1; depends (six ^= 1.10.0, cryptography ^= 1.3)
+- pyopenssl 16.0.0-2; depends (six ^= 1.10.0, cryptography ^= 1.3.1)
+- pyparsing 1.5.5-3
+- pyparsing 1.5.6-1
+- pyparsing 2.0.2-1
+- pyparsing 2.0.3-1
+- pyproj 1.8.8-2
+- pyproj 1.8.9-1
+- pyproj 1.9.0-1
+- pyproj 1.9.3-1
+- pyproj 1.9.4-1
+- pyqt 4.10.3-1; depends (sip ^= 4.15.3, qt ^= 4.8.5)
+- pyqt 4.11.0-1; depends (sip ^= 4.16.1)
+- pyqt 4.11.3-1; depends (sip ^= 4.16.7, qt ^= 4.8.6)
+- pyqt 4.11.4-1; depends (sip ^= 4.17, qt ^= 4.8.6)
+- pyqt 4.11.4-2; depends (sip ^= 4.17, qt ^= 4.8.6)
+- pyqt 4.11.4-3; depends (sip ^= 4.17, qt ^= 4.8.7)
+- pyqt 4.11.4-4; depends (sip ^= 4.17, qt ^= 4.8.7)
+- pysal 1.7.0-1; depends (scipy ^= 0.13.3, numpy ^= 1.8.0)
+- pysal 1.7.0-2; depends (scipy ^= 0.14.0, numpy ^= 1.8.0)
+- pysal 1.7.0-3; depends (scipy ^= 0.14.0, numpy ^= 1.8.1)
+- pysal 1.7.0-4; depends (scipy ^= 0.14.1rc1, numpy ^= 1.8.1)
+- pysal 1.7.0-5; depends (scipy ^= 0.15.1, numpy ^= 1.8.1)
+- pysal 1.7.0-6; depends (scipy ^= 0.15.1, numpy ^= 1.9.2)
+- pysal 1.7.0-7; depends (scipy ^= 0.16.0, numpy ^= 1.9.2)
+- pysal 1.7.0-8; depends (scipy ^= 0.16.1, numpy ^= 1.9.2)
+- pysal 1.7.0-9; depends (scipy ^= 0.17.0, numpy ^= 1.9.2)
+- pysal 1.7.0-10; depends (scipy ^= 0.17.0, numpy ^= 1.10.4)
+- pyserial 2.5-2
+- pyserial 2.6-1
+- pyserial 2.7-1
+- pyshp 1.2.0-1
+- pyside 1.0.0rc1-1; depends (qt ^= 4.7.1)
+- pyside 1.0.3-1; depends (qt ^= 4.7.3)
+- pyside 1.0.3-2; depends (qt ^= 4.7.3)
+- pyside 1.0.5-1; depends (qt ^= 4.7.3)
+- pyside 1.1.0-2; depends (qt ^= 4.7.3)
+- pyside 1.1.0-3; depends (qt ^= 4.7.3)
+- pyside 1.2.1-1; depends (qt ^= 4.8.5, shiboken ^= 1.2.1)
+- pyside 1.2.1-2; depends (qt ^= 4.8.5, shiboken ^= 1.2.1)
+- pyside 1.2.2-1; depends (qt ^= 4.8.5, shiboken ^= 1.2.2)
+- pyside 1.2.2-2; depends (qt ^= 4.8.6, shiboken ^= 1.2.2)
+- pyside 1.2.2-4; depends (qt ^= 4.8.6, shiboken ^= 1.2.2)
+- pyside 1.2.2-5; depends (qt ^= 4.8.6, shiboken ^= 1.2.2)
+- pyside 1.2.2-6; depends (qt ^= 4.8.6, shiboken ^= 1.2.2)
+- pyside 1.2.2-7; depends (qt ^= 4.8.7, shiboken ^= 1.2.2)
+- pyside 1.2.2-8; depends (qt ^= 4.8.7, shiboken ^= 1.2.2)
+- pyside_debug 1.2.2-5; depends (pyside == 1.2.2-5)
+- pyside_debug 1.2.2-6; depends (pyside == 1.2.2-6)
+- pyside_debug 1.2.2-7; depends (pyside == 1.2.2-7)
+- pyside_debug 1.2.2-8; depends (pyside == 1.2.2-8)
+- pysparse 1.2.dev203-2; depends (mkl ^= 10.3, numpy ^= 1.5.1)
+- pysparse 1.2.dev213-1; depends (mkl ^= 10.3, numpy ^= 1.5.1)
+- pysparse 1.2.dev213-5; depends (mkl ^= 10.3, numpy)
+- pysparse 1.2.dev213-6; depends (mkl ^= 10.3, numpy)
+- pysparse 1.2.dev213-7; depends (mkl ^= 10.3, numpy)
+- pysparse 1.2.dev213-8; depends (mkl ^= 10.3, numpy)
+- pysparse 1.2.dev213-9; depends (mkl ^= 10.3, numpy ^= 1.9.2)
+- pysparse 1.2.dev213-10; depends (mkl ^= 11.1.4, numpy ^= 1.9.2)
+- pysparse 1.2.dev213-11; depends (mkl ^= 11.1.4, numpy ^= 1.10.4)
+- pystache 0.5.4-1
+- pytables 2.2.1-1; depends (numexpr ^= 1.4.2, numpy ^= 1.5.1, hdf5 ^= 1.8.5.1)
+- pytables 2.2.1-2; depends (numexpr ^= 1.4.2, numpy ^= 1.6.0, hdf5 ^= 1.8.5.1)
+- pytables 2.3b1.dev4669-1; depends (numexpr ^= 1.4.2, numpy ^= 1.6.0, hdf5 ^= 1.8.5.1)
+- pytables 2.3b1.dev4669-2; depends (numexpr ^= 1.4.2, numpy ^= 1.6.1, hdf5 ^= 1.8.5.1)
+- pytables 2.3-1; depends (numexpr ^= 1.4.2, numpy ^= 1.6.1, hdf5 ^= 1.8.5.1)
+- pytables 2.3.1-1; depends (numexpr ^= 1.4.2, numpy ^= 1.6.1, hdf5 ^= 1.8.5.1)
+- pytables 2.3.1-2; depends (numexpr ^= 2.0, numpy ^= 1.6.1, hdf5 ^= 1.8.5.1)
+- pytables 2.3.1-3; depends (numexpr ^= 2.0.1, numpy ^= 1.6.1, hdf5 ^= 1.8.5.1)
+- pytables 2.3.1-4; depends (numexpr ^= 2.0.1, numpy ^= 1.6.1, hdf5 ^= 1.8.9)
+- pytables 2.3.1-6; depends (numexpr ^= 2.0.1, numpy ^= 1.7.1, hdf5 ^= 1.8.9)
+- pytables 2.4.0-1; depends (numexpr ^= 2.0.1, numpy ^= 1.7.1, hdf5 ^= 1.8.9)
+- pytables 2.4.0-2; depends (numexpr ^= 2.0.1, numpy ^= 1.7.1, hdf5 ^= 1.8.9)
+- pytables 2.4.0-3; depends (numexpr ^= 2.0.1, numpy ^= 1.7.1, hdf5 ^= 1.8.11)
+- pytables 2.4.0-4; depends (numexpr ^= 2.2.2, numpy ^= 1.7.1, hdf5 ^= 1.8.11)
+- pytables 2.4.0-5; depends (numexpr ^= 2.2.2, numpy ^= 1.8.0, hdf5 ^= 1.8.11)
+- pytables 3.1.1-1; depends (numexpr ^= 2.4.0, numpy ^= 1.8.0, hdf5 ^= 1.8.11)
+- pytables 3.1.1-3; depends (numexpr ^= 2.4.0, numpy ^= 1.8.1, hdf5 ^= 1.8.11)
+- pytables 3.1.1-4; depends (numexpr ^= 2.4.0, numpy ^= 1.8.1, hdf5 ^= 1.8.11)
+- pytables 3.1.1-5; depends (numexpr ^= 2.4.0, numpy ^= 1.8.1, hdf5 ^= 1.8.14)
+- pytables 3.1.1-6; depends (numexpr ^= 2.4.0, numpy ^= 1.9.2, hdf5 ^= 1.8.14)
+- pytables 3.1.1-7; depends (numexpr ^= 2.4.0, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- pytables 3.2.0-1; depends (numexpr ^= 2.4.0, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- pytables 3.2.0-2; depends (numexpr ^= 2.4.0, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- pytables 3.2.2-2; depends (numexpr ^= 2.4.0, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- pytables 3.2.2-3; depends (numexpr ^= 2.5, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- pytables 3.2.2-4; depends (numexpr ^= 2.5, numpy ^= 1.9.2, hdf5 ^= 1.8.15.1)
+- pytables 3.2.2-5; depends (numexpr ^= 2.5, numpy ^= 1.9.2, hdf5 ^= 1.8.16)
+- pytables 3.2.2-6; depends (numexpr ^= 2.5.1, numpy ^= 1.9.2, hdf5 ^= 1.8.16)
+- pytables 3.2.2-7; depends (numexpr ^= 2.5.1, numpy ^= 1.10.4, hdf5 ^= 1.8.16)
+- pytables 3.2.2-8; depends (numexpr ^= 2.5.2, numpy ^= 1.10.4, hdf5 ^= 1.8.16)
+- pytables 3.2.2-9; depends (numexpr ^= 2.5.2, numpy ^= 1.10.4, hdf5 ^= 1.8.16)
+- pytest 2.3.5-1; depends (py)
+- pytest 2.4.2-1; depends (py ^= 1.4.18)
+- pytest 2.5.2-1; depends (py ^= 1.4.20)
+- pytest 2.6.2-2; depends (py ^= 1.4.24)
+- pytest 2.6.3-1; depends (py ^= 1.4.25)
+- pytest 2.6.3-2; depends (py ^= 1.4.25)
+- pytest 2.6.4-1; depends (py ^= 1.4.26)
+- pytest 2.8.2-1; depends (py ^= 1.4.30)
+- pytest 2.8.7-1; depends (py ^= 1.4.31)
+- pytest 2.9.1-1; depends (py ^= 1.4.31)
+- pytest_httpbin 0.2.0-1; depends (pytest ^= 2.8.2, httpbin ^= 0.4.0)
+- python_daemon 2.1.1-1; depends (docutils ^= 0.12, lockfile ^= 0.12.2)
+- python_dateutil 1.5-2
+- python_dateutil 2.2.0-1; depends (six ^= 1.3.0)
+- python_dateutil 2.2.0-2; depends (six ^= 1.4.1)
+- python_dateutil 2.2.0-3; depends (six ^= 1.7.2)
+- python_dateutil 2.2.0-4; depends (six ^= 1.7.3)
+- python_dateutil 2.2.0-5; depends (six ^= 1.8.0)
+- python_dateutil 2.2.0-7; depends (six ^= 1.9.0)
+- python_dateutil 2.4.2-1; depends (six ^= 1.9.0)
+- python_dateutil 2.4.2-2; depends (six ^= 1.10.0)
+- python_dateutil 2.5.1-1; depends (six ^= 1.10.0)
+- python_dateutil 2.5.2-1; depends (six ^= 1.10.0)
+- python_ntlm3 1.0.2-1; depends (six ^= 1.10.0)
+- python_pptx 0.5.7-1; depends (xlsxwriter ^= 0.7.2, lxml ^= 3.4.4, pillow ^= 2.8.1)
+- python_pptx 0.5.7-2; depends (xlsxwriter ^= 0.7.3, lxml ^= 3.4.4, pillow ^= 2.8.1)
+- python_pptx 0.5.7-3; depends (xlsxwriter ^= 0.7.3, lxml ^= 3.4.4, pillow ^= 2.9.0)
+- python_pptx 0.5.7-4; depends (xlsxwriter ^= 0.7.6, lxml ^= 3.4.4, pillow ^= 2.9.0)
+- python_pptx 0.5.7-5; depends (xlsxwriter ^= 0.7.6, lxml ^= 3.4.4, pillow ^= 3.0.0)
+- python_pptx 0.5.8-1; depends (xlsxwriter ^= 0.7.7, lxml ^= 3.4.4, pillow ^= 3.0.0)
+- python_pptx 0.5.8-2; depends (xlsxwriter ^= 0.7.7, lxml ^= 3.5.0, pillow ^= 3.0.0)
+- python_pptx 0.5.8-3; depends (xlsxwriter ^= 0.7.7, lxml ^= 3.5.0, pillow ^= 3.1.0)
+- python_pptx 0.5.8-4; depends (xlsxwriter ^= 0.8.4, lxml ^= 3.5.0, pillow ^= 3.1.0)
+- python_pptx 0.5.8-5; depends (xlsxwriter ^= 0.8.4, lxml ^= 3.6.0, pillow ^= 3.1.0)
+- python_termstyle 0.1.10-1
+- pythondoc 2.7.3-1; depends (appinst)
+- pytz 2010o-1
+- pytz 2011e-1
+- pytz 2011g-1
+- pytz 2011k-1
+- pytz 2011n-1
+- pytz 2013.8.0-1
+- pytz 2014.9.0-1
+- pytz 2015.7-1
+- pytz 2016.3-1
+- pyvisa 1.3-3
+- pyvisa 1.6.1-1; depends (enum34 ^= 1.0.3)
+- pyvisa 1.6.1-2; depends (enum34 ^= 1.0.4)
+- pyvisa 1.6.1-3; depends (enum34 ^= 1.1.1)
+- pyvisa 1.6.1-4; depends (enum34 ^= 1.1.2)
+- pyvisa 1.8-1; depends (enum34 ^= 1.1.2)
+- pywinrm 0.0.3-1; depends (xmltodict ^= 0.9.2, isodate ^= 0.5.1)
+- pywinrm 0.0.3-2; depends (xmltodict ^= 0.9.2, isodate ^= 0.5.1)
+- pywinrm 0.0.3-3; depends (xmltodict ^= 0.9.2, isodate ^= 0.5.1)
+- pyxb 1.2.4-1
+- pyyaml 3.9-2
+- pyyaml 3.10-1
+- pyyaml 3.11-1
+- pyzmq 2.0.10-2; depends (zeromq ^= 2.0.10)
+- pyzmq 2.0.10.1-1; depends (zeromq ^= 2.0.10)
+- pyzmq 2.0.10.1-2; depends (zeromq ^= 2.0.10)
+- pyzmq 2.1.1-1; depends (zeromq ^= 2.1.1)
+- pyzmq 2.1.4-1; depends (zeromq ^= 2.1.4)
+- pyzmq 2.1.7-1; depends (zeromq ^= 2.1.7)
+- pyzmq 2.1.9-1
+- pyzmq 2.1.10-1
+- pyzmq 2.1.11-1
+- pyzmq 2.2.0-1
+- pyzmq 2.2.0-2
+- pyzmq 2.2.0-3
+- pyzmq 2.2.0-4
+- pyzmq 14.1.1-1; depends (zeromq ^= 3.2.4)
+- pyzmq 14.3.1-1; depends (zeromq ^= 4.0.4)
+- pyzmq 14.4.1-1; depends (zeromq ^= 4.0.4)
+- pyzmq 14.5.0-1; depends (zeromq ^= 4.0.5)
+- pyzmq 14.6.0-1; depends (zeromq ^= 4.0.5)
+- pyzmq 14.7.0-1; depends (zeromq ^= 4.0.5)
+- pyzmq 14.7.0-2; depends (zeromq ^= 4.1.3)
+- pyzmq 14.7.0-3; depends (zeromq ^= 4.1.3)
+- pyzmq 15.1.0-1; depends (zeromq ^= 4.1.3)
+- pyzmq 15.2.0-1; depends (zeromq ^= 4.1.3)
+- pyzmq 15.2.0-2; depends (zeromq ^= 4.1.3)
+- qpython 1.0.0-1; depends (numpy ^= 1.9.2, pandas ^= 0.16.2, twisted ^= 15.2.1)
+- qpython 1.0.0-2; depends (numpy ^= 1.9.2, pandas ^= 0.16.2, twisted ^= 15.4.0)
+- qpython 1.0.0-3; depends (numpy ^= 1.9.2, pandas ^= 0.16.2, twisted ^= 15.4.0)
+- qpython 1.0.0-4; depends (numpy ^= 1.9.2, pandas ^= 0.17.1, twisted ^= 15.4.0)
+- qpython 1.0.0-5; depends (numpy ^= 1.9.2, pandas ^= 0.17.1, twisted ^= 15.4.0)
+- qpython 1.0.0-6; depends (numpy ^= 1.9.2, pandas ^= 0.17.1, twisted ^= 15.5.0)
+- qpython 1.0.0-7; depends (numpy ^= 1.9.2, pandas ^= 0.18.0, twisted ^= 15.5.0)
+- qpython 1.0.0-8; depends (numpy ^= 1.9.2, pandas ^= 0.18.0, twisted ^= 16.0.0)
+- qpython 1.0.0-9; depends (numpy ^= 1.10.4, pandas ^= 0.18.0, twisted ^= 16.0.0)
+- qpython 1.0.0-10; depends (numpy ^= 1.10.4, pandas ^= 0.18.0, twisted ^= 16.0.0)
+- qpython 1.0.0-11; depends (numpy ^= 1.10.4, pandas ^= 0.18.0, twisted ^= 16.1.1)
+- qt 4.7.1-1
+- qt 4.7.2-1
+- qt 4.7.3-1
+- qt 4.7.3-2
+- qt 4.8.5-6
+- qt 4.8.5-7
+- qt 4.8.5-9
+- qt 4.8.5-10
+- qt 4.8.6-1
+- qt 4.8.6-2
+- qt 4.8.6-3
+- qt 4.8.7-4
+- qt_binder 0.2-1
+- qt_debug 4.8.6-2; depends (qt == 4.8.6-2)
+- qt_debug 4.8.6-3; depends (qt == 4.8.6-3)
+- qt_debug 4.8.7-4; depends (qt == 4.8.7-4)
+- qtconsole 4.0.1-1; depends (jupyter_core ^= 4.0.4, pygments ^= 2.0.2, jupyter_client ^= 4.0.0, ipykernel ^= 4.0.3, traitlets ^= 4.0.0)
+- qtconsole 4.0.1-2; depends (jupyter_core ^= 4.0.6, pygments ^= 2.0.2, jupyter_client ^= 4.0.0, ipykernel ^= 4.0.3, traitlets ^= 4.0.0)
+- qtconsole 4.0.1-3; depends (jupyter_core ^= 4.0.6, pygments ^= 2.0.2, jupyter_client ^= 4.0.0, ipykernel ^= 4.1.0, traitlets ^= 4.0.0)
+- qtconsole 4.1.1-1; depends (jupyter_core ^= 4.0.6, pygments ^= 2.0.2, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.0, traitlets ^= 4.0.0)
+- qtconsole 4.1.1-2; depends (jupyter_core ^= 4.0.6, pygments ^= 2.0.2, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.0, traitlets ^= 4.0.0)
+- qtconsole 4.1.1-3; depends (jupyter_core ^= 4.0.6, pygments ^= 2.0.2, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.2, traitlets ^= 4.1.0)
+- qtconsole 4.1.1-4; depends (jupyter_core ^= 4.0.6, pygments ^= 2.1, jupyter_client ^= 4.1.1, ipykernel ^= 4.2.2, traitlets ^= 4.1.0)
+- qtconsole 4.2.0-1; depends (jupyter_core ^= 4.0.6, pygments ^= 2.1, jupyter_client ^= 4.2.1, ipykernel ^= 4.3.1, traitlets ^= 4.1.0)
+- qtconsole 4.2.0-2; depends (jupyter_core ^= 4.1.0, pygments ^= 2.1, jupyter_client ^= 4.2.1, ipykernel ^= 4.3.1, traitlets ^= 4.1.0)
+- qtconsole 4.2.0-4; depends (jupyter_core ^= 4.1.0, pygments ^= 2.1, jupyter_client ^= 4.2.2, ipykernel ^= 4.3.1, traitlets ^= 4.2.1)
+- qtconsole 4.2.1-1; depends (jupyter_core ^= 4.1.0, pygments ^= 2.1, jupyter_client ^= 4.2.2, ipykernel ^= 4.3.1, traitlets ^= 4.2.1)
+- qtconsole 4.2.1-2; depends (jupyter_core ^= 4.1.0, pygments ^= 2.1.3, jupyter_client ^= 4.2.2, ipykernel ^= 4.3.1, traitlets ^= 4.2.1)
+- quandl 2.8.5-1
+- quandl 2.8.7-1
+- quandl 2.8.9-1
+- queuelib 1.2.2-1
+- queuelib 1.4.2-1
+- readline_remove 1.0.0-1
+- redis 2.6.16-1
+- redis_py 2.8.0-1
+- redis_py 2.10.3-1
+- rednose 0.4.1-1; depends (nose ^= 1.3.4)
+- rednose 0.4.1-2; depends (python_termstyle ^= 0.1.10, nose ^= 1.3.4)
+- reportlab 2.5-2; depends (freetype ^= 2.4.4)
+- reportlab 3.1.8-1; depends (freetype ^= 2.4.4)
+- reportlab 3.1.44-1; depends (freetype ^= 2.5.3)
+- reportlab 3.1.44-2; depends (freetype ^= 2.5.3)
+- reportlab 3.2.0-1; depends (freetype ^= 2.5.3)
+- reportlab 3.2.0-2; depends (freetype ^= 2.5.3)
+- reportlab 3.2.0-3; depends (freetype ^= 2.5.3)
+- reportlab 3.2.0-4; depends (freetype ^= 2.5.3)
+- reportlab 3.3.0-1; depends (freetype ^= 2.5.3)
+- requests 1.2.3-1
+- requests 2.2.1-1
+- requests 2.3.0-1
+- requests 2.4.0-1
+- requests 2.4.1-1
+- requests 2.4.3-1
+- requests 2.5.0-1
+- requests 2.5.1-1
+- requests 2.5.1-2
+- requests 2.5.3-1
+- requests 2.6.0-1
+- requests 2.6.2-1
+- requests 2.7.0-1
+- requests 2.8.0-1
+- requests 2.8.0-2
+- requests 2.9.0-1
+- requests 2.9.1-1
+- requests_file 1.4-1; depends (requests ^= 2.8.0)
+- requests_file 1.4-2; depends (requests ^= 2.9.0)
+- requests_file 1.4-3; depends (requests ^= 2.9.1)
+- requests_ntlm 0.2.0-1; depends (requests ^= 2.8.0, python_ntlm3 ^= 1.0.2)
+- requests_ntlm 0.2.0-2; depends (requests ^= 2.9.0, python_ntlm3 ^= 1.0.2)
+- requests_ntlm 0.2.0-3; depends (requests ^= 2.9.1, python_ntlm3 ^= 1.0.2)
+- responses 0.3.0-1; depends (requests ^= 2.5.0)
+- responses 0.3.0-2; depends (requests ^= 2.5.1)
+- responses 0.3.0-3; depends (requests ^= 2.5.3)
+- responses 0.3.0-4; depends (requests ^= 2.6.0)
+- responses 0.3.0-5; depends (requests ^= 2.6.2)
+- responses 0.3.0-6; depends (requests ^= 2.7.0)
+- responses 0.3.0-7; depends (requests ^= 2.8.0)
+- responses 0.3.0-8; depends (requests ^= 2.9.0)
+- responses 0.3.0-9; depends (requests ^= 2.9.1)
+- rsa 3.1.2-2; depends (pyasn1 ^= 0.1.7)
+- rsa 3.1.2-3; depends (pyasn1 ^= 0.1.9)
+- runipy 0.1.3-1; depends (ipython ^= 2.3.1, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.5.0)
+- runipy 0.1.3-2; depends (ipython ^= 2.4.1, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.5.0)
+- runipy 0.1.3-3; depends (ipython ^= 3.1.0, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.5.0)
+- runipy 0.1.3-4; depends (ipython ^= 3.1.0, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.6.0)
+- runipy 0.1.3-5; depends (ipython ^= 3.2.0, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.7.0)
+- runipy 0.1.3-6; depends (ipython ^= 3.2.1, pygments ^= 2.0.2, jinja2 ^= 2.7.3, pyzmq ^= 14.7.0)
+- sas7bdat 2.0.4-1; depends (six ^= 1.9.0)
+- sas7bdat 2.0.4-2; depends (six ^= 1.10.0)
+- sas7bdat 2.0.7-1; depends (six ^= 1.10.0)
+- scandir 1.1-1
+- scientificpython 2.9.0-6; depends (lib_netcdf4 ^= 4.3.0, numpy ^= 1.7.1)
+- scientificpython 2.9.0-8; depends (lib_netcdf4 ^= 4.3.0, numpy ^= 1.8.0)
+- scientificpython 2.9.0-10; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.8.1)
+- scientificpython 2.9.0-11; depends (lib_netcdf4 ^= 4.3.2, numpy ^= 1.8.1)
+- scikit_learn 0.9-1; depends (mkl ^= 10.3, scipy, numpy ^= 1.6.1)
+- scikit_learn 0.10-1; depends (mkl ^= 10.3, scipy, numpy ^= 1.6.1)
+- scikit_learn 0.11-1; depends (mkl ^= 10.3, scipy, numpy ^= 1.6.1)
+- scikit_learn 0.13.1-1; depends (mkl ^= 10.3, scipy, numpy ^= 1.6.1)
+- scikit_learn 0.13.1-3; depends (mkl ^= 10.3, scipy, numpy ^= 1.6.1)
+- scikit_learn 0.13.1-4; depends (mkl ^= 10.3, scipy, numpy ^= 1.7.1)
+- scikit_learn 0.14.1-1; depends (mkl ^= 10.3, scipy, numpy ^= 1.7.1)
+- scikit_learn 0.14.1-2; depends (mkl ^= 10.3, scipy ^= 0.13.0, numpy ^= 1.7.1)
+- scikit_learn 0.14.1-3; depends (mkl ^= 10.3, scipy ^= 0.13.0, numpy ^= 1.8.0)
+- scikit_learn 0.14.1-4; depends (mkl ^= 10.3, scipy ^= 0.13.2, numpy ^= 1.8.0)
+- scikit_learn 0.14.1-5; depends (mkl ^= 10.3, scipy ^= 0.13.3, numpy ^= 1.8.0)
+- scikit_learn 0.14.1-6; depends (mkl ^= 10.3, scipy ^= 0.14.0, numpy ^= 1.8.0)
+- scikit_learn 0.15.0-1; depends (mkl ^= 10.3, scipy ^= 0.14.0, numpy ^= 1.8.0)
+- scikit_learn 0.15.0-2; depends (mkl ^= 10.3, scipy ^= 0.14.0, numpy ^= 1.8.1)
+- scikit_learn 0.15.1-1; depends (mkl ^= 10.3, scipy ^= 0.14.0, numpy ^= 1.8.1)
+- scikit_learn 0.15.2-1; depends (mkl ^= 10.3, scipy ^= 0.14.0, numpy ^= 1.8.1)
+- scikit_learn 0.15.2-2; depends (mkl ^= 10.3, scipy ^= 0.14.1rc1, numpy ^= 1.8.1)
+- scikit_learn 0.15.2-3; depends (mkl ^= 10.3, scipy ^= 0.15.1, numpy ^= 1.8.1)
+- scikit_learn 0.16.0-1; depends (mkl ^= 10.3, scipy ^= 0.15.1, numpy ^= 1.8.1)
+- scikit_learn 0.16.1-1; depends (mkl ^= 10.3, scipy ^= 0.15.1, numpy ^= 1.8.1)
+- scikit_learn 0.16.1-2; depends (mkl ^= 10.3, scipy ^= 0.15.1, numpy ^= 1.9.2)
+- scikit_learn 0.16.1-3; depends (mkl ^= 10.3, scipy ^= 0.16.0, numpy ^= 1.9.2)
+- scikit_learn 0.17-1; depends (mkl ^= 10.3, scipy ^= 0.16.1, numpy ^= 1.9.2)
+- scikit_learn 0.17-2; depends (mkl ^= 10.3, scipy ^= 0.17.0, numpy ^= 1.9.2)
+- scikit_learn 0.17-3; depends (mkl ^= 11.1.4, scipy ^= 0.17.0, numpy ^= 1.9.2)
+- scikit_learn 0.17-4; depends (mkl ^= 11.1.4, scipy ^= 0.17.0, numpy ^= 1.10.4)
+- scikits.image 0.2.2-2; depends (numpy ^= 1.5.1, pil)
+- scikits.image 0.2.2-3; depends (numpy ^= 1.6.0, pil)
+- scikits.image 0.2.2-4; depends (numpy, pil)
+- scikits.image 0.3.1-1; depends (numpy, pil)
+- scikits.image 0.4.2-1; depends (numpy, pil)
+- scikits.image 0.5.0-1; depends (numpy, pil)
+- scikits.image 0.8.2-1; depends (numpy ^= 1.6.1, scipy ^= 0.12.0, pil)
+- scikits.image 0.8.2-2; depends (numpy ^= 1.7.1, scipy ^= 0.12.0, pil)
+- scikits.image 0.8.2-3; depends (numpy ^= 1.7.1, scipy ^= 0.12.0, pil)
+- scikits.image 0.8.2-4; depends (numpy ^= 1.7.1, scipy ^= 0.13.0, pil)
+- scikits.image 0.9.3-1; depends (numpy ^= 1.8.0, scipy ^= 0.13.0, pil)
+- scikits.image 0.9.3-3; depends (numpy ^= 1.8.0, scipy ^= 0.13.2, pil)
+- scikits.image 0.9.3-4; depends (numpy ^= 1.8.0, scipy ^= 0.13.3, pil)
+- scikits.image 0.9.3-5; depends (numpy ^= 1.8.0, scipy ^= 0.14.0, pil)
+- scikits.image 0.10.0-1; depends (numpy ^= 1.8.0, scipy ^= 0.14.0, pil)
+- scikits.image 0.10.0-3; depends (numpy ^= 1.8.1, scipy ^= 0.14.0, pil)
+- scikits.image 0.10.1-1; depends (numpy ^= 1.8.1, scipy ^= 0.14.0, pil)
+- scikits.image 0.10.1-2; depends (numpy ^= 1.8.1, scipy ^= 0.14.0, pil)
+- scikits.image 0.10.1-3; depends (numpy ^= 1.8.1, scipy ^= 0.14.0, pil)
+- scikits.image 0.10.1-4; depends (numpy ^= 1.8.1, scipy ^= 0.14.1rc1, pil)
+- scikits.image 0.10.1-5; depends (numpy ^= 1.8.1, scipy ^= 0.15.1, pil)
+- scikits.image 0.10.1-6; depends (numpy ^= 1.8.1, scipy ^= 0.15.1, pil)
+- scikits.image 0.11.2-1; depends (numpy ^= 1.8.1, scipy ^= 0.15.1, pil, networkx ^= 1.9.1)
+- scikits.image 0.11.3-1; depends (numpy ^= 1.8.1, scipy ^= 0.15.1, pil, networkx ^= 1.9.1)
+- scikits.image 0.11.3-2; depends (numpy ^= 1.9.2, scipy ^= 0.15.1, pil, networkx ^= 1.9.1)
+- scikits.image 0.11.3-3; depends (scipy ^= 0.15.1, numpy ^= 1.9.2, pillow ^= 2.8.1, networkx ^= 1.9.1)
+- scikits.image 0.11.3-4; depends (scipy ^= 0.15.1, numpy ^= 1.9.2, pillow ^= 2.9.0, networkx ^= 1.9.1)
+- scikits.image 0.11.3-5; depends (scipy ^= 0.15.1, numpy ^= 1.9.2, pillow ^= 2.9.0, networkx ^= 1.10)
+- scikits.image 0.11.3-6; depends (scipy ^= 0.16.0, numpy ^= 1.9.2, pillow ^= 2.9.0, networkx ^= 1.10)
+- scikits.image 0.11.3-7; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pillow ^= 2.9.0, networkx ^= 1.10)
+- scikits.image 0.11.3-8; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pillow ^= 2.9.0, networkx ^= 1.10)
+- scikits.image 0.11.3-9; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pillow ^= 2.9.0, networkx ^= 1.10)
+- scikits.image 0.11.3-10; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pillow ^= 3.0.0, networkx ^= 1.10)
+- scikits.image 0.11.3-11; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pillow ^= 3.0.0, networkx ^= 1.10)
+- scikits.image 0.11.3-12; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pillow ^= 3.1.0, networkx ^= 1.10)
+- scikits.image 0.11.3-13; depends (scipy ^= 0.17.0, numpy ^= 1.9.2, pillow ^= 3.1.0, networkx ^= 1.10)
+- scikits.image 0.11.3-14; depends (scipy ^= 0.17.0, numpy ^= 1.9.2, pillow ^= 3.1.0, networkx ^= 1.11)
+- scikits.image 0.12.3-1; depends (scipy ^= 0.17.0, numpy ^= 1.9.2, pillow ^= 3.1.0, networkx ^= 1.11)
+- scikits.image 0.12.3-2; depends (scipy ^= 0.17.0, numpy ^= 1.9.2, pillow ^= 3.1.0, networkx ^= 1.11)
+- scikits.image 0.12.3-3; depends (scipy ^= 0.17.0, numpy ^= 1.10.4, pillow ^= 3.1.0, networkx ^= 1.11)
+- scikits.image 0.12.3-4; depends (scipy ^= 0.17.0, numpy ^= 1.10.4, pillow ^= 3.1.0, networkx ^= 1.11)
+- scikits.learn 0.6-1; depends (numpy ^= 1.5.1)
+- scikits.learn 0.7.1-1; depends (mkl ^= 10.3, numpy ^= 1.5.1)
+- scikits.learn 0.7.1-2; depends (mkl ^= 10.3, scipy, numpy ^= 1.6.0)
+- scikits.learn 0.8-1; depends (mkl ^= 10.3, scipy, numpy ^= 1.6.0)
+- scikits.learn 0.8-2; depends (mkl ^= 10.3, scipy, numpy ^= 1.6.1)
+- scikits.rsformats 0.1-9; depends (numpy ^= 1.7.1, pyparsing, pyhdf ^= 0.8.3)
+- scikits.rsformats 0.1-10; depends (numpy ^= 1.8.0, pyparsing, pyhdf ^= 0.8.3)
+- scikits.rsformats 0.1-11; depends (numpy ^= 1.8.0, pyparsing ^= 2.0.2, pyhdf ^= 0.8.3)
+- scikits.rsformats 0.1-12; depends (numpy ^= 1.8.1, pyparsing ^= 2.0.2, pyhdf ^= 0.8.3)
+- scikits.rsformats 0.1-13; depends (numpy ^= 1.8.1, pyparsing ^= 2.0.3, pyhdf ^= 0.8.3)
+- scikits.statsmodels 0.2.0-2
+- scikits.statsmodels 0.3.0-1
+- scikits.statsmodels 0.3.1-1
+- scikits.timeseries 0.91.3-2; depends (numpy ^= 1.5.1)
+- scikits.timeseries 0.91.3-3; depends (numpy ^= 1.6.0)
+- scikits.timeseries 0.91.3-4; depends (numpy ^= 1.6.1)
+- scikits.timeseries 0.91.3-5; depends (numpy ^= 1.7.1)
+- scikits.timeseries 0.91.3-6; depends (numpy ^= 1.8.0)
+- scikits.timeseries 0.91.3-7; depends (numpy ^= 1.8.1)
+- scikits.timeseries 0.91.3-8; depends (numpy ^= 1.9.2)
+- scikits.timeseries 0.91.3-9; depends (numpy ^= 1.10.4)
+- scimath 4.0.0-1; depends (numpy ^= 1.6.0)
+- scimath 4.0.0-2; depends (numpy ^= 1.6.1)
+- scimath 4.0.1-1; depends (numpy ^= 1.6.1)
+- scimath 4.1.0-1; depends (numpy ^= 1.6.1)
+- scimath 4.1.2-1; depends (numpy ^= 1.6.1)
+- scimath 4.1.2-2; depends (numpy ^= 1.7.1)
+- scimath 4.1.2-3; depends (numpy ^= 1.8.0)
+- scimath 4.1.2-4; depends (numpy ^= 1.8.1)
+- scimath 4.1.2-5; depends (numpy ^= 1.9.2)
+- scimath 4.1.2-6; depends (traits ^= 4.5.0, scipy ^= 0.16.0, numpy ^= 1.9.2)
+- scimath 4.1.2-7; depends (traits ^= 4.5.0, scipy ^= 0.16.1, numpy ^= 1.9.2)
+- scimath 4.1.2-8; depends (traits ^= 4.5.0, scipy ^= 0.17.0, numpy ^= 1.9.2)
+- scimath 4.1.2-9; depends (traits ^= 4.5.0, scipy ^= 0.17.0, numpy ^= 1.10.4)
+- scipy 0.9.0rc2-1; depends (numpy ^= 1.5.1)
+- scipy 0.9.0-1; depends (numpy ^= 1.5.1)
+- scipy 0.9.0-2; depends (numpy ^= 1.6.0)
+- scipy 0.9.0-3; depends (numpy ^= 1.6.1)
+- scipy 0.10.0-1; depends (numpy ^= 1.6.1)
+- scipy 0.10.1-1; depends (numpy ^= 1.6.1)
+- scipy 0.10.1-4; depends (numpy ^= 1.6.1)
+- scipy 0.10.1-5; depends (numpy ^= 1.6.1)
+- scipy 0.11.0-1; depends (numpy ^= 1.6.1)
+- scipy 0.12.0-1; depends (numpy ^= 1.6.1)
+- scipy 0.12.0-2; depends (numpy ^= 1.7.1)
+- scipy 0.13.0-1; depends (numpy ^= 1.7.1)
+- scipy 0.13.0-2; depends (numpy ^= 1.8.0)
+- scipy 0.13.2-1; depends (numpy ^= 1.8.0)
+- scipy 0.13.3-1; depends (numpy ^= 1.8.0)
+- scipy 0.14.0-1; depends (numpy ^= 1.8.0)
+- scipy 0.14.0-2; depends (numpy ^= 1.8.0)
+- scipy 0.14.0-3; depends (numpy ^= 1.8.1)
+- scipy 0.14.1rc1-1; depends (mkl ^= 10.3, numpy ^= 1.8.1)
+- scipy 0.15.1-1; depends (mkl ^= 10.3, numpy ^= 1.8.1)
+- scipy 0.15.1-2; depends (mkl ^= 10.3, numpy ^= 1.9.2)
+- scipy 0.16.0-1; depends (mkl ^= 10.3, numpy ^= 1.9.2)
+- scipy 0.16.1-1; depends (mkl ^= 10.3, numpy ^= 1.9.2)
+- scipy 0.17.0-1; depends (mkl ^= 10.3, numpy ^= 1.9.2)
+- scipy 0.17.0-2; depends (mkl ^= 11.1.4, numpy ^= 1.9.2)
+- scipy 0.17.0-3; depends (mkl ^= 11.1.4, numpy ^= 1.10.4)
+- scons 2.0.1-2
+- scons 2.3.3-1
+- scrapy 0.24.4-2; depends (lxml ^= 3.4.0, pyopenssl ^= 0.14, six ^= 1.8.0, cffi ^= 0.8.6, twisted ^= 14.0.2, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-3; depends (lxml ^= 3.4.1, pyopenssl ^= 0.14, six ^= 1.8.0, cffi ^= 0.8.6, twisted ^= 14.0.2, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-4; depends (lxml ^= 3.4.1, pyopenssl ^= 0.14, six ^= 1.9.0, cffi ^= 0.8.6, twisted ^= 14.0.2, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-5; depends (lxml ^= 3.4.2, pyopenssl ^= 0.14, six ^= 1.9.0, cffi ^= 0.8.6, twisted ^= 15.0.0, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-6; depends (lxml ^= 3.4.2, pyopenssl ^= 0.14, six ^= 1.9.0, cffi ^= 0.9.2, twisted ^= 15.0.0, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-7; depends (lxml ^= 3.4.2, pyopenssl ^= 0.14, six ^= 1.9.0, cffi ^= 0.9.2, twisted ^= 15.1.0, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-8; depends (lxml ^= 3.4.3, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 0.9.2, twisted ^= 15.1.0, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-9; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 0.9.2, twisted ^= 15.1.0, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-10; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 0.9.2, twisted ^= 15.2.1, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-11; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 1.0.3, twisted ^= 15.2.1, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 0.24.4-12; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 1.1.2, twisted ^= 15.2.1, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 1.0.3-1; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 1.1.2, twisted ^= 15.4.0, w3lib ^= 1.10.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 1.0.3-2; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 1.1.2, twisted ^= 15.4.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.2.2)
+- scrapy 1.0.3-3; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 1.1.2, twisted ^= 15.4.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-4; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.9.0, cffi ^= 1.2.1, twisted ^= 15.4.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-5; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.10.0, cffi ^= 1.2.1, twisted ^= 15.4.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-6; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.10.0, cffi ^= 1.3.1, twisted ^= 15.4.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-7; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.10.0, cffi ^= 1.3.1, twisted ^= 15.5.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-8; depends (lxml ^= 3.4.4, pyopenssl ^= 0.15.1, six ^= 1.10.0, cffi ^= 1.4.2, twisted ^= 15.5.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-9; depends (lxml ^= 3.5.0, pyopenssl ^= 0.15.1, six ^= 1.10.0, cffi ^= 1.4.2, twisted ^= 15.5.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-10; depends (lxml ^= 3.5.0, pyopenssl ^= 0.15.1, six ^= 1.10.0, cffi ^= 1.5.2, twisted ^= 15.5.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-11; depends (lxml ^= 3.5.0, pyopenssl ^= 16.0.0, six ^= 1.10.0, cffi ^= 1.5.2, twisted ^= 15.5.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-12; depends (lxml ^= 3.5.0, pyopenssl ^= 16.0.0, six ^= 1.10.0, cffi ^= 1.5.2, twisted ^= 16.0.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-13; depends (lxml ^= 3.6.0, pyopenssl ^= 16.0.0, six ^= 1.10.0, cffi ^= 1.5.2, twisted ^= 16.0.0, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scrapy 1.0.3-14; depends (lxml ^= 3.6.0, pyopenssl ^= 16.0.0, six ^= 1.10.0, cffi ^= 1.5.2, twisted ^= 16.1.1, w3lib ^= 1.12.0, cssselect ^= 0.9.1, queuelib ^= 1.4.2)
+- scs 1.2.1-1; depends (scipy ^= 0.16.1, numpy ^= 1.9.2)
+- scs 1.2.1-2; depends (scipy ^= 0.17.0, numpy ^= 1.9.2)
+- scs 1.2.1-4; depends (scipy ^= 0.17.0, numpy ^= 1.10.4)
+- seaborn 0.4.0-1; depends (scipy ^= 0.14.0, numpy ^= 1.8.1, pandas ^= 0.15.0, matplotlib ^= 1.4.2)
+- seaborn 0.5.0-1; depends (scipy ^= 0.14.0, numpy ^= 1.8.1, pandas ^= 0.15.0, matplotlib ^= 1.4.2)
+- seaborn 0.5.0-3; depends (scipy ^= 0.14.0, numpy ^= 1.8.1, pandas ^= 0.15.2, matplotlib ^= 1.4.2)
+- seaborn 0.5.1-1; depends (scipy ^= 0.14.0, numpy ^= 1.8.1, pandas ^= 0.15.2, matplotlib ^= 1.4.2)
+- seaborn 0.5.1-2; depends (scipy ^= 0.14.1rc1, numpy ^= 1.8.1, pandas ^= 0.15.2, matplotlib ^= 1.4.2)
+- seaborn 0.5.1-3; depends (scipy ^= 0.15.1, numpy ^= 1.8.1, pandas ^= 0.15.2, matplotlib ^= 1.4.2)
+- seaborn 0.5.1-4; depends (scipy ^= 0.15.1, numpy ^= 1.8.1, pandas ^= 0.15.2, matplotlib ^= 1.4.3)
+- seaborn 0.5.1-5; depends (scipy ^= 0.15.1, numpy ^= 1.8.1, pandas ^= 0.16.0, matplotlib ^= 1.4.3)
+- seaborn 0.5.1-7; depends (scipy ^= 0.15.1, numpy ^= 1.9.2, pandas ^= 0.16.0, matplotlib ^= 1.4.3)
+- seaborn 0.5.1-8; depends (scipy ^= 0.15.1, numpy ^= 1.9.2, pandas ^= 0.16.1, matplotlib ^= 1.4.3)
+- seaborn 0.5.1-9; depends (scipy ^= 0.15.1, numpy ^= 1.9.2, pandas ^= 0.16.2, matplotlib ^= 1.4.3)
+- seaborn 0.6.0-1; depends (scipy ^= 0.15.1, numpy ^= 1.9.2, pandas ^= 0.16.2, matplotlib ^= 1.4.3)
+- seaborn 0.6.0-2; depends (scipy ^= 0.16.0, numpy ^= 1.9.2, pandas ^= 0.16.2, matplotlib ^= 1.4.3)
+- seaborn 0.6.0-4; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pandas ^= 0.17.1, matplotlib ^= 1.4.3)
+- seaborn 0.6.0-5; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pandas ^= 0.17.1, matplotlib ^= 1.5.0)
+- seaborn 0.6.0-6; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pandas ^= 0.17.1, matplotlib ^= 1.5.1)
+- seaborn 0.7.0-1; depends (scipy ^= 0.16.1, numpy ^= 1.9.2, pandas ^= 0.17.1, matplotlib ^= 1.5.1)
+- seaborn 0.7.0-2; depends (scipy ^= 0.17.0, numpy ^= 1.9.2, pandas ^= 0.17.1, matplotlib ^= 1.5.1)
+- seaborn 0.7.0-3; depends (scipy ^= 0.17.0, numpy ^= 1.9.2, pandas ^= 0.18.0, matplotlib ^= 1.5.1)
+- seaborn 0.7.0-4; depends (scipy ^= 0.17.0, numpy ^= 1.10.4, pandas ^= 0.18.0, matplotlib ^= 1.5.1)
+- selenium 2.48.0-1
+- setuptools 14.3.1-1; depends (_distribute_remove ^= 1.0.0)
+- setuptools 14.3.1-2; depends (distribute_remove ^= 1.0.0)
+- setuptools 15.1-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 15.2-2; depends (distribute_remove ^= 1.0.0)
+- setuptools 16.0-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 17.1.1-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 18.2-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 18.4-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 18.7.1-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 19.1.1-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 19.4-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 20.1.1-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 20.2.2-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 20.3.1-1; depends (distribute_remove ^= 1.0.0)
+- setuptools 20.6.7-1; depends (distribute_remove ^= 1.0.0)
+- sfepy 2010.2-4; depends (pyparsing ^= 2.0.2)
+- sfepy 2014.4-1; depends (pytables ^= 3.1.1, mayavi ^= 4.3.1, matplotlib ^= 1.4.2, scipy ^= 0.14.1rc1, sympy ^= 0.7.6, pyparsing ^= 2.0.2, numpy ^= 1.8.1)
+- sfepy 2014.4-2; depends (pytables ^= 3.1.1, mayavi ^= 4.3.1, matplotlib ^= 1.4.2, scipy ^= 0.15.1, sympy ^= 0.7.6, pyparsing ^= 2.0.2, numpy ^= 1.8.1)
+- sfepy 2014.4-3; depends (pytables ^= 3.1.1, mayavi ^= 4.3.1, matplotlib ^= 1.4.3, scipy ^= 0.15.1, sympy ^= 0.7.6, pyparsing ^= 2.0.2, numpy ^= 1.8.1)
+- sfepy 2014.4-4; depends (pytables ^= 3.1.1, mayavi ^= 4.3.1, matplotlib ^= 1.4.3, scipy ^= 0.15.1, sympy ^= 0.7.6, pyparsing ^= 2.0.3, numpy ^= 1.8.1)
+- sfepy 2014.4-5; depends (pytables ^= 3.1.1, mayavi ^= 4.4.0, matplotlib ^= 1.4.3, scipy ^= 0.15.1, sympy ^= 0.7.6, pyparsing ^= 2.0.3, numpy ^= 1.8.1)
+- sfepy 2014.4-6; depends (pytables ^= 3.1.1, mayavi ^= 4.4.0, matplotlib ^= 1.4.3, scipy ^= 0.15.1, sympy ^= 0.7.6, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-7; depends (pytables ^= 3.1.1, mayavi ^= 4.4.2, matplotlib ^= 1.4.3, scipy ^= 0.15.1, sympy ^= 0.7.6, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-8; depends (pytables ^= 3.2.0, mayavi ^= 4.4.2, matplotlib ^= 1.4.3, scipy ^= 0.15.1, sympy ^= 0.7.6, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-9; depends (pytables ^= 3.2.0, mayavi ^= 4.4.2, matplotlib ^= 1.4.3, scipy ^= 0.15.1, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-10; depends (pytables ^= 3.2.0, mayavi ^= 4.4.3, matplotlib ^= 1.4.3, scipy ^= 0.15.1, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-11; depends (pytables ^= 3.2.0, mayavi ^= 4.4.3, matplotlib ^= 1.4.3, scipy ^= 0.16.0, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-12; depends (pytables ^= 3.2.0, mayavi ^= 4.4.3, matplotlib ^= 1.4.3, scipy ^= 0.16.1, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-13; depends (pytables ^= 3.2.0, mayavi ^= 4.4.3, matplotlib ^= 1.5.0, scipy ^= 0.16.1, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-14; depends (pytables ^= 3.2.0, mayavi ^= 4.4.3, matplotlib ^= 1.5.0, scipy ^= 0.16.1, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-15; depends (pytables ^= 3.2.2, mayavi ^= 4.4.3, matplotlib ^= 1.5.0, scipy ^= 0.16.1, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-16; depends (pytables ^= 3.2.2, mayavi ^= 4.4.3, matplotlib ^= 1.5.1, scipy ^= 0.16.1, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-17; depends (pytables ^= 3.2.2, mayavi ^= 4.4.3, matplotlib ^= 1.5.1, scipy ^= 0.17.0, sympy ^= 0.7.6.1, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-18; depends (pytables ^= 3.2.2, mayavi ^= 4.4.3, matplotlib ^= 1.5.1, scipy ^= 0.17.0, sympy ^= 1.0, pyparsing ^= 2.0.3, numpy ^= 1.9.2)
+- sfepy 2014.4-20; depends (pytables ^= 3.2.2, mayavi ^= 4.4.3, matplotlib ^= 1.5.1, scipy ^= 0.17.0, sympy ^= 1.0, pyparsing ^= 2.0.3, numpy ^= 1.10.4)
+- sfepy 2014.4-21; depends (pytables ^= 3.2.2, mayavi ^= 4.4.3, matplotlib ^= 1.5.1, scipy ^= 0.17.0, sympy ^= 1.0, pyparsing ^= 2.0.3, numpy ^= 1.10.4)
+- shapely 1.2.14-1; depends (basemap ^= 1.0.2)
+- shapely 1.2.17-1; depends (basemap ^= 1.0.6)
+- shapely 1.2.17-2; depends (basemap ^= 1.0.7)
+- shapely 1.3.2-1; depends (basemap ^= 1.0.7)
+- shapely 1.4.1-1; depends (geos ^= 3.4.2)
+- shapely 1.5.1-1; depends (geos ^= 3.4.2)
+- shapely 1.5.13-1; depends (geos ^= 3.5.0, numpy ^= 1.9.2)
+- shapely 1.5.13-2; depends (geos ^= 3.5.0, numpy ^= 1.9.2)
+- shapely 1.5.13-3; depends (geos ^= 3.5.0, numpy ^= 1.10.4)
+- shapely 1.5.13-4; depends (geos ^= 3.5.0, numpy ^= 1.10.4)
+- shiboken 1.2.1-2; depends (qt ^= 4.8.5)
+- shiboken 1.2.1-3; depends (qt ^= 4.8.5)
+- shiboken 1.2.2-1; depends (qt ^= 4.8.5)
+- shiboken 1.2.2-2; depends (qt ^= 4.8.5)
+- shiboken 1.2.2-3; depends (qt ^= 4.8.6)
+- shiboken 1.2.2-5; depends (qt ^= 4.8.6)
+- shiboken 1.2.2-6; depends (qt ^= 4.8.6)
+- shiboken 1.2.2-7; depends (qt ^= 4.8.7)
+- shiboken 1.2.2-9; depends (qt ^= 4.8.7)
+- shiboken_debug 1.2.2-5; depends (shiboken == 1.2.2-5)
+- shiboken_debug 1.2.2-6; depends (shiboken == 1.2.2-6)
+- shiboken_debug 1.2.2-7; depends (shiboken == 1.2.2-7)
+- shiboken_debug 1.2.2-9; depends (shiboken == 1.2.2-9)
+- simplegeneric 0.8.1-1
+- simpy 2.1.0-2; depends (numpy)
+- simpy 2.2-1; depends (numpy)
+- simpy 2.2-2; depends (numpy)
+- simpy 2.2-3; depends (numpy)
+- simpy 3.0.2-1
+- simpy 3.0.5-1
+- simpy 3.0.5-2
+- singledispatch 3.4.0.3-1
+- sip 4.15.3-1
+- sip 4.16.1-1
+- sip 4.16.7-1
+- sip 4.17-1
+- sip 4.17-2
+- six 1.3.0-1
+- six 1.4.1-1
+- six 1.7.2-1
+- six 1.7.3-1
+- six 1.8.0-1
+- six 1.8.0-2
+- six 1.9.0-1
+- six 1.9.0-3
+- six 1.10.0-1
+- smart_open 1.2.1-1; depends (bz2file ^= 0.98, boto ^= 2.38.0)
+- smart_open 1.2.1-2; depends (bz2file ^= 0.98, boto ^= 2.38.0)
+- smart_open 1.2.1-3; depends (bz2file ^= 0.98, boto ^= 2.39.0)
+- smart_open 1.3.2-1; depends (bz2file ^= 0.98, boto ^= 2.39.0)
+- smmap 0.9.0-1
+- snowballstemmer 1.2.0-1
+- snowballstemmer 1.2.1-1
+- speaklater 1.3-1
+- speaklater 1.3-2
+- sphinx 1.0.5-1; depends (docutils ^= 0.7, jinja2 ^= 2.5.5)
+- sphinx 1.0.7-1; depends (docutils ^= 0.7, jinja2 ^= 2.5.5)
+- sphinx 1.1-1; depends (docutils ^= 0.8.1, jinja2 ^= 2.6)
+- sphinx 1.1.2-1; depends (docutils ^= 0.8.1, jinja2 ^= 2.6)
+- sphinx 1.1.2-3; depends (docutils ^= 0.11, jinja2 ^= 2.7.1)
+- sphinx 1.1.3-1; depends (docutils ^= 0.11, jinja2 ^= 2.7.1)
+- sphinx 1.2.2-1; depends (docutils ^= 0.11, jinja2 ^= 2.7.1)
+- sphinx 1.2.2-2; depends (docutils ^= 0.11, jinja2 ^= 2.7.3)
+- sphinx 1.2.2-3; depends (docutils ^= 0.12, jinja2 ^= 2.7.3)
+- sphinx 1.2.3-1; depends (docutils ^= 0.12, jinja2 ^= 2.7.3)
+- sphinx 1.3.1-1; depends (docutils ^= 0.12, jinja2 ^= 2.7.3)
+- sphinx 1.3.1-2; depends (snowballstemmer ^= 1.2.0, babel ^= 1.3, alabaster ^= 0.7.3, six ^= 1.9.0, docutils ^= 0.12, pygments ^= 2.0.2, jinja2 ^= 2.7.3)
+- sphinx 1.3.1-3; depends (sphinx_rtd_theme ^= 0.1.7, snowballstemmer ^= 1.2.0, babel ^= 1.3, alabaster ^= 0.7.3, six ^= 1.9.0, docutils ^= 0.12, pygments ^= 2.0.2, jinja2 ^= 2.7.3)
+- sphinx 1.3.1-4; depends (sphinx_rtd_theme ^= 0.1.7, snowballstemmer ^= 1.2.0, babel ^= 2.1.1, alabaster ^= 0.7.6, six ^= 1.9.0, docutils ^= 0.12, pygments ^= 2.0.2, jinja2 ^= 2.8)
+- sphinx 1.3.1-5; depends (sphinx_rtd_theme ^= 0.1.7, snowballstemmer ^= 1.2.0, babel ^= 2.1.1, alabaster ^= 0.7.6, six ^= 1.10.0, docutils ^= 0.12, pygments ^= 2.0.2, jinja2 ^= 2.8)
+- sphinx 1.3.5-1; depends (sphinx_rtd_theme ^= 0.1.9, snowballstemmer ^= 1.2.1, babel ^= 2.2.0, alabaster ^= 0.7.7, six ^= 1.10.0, docutils ^= 0.12, pygments ^= 2.1, jinja2 ^= 2.8)
+- sphinx 1.4.1-1; depends (sphinx_rtd_theme ^= 0.1.9, snowballstemmer ^= 1.2.1, babel ^= 2.3.4, alabaster ^= 0.7.7, six ^= 1.10.0, docutils ^= 0.12, pygments ^= 2.1.3, jinja2 ^= 2.8)
+- sphinx 1.4.1-2; depends (sphinx_rtd_theme ^= 0.1.9, imagesize ^= 0.7.1, snowballstemmer ^= 1.2.1, babel ^= 2.3.4, alabaster ^= 0.7.7, six ^= 1.10.0, docutils ^= 0.12, pygments ^= 2.1.3, jinja2 ^= 2.8)
+- sphinx_rtd_theme 0.1.7-1
+- sphinx_rtd_theme 0.1.9-1
+- spyder 2.3.5.2-1; depends (ipython ^= 3.2.0, jedi ^= 0.9.0, pygments ^= 2.0.2, pyqt ^= 4.11.3, pyflakes ^= 0.9.2)
+- spyder 2.3.5.2-2; depends (ipython ^= 3.2.1, jedi ^= 0.9.0, pygments ^= 2.0.2, pyqt ^= 4.11.3, pyflakes ^= 0.9.2)
+- spyder 2.3.6-1; depends (ipython ^= 3.2.1, jedi ^= 0.9.0, pygments ^= 2.0.2, pyqt ^= 4.11.3, pyflakes ^= 0.9.2)
+- spyder 2.3.6-2; depends (ipython ^= 4.0.0, jedi ^= 0.9.0, pygments ^= 2.0.2, pyqt ^= 4.11.3, pyflakes ^= 0.9.2)
+- spyder 2.3.6-3; depends (ipython ^= 4.0.0, jedi ^= 0.9.0, pygments ^= 2.0.2, pyqt ^= 4.11.3, pyflakes ^= 1.0.0)
+- spyder 2.3.7-1; depends (ipython ^= 4.0.0, jedi ^= 0.9.0, pygments ^= 2.0.2, pyqt ^= 4.11.3, pyflakes ^= 1.0.0)
+- spyder 2.3.8-1; depends (ipython ^= 4.0.0, jedi ^= 0.9.0, pygments ^= 2.0.2, pyqt ^= 4.11.3, pyflakes ^= 1.0.0)
+- spyder 2.3.8-2; depends (ipython ^= 4.0.0, jedi ^= 0.9.0, pygments ^= 2.0.2, pyqt ^= 4.11.4, pyflakes ^= 1.0.0)
+- spyder 2.3.8-3; depends (ipython ^= 4.0.0, jedi ^= 0.9.0, pygments ^= 2.1, pyqt ^= 4.11.4, pyflakes ^= 1.0.0)
+- spyder 2.3.8-4; depends (ipython ^= 4.0.0, jedi ^= 0.9.0, pygments ^= 2.1, pyqt ^= 4.11.4, pyflakes ^= 1.1.0)
+- spyder 2.3.8-5; depends (ipython ^= 4.0.0, jedi ^= 0.9.0, pygments ^= 2.1.3, pyqt ^= 4.11.4, pyflakes ^= 1.1.0)
+- sqlalchemy 0.6.5-1
+- sqlalchemy 0.6.6-1
+- sqlalchemy 0.7.0-1
+- sqlalchemy 0.7.1-1
+- sqlalchemy 0.7.4-1
+- sqlalchemy 0.7.5-1
+- sqlalchemy 0.7.6-1
+- sqlalchemy 0.8.2-1
+- sqlalchemy 0.8.3-1
+- sqlalchemy 0.9.4-1
+- sqlalchemy 0.9.7-1
+- sqlalchemy 0.9.8-1
+- sqlalchemy 0.9.9-1
+- sqlalchemy 1.0.0-1
+- sqlalchemy 1.0.1-1
+- sqlalchemy 1.0.4-1
+- sqlalchemy 1.0.6-1
+- sqlalchemy 1.0.6-2
+- sqlalchemy 1.0.8-1
+- sqlalchemy 1.0.8-2
+- sqlalchemy 1.0.10-1
+- sqlalchemy 1.0.12-1
+- sqlparse 0.1.8-1
+- sqlparse 0.1.11-1
+- sqlparse 0.1.12-1
+- sqlparse 0.1.14-1
+- sqlparse 0.1.15-1
+- sqlparse 0.1.16-1
+- sqlparse 0.1.16-2
+- sqlparse 0.1.18-1
+- ssl_match_hostname 3.4.0.2-1
+- statsmodels 0.4.0-1; depends (scipy)
+- statsmodels 0.4.3-1; depends (scipy)
+- statsmodels 0.4.3-2; depends (scipy)
+- statsmodels 0.4.3-3; depends (scipy, pandas ^= 0.12.0)
+- statsmodels 0.5.0-1; depends (scipy, pandas ^= 0.12.0, patsy ^= 0.2.0)
+- statsmodels 0.5.0-2; depends (scipy ^= 0.13.0, pandas ^= 0.12.0, patsy ^= 0.2.0)
+- statsmodels 0.5.0-4; depends (scipy ^= 0.13.2, pandas ^= 0.12.0, patsy ^= 0.2.0)
+- statsmodels 0.5.0-5; depends (scipy ^= 0.13.2, pandas ^= 0.13.1, patsy ^= 0.2.0)
+- statsmodels 0.5.0-6; depends (scipy ^= 0.13.3, pandas ^= 0.13.1, patsy ^= 0.2.0)
+- statsmodels 0.5.0-7; depends (scipy ^= 0.14.0, pandas ^= 0.13.1, patsy ^= 0.2.0)
+- statsmodels 0.5.0-8; depends (scipy ^= 0.14.0, pandas ^= 0.14.0, patsy ^= 0.2.0)
+- statsmodels 0.5.0-10; depends (scipy ^= 0.14.0, pandas ^= 0.14.1, patsy ^= 0.2.0)
+- statsmodels 0.5.0-11; depends (scipy ^= 0.14.0, pandas ^= 0.14.1, patsy ^= 0.3.0)
+- statsmodels 0.6.0rc1-1; depends (scipy ^= 0.14.0, pandas ^= 0.15.0, patsy ^= 0.3.0)
+- statsmodels 0.6.0-1; depends (scipy ^= 0.14.0, pandas ^= 0.15.0, patsy ^= 0.3.0)
+- statsmodels 0.6.0-2; depends (scipy ^= 0.14.0, pandas ^= 0.15.1, patsy ^= 0.3.0)
+- statsmodels 0.6.1-1; depends (scipy ^= 0.14.0, pandas ^= 0.15.1, patsy ^= 0.3.0)
+- statsmodels 0.6.1-2; depends (scipy ^= 0.14.0, pandas ^= 0.15.2, patsy ^= 0.3.0)
+- statsmodels 0.6.1-3; depends (scipy ^= 0.14.1rc1, pandas ^= 0.15.2, patsy ^= 0.3.0)
+- statsmodels 0.6.1-4; depends (scipy ^= 0.15.1, pandas ^= 0.15.2, patsy ^= 0.3.0)
+- statsmodels 0.6.1-5; depends (scipy ^= 0.15.1, pandas ^= 0.16.0, patsy ^= 0.3.0)
+- statsmodels 0.6.1-6; depends (scipy ^= 0.15.1, pandas ^= 0.16.1, patsy ^= 0.3.0)
+- statsmodels 0.6.1-7; depends (scipy ^= 0.15.1, pandas ^= 0.16.2, patsy ^= 0.3.0)
+- statsmodels 0.6.1-8; depends (scipy ^= 0.15.1, pandas ^= 0.16.2, patsy ^= 0.4.0)
+- statsmodels 0.6.1-9; depends (scipy ^= 0.16.0, pandas ^= 0.16.2, patsy ^= 0.4.0)
+- statsmodels 0.6.1-11; depends (scipy ^= 0.16.1, pandas ^= 0.17.1, patsy ^= 0.4.0)
+- statsmodels 0.6.1-12; depends (scipy ^= 0.16.1, pandas ^= 0.17.1, patsy ^= 0.4.0)
+- statsmodels 0.6.1-13; depends (scipy ^= 0.16.1, pandas ^= 0.17.1, patsy ^= 0.4.1)
+- statsmodels 0.6.1-14; depends (scipy ^= 0.17.0, pandas ^= 0.17.1, patsy ^= 0.4.1)
+- statsmodels 0.6.1-15; depends (scipy ^= 0.17.0, pandas ^= 0.18.0, patsy ^= 0.4.1)
+- statsmodels 0.6.1-16; depends (scipy ^= 0.17.0, pandas ^= 0.18.0, patsy ^= 0.4.1)
+- stevedore 1.1.0-1
+- stevedore 1.2.0-1
+- stevedore 1.2.0-2; depends (distribute ^= 0.6.49)
+- stevedore 1.2.0-3; depends (setuptools ^= 14.3.1)
+- stevedore 1.2.0-4; depends (setuptools ^= 15.1)
+- stevedore 1.2.0-5; depends (setuptools ^= 15.2)
+- stevedore 1.2.0-6; depends (setuptools ^= 16.0)
+- stevedore 1.2.0-7; depends (setuptools ^= 17.1.1)
+- stevedore 1.2.0-8; depends (setuptools ^= 17.1.1)
+- stevedore 1.2.0-9; depends (setuptools ^= 18.2)
+- stevedore 1.2.0-10; depends (setuptools ^= 18.2)
+- stevedore 1.2.0-11; depends (setuptools ^= 18.4)
+- stevedore 1.2.0-12; depends (setuptools ^= 18.7.1)
+- stevedore 1.2.0-13; depends (setuptools ^= 19.1.1)
+- stevedore 1.2.0-14; depends (setuptools ^= 19.4)
+- stevedore 1.2.0-15; depends (setuptools ^= 20.1.1)
+- stevedore 1.2.0-16; depends (setuptools ^= 20.2.2)
+- stevedore 1.2.0-17; depends (setuptools ^= 20.3.1)
+- stevedore 1.2.0-18; depends (setuptools ^= 20.6.7)
+- supervisor 3.0-1; depends (meld3 ^= 0.6.10)
+- supervisor 3.1.2-1; depends (meld3 ^= 1.0.0)
+- supervisor 3.1.2-2; depends (meld3 ^= 1.0.0)
+- supervisor 3.1.2-3; depends (meld3 ^= 1.0.2)
+- swig 1.3.40-1
+- swig 1.3.40-2
+- swig 2.0.12-1
+- swig 3.0.2-1
+- swig 3.0.8-1
+- sympy 0.6.7-2; depends (pyglet)
+- sympy 0.7.0-1; depends (pyglet)
+- sympy 0.7.1-1; depends (pyglet)
+- sympy 0.7.2-1; depends (pyglet)
+- sympy 0.7.3-1; depends (pyglet)
+- sympy 0.7.5-1; depends (pyglet)
+- sympy 0.7.6-1; depends (pyglet)
+- sympy 0.7.6.1-1; depends (pyglet)
+- sympy 1.0-1; depends (mpmath ^= 0.19, pyglet ^= 1.1.4)
+- tabulate 0.7.3-1
+- tempita 0.5.1-2
+- tempita 0.5.3-1
+- terminado 0.5-1; depends (tornado ^= 4.1, ptyprocess ^= 0.4)
+- terminado 0.5-2; depends (tornado ^= 4.2, ptyprocess ^= 0.4)
+- terminado 0.5-3; depends (tornado ^= 4.2.1, ptyprocess ^= 0.4)
+- terminado 0.5-4; depends (tornado ^= 4.3, ptyprocess ^= 0.4)
+- testpath 0.2-1
+- toolz 0.7.0-1
+- toolz 0.7.1-1
+- toolz 0.7.2-1
+- toolz 0.7.4-1
+- tornado 2.1-1
+- tornado 2.1.1-1
+- tornado 2.2-1
+- tornado 3.1.1-1
+- tornado 3.2.2-1; depends (ssl_match_hostname ^= 3.4.0.2)
+- tornado 4.0.1-1; depends (ssl_match_hostname ^= 3.4.0.2)
+- tornado 4.0.2-1; depends (ssl_match_hostname ^= 3.4.0.2)
+- tornado 4.0.2-2; depends (ssl_match_hostname ^= 3.4.0.2)
+- tornado 4.1-1; depends (ssl_match_hostname ^= 3.4.0.2)
+- tornado 4.2-1; depends (ssl_match_hostname ^= 3.4.0.2, certifi ^= 14.05.14)
+- tornado 4.2.1-1; depends (ssl_match_hostname ^= 3.4.0.2, certifi ^= 14.05.14)
+- tornado 4.3-1; depends (singledispatch ^= 3.4.0.3, ssl_match_hostname ^= 3.4.0.2, certifi ^= 2015.11.20.1, backports_abc ^= 0.4)
+- traceback2 1.4.0-1; depends (linecache2 ^= 1.0.0)
+- traitlets 4.0.0-1; depends (ipython_genutils ^= 0.1.0, decorator ^= 4.0.2)
+- traitlets 4.0.0-2; depends (ipython_genutils ^= 0.1.0, decorator ^= 4.0.4)
+- traitlets 4.1.0-2; depends (ipython_genutils ^= 0.1.0, decorator ^= 4.0.6)
+- traitlets 4.1.0-3; depends (ipython_genutils ^= 0.1.0, decorator ^= 4.0.9)
+- traitlets 4.2.1-1; depends (ipython_genutils ^= 0.1.0, decorator ^= 4.0.9)
+- traits 4.0.0-1; depends (numpy ^= 1.6.0)
+- traits 4.0.0-2; depends (numpy ^= 1.6.1)
+- traits 4.1.0-1; depends (numpy ^= 1.6.1)
+- traits 4.2.0-1; depends (numpy ^= 1.6.1)
+- traits 4.3.0-1; depends (numpy ^= 1.6.1)
+- traits 4.3.0-2; depends (numpy ^= 1.7.1)
+- traits 4.3.0-3; depends (numpy ^= 1.8.0)
+- traits 4.4.0-1; depends (numpy ^= 1.8.0)
+- traits 4.4.0-2
+- traits 4.5.0-1
+- traits_enaml 0.2.0-1; depends (enaml ^= 0.8.9, traitsui ^= 4.4.0)
+- traits_enaml 0.2.1-1; depends (enaml ^= 0.9.4, traitsui ^= 4.4.0)
+- traits_enaml 0.2.1-2; depends (enaml ^= 0.9.5, traitsui ^= 4.4.0)
+- traits_enaml 0.2.1-3; depends (enaml ^= 0.9.5, traitsui ^= 4.4.0)
+- traits_enaml 0.2.1-4; depends (enaml ^= 0.9.8, traitsui ^= 4.4.0)
+- traits_enaml 0.2.1-5; depends (enaml ^= 0.9.8, traitsui ^= 4.4.0)
+- traits_enaml 0.2.1-6; depends (enaml ^= 0.9.8, traitsui ^= 4.4.0)
+- traits_enaml 0.2.1-7; depends (enaml ^= 0.9.8, traitsui ^= 4.4.0)
+- traits_enaml 0.2.1-8; depends (enaml ^= 0.9.8, traitsui ^= 4.5.1)
+- traits_enaml 0.2.1-9; depends (enaml ^= 0.9.8, traitsui ^= 4.5.1)
+- traits_enaml 0.2.1-10; depends (enaml ^= 0.9.8, traitsui ^= 4.5.1)
+- traits_enaml 0.2.1-11; depends (enaml ^= 0.9.8, traitsui ^= 4.5.1)
+- traits_enaml 0.2.1-12; depends (enaml ^= 0.9.8, traitsui ^= 5.0.0)
+- traits_enaml 0.2.1-13; depends (enaml ^= 0.9.8, traitsui ^= 5.0.0)
+- traits_enaml 0.2.1-14; depends (enaml ^= 0.9.8, traitsui ^= 5.0.0)
+- traits_enaml 0.2.1-15; depends (enaml ^= 0.9.8, traitsui ^= 5.0.0)
+- traits_enaml 0.2.1-16; depends (enaml ^= 0.9.8, traitsui ^= 5.1.0)
+- traitsui 4.0.0-1
+- traitsui 4.1.0-1
+- traitsui 4.2.0-1
+- traitsui 4.3.0-1
+- traitsui 4.3.0-2; depends (pyface ^= 4.3.0, traits ^= 4.3.0)
+- traitsui 4.4.0-1; depends (pyface ^= 4.4.0, traits ^= 4.4.0)
+- traitsui 4.4.0-2; depends (pyface ^= 4.4.0, traits ^= 4.5.0)
+- traitsui 4.4.0-3; depends (pyface ^= 4.5.0, traits ^= 4.5.0)
+- traitsui 4.5.1-1; depends (pyface ^= 4.5.0, traits ^= 4.5.0)
+- traitsui 4.5.1-2; depends (pyface ^= 4.5.2, traits ^= 4.5.0)
+- traitsui 5.0.0-1; depends (pyface ^= 5.0.0, traits ^= 4.5.0)
+- traitsui 5.1.0-1; depends (pyface ^= 5.1.0, traits ^= 4.5.0)
+- transaction 1.4.4-1; depends (zope.interface ^= 4.1.3)
+- twisted 10.2.0-1; depends (pyopenssl ^= 0.11, zope.interface ^= 3.6.1)
+- twisted 11.0.0-1; depends (pyopenssl ^= 0.11, zope.interface ^= 3.6.1)
+- twisted 11.0.0-2; depends (pyopenssl ^= 0.12, zope.interface ^= 3.6.3)
+- twisted 11.1.0-2; depends (pyopenssl ^= 0.12, zope.interface ^= 3.8.0)
+- twisted 12.0.0-1; depends (pyopenssl ^= 0.12, zope.interface ^= 3.8.0)
+- twisted 12.0.0-3; depends (pyopenssl ^= 0.13.1, zope.interface ^= 3.8.0)
+- twisted 14.0.0-1; depends (pyopenssl ^= 0.13.1, zope.interface ^= 4.1.1)
+- twisted 14.0.2-1; depends (pyopenssl ^= 0.13.1, zope.interface ^= 4.1.1)
+- twisted 14.0.2-3; depends (pyopenssl ^= 0.14, zope.interface ^= 4.1.1)
+- twisted 14.0.2-4; depends (pyopenssl ^= 0.14, zope.interface ^= 4.1.2)
+- twisted 15.0.0-1; depends (pyopenssl ^= 0.14, zope.interface ^= 4.1.2)
+- twisted 15.1.0-1; depends (pyopenssl ^= 0.14, zope.interface ^= 4.1.2)
+- twisted 15.1.0-2; depends (pyopenssl ^= 0.15.1, zope.interface ^= 4.1.2)
+- twisted 15.2.1-1; depends (pyopenssl ^= 0.15.1, zope.interface ^= 4.1.2)
+- twisted 15.4.0-1; depends (pyopenssl ^= 0.15.1, zope.interface ^= 4.1.2)
+- twisted 15.4.0-2; depends (pyopenssl ^= 0.15.1, zope.interface ^= 4.1.3)
+- twisted 15.5.0-1; depends (pyopenssl ^= 0.15.1, zope.interface ^= 4.1.3)
+- twisted 15.5.0-3; depends (pyopenssl ^= 16.0.0, zope.interface ^= 4.1.3)
+- twisted 16.0.0-1; depends (pyopenssl ^= 16.0.0, zope.interface ^= 4.1.3)
+- twisted 16.1.1-1; depends (pyopenssl ^= 16.0.0, zope.interface ^= 4.1.3)
+- tzlocal 1.2-1; depends (pytz ^= 2015.7)
+- tzlocal 1.2-2; depends (pytz ^= 2016.3)
+- ujson 1.33.0-1
+- ujson 1.33.0-2
+- ujson 1.35-1
+- ujson 1.35-2
+- unittest2 0.8.0-1
+- unittest2 1.1.0-1; depends (traceback2 ^= 1.4.0)
+- unixodbc 2.3.2-2
+- venusian 1.0-1
+- virtualenv 14.0.1-1
+- vtk 5.6.0-3
+- vtk 5.6.0-6
+- vtk 5.10.1-1
+- vtk 5.10.1-2
+- vtk 5.10.1-3
+- vtk 6.2.0-1
+- vtk 6.3.0-1
+- vtk 6.3.0-3
+- vtk 6.3.0-4
+- w3lib 1.10.0-1; depends (six ^= 1.8.0)
+- w3lib 1.10.0-2; depends (six ^= 1.9.0)
+- w3lib 1.12.0-1; depends (six ^= 1.9.0)
+- w3lib 1.12.0-2; depends (six ^= 1.10.0)
+- werkzeug 0.9.4-1
+- werkzeug 0.9.6-1
+- werkzeug 0.10.1-1
+- werkzeug 0.10.4-1
+- werkzeug 0.10.4-2
+- werkzeug 0.11.2-1
+- werkzeug 0.11.3-1
+- werkzeug 0.11.4-1
+- werkzeug 0.11.5-1
+- wheel 0.26.0-1; depends (setuptools ^= 19.1.1)
+- wheel 0.26.0-2; depends (setuptools ^= 19.4)
+- wheel 0.29.0-1; depends (setuptools ^= 20.1.1)
+- wheel 0.29.0-2; depends (setuptools ^= 20.2.2)
+- wheel 0.29.0-3; depends (setuptools ^= 20.3.1)
+- wheel 0.29.0-4; depends (setuptools ^= 20.6.7)
+- whoosh 1.6.2-1
+- whoosh 2.5.6-1
+- whoosh 2.5.7-1
+- whoosh 2.7.0-1
+- whoosh 2.7.2-1
+- whoosh 2.7.4-1
+- whooshdoc 1.0-6; depends (epydoc ^= 3.0.1, pyparsing ^= 1.5.5, epdindex ^= 1.2, whoosh ^= 1.6.2)
+- whooshdoc 1.0-7
+- wrapt 1.10.6-1
+- wtforms 2.0.2-1
+- wxpython 2.9.2.4-1
+- wxpython 3.0.2.0-1
+- wxpython 3.0.2.0-2
+- xarray 0.7.0-1; depends (numpy ^= 1.9.2, pandas ^= 0.17.1)
+- xarray 0.7.1-1; depends (numpy ^= 1.9.2, pandas ^= 0.17.1)
+- xarray 0.7.1-2; depends (numpy ^= 1.9.2, pandas ^= 0.18.0)
+- xarray 0.7.2-1; depends (numpy ^= 1.9.2, pandas ^= 0.18.0)
+- xarray 0.7.2-2; depends (numpy ^= 1.10.4, pandas ^= 0.18.0)
+- xlrd 0.7.1-3
+- xlrd 0.7.1-4
+- xlrd 0.7.2-1
+- xlrd 0.7.3-1
+- xlrd 0.7.6-1
+- xlrd 0.7.9-1
+- xlrd 0.9.2-1
+- xlrd 0.9.3-1
+- xlrd 0.9.4-1
+- xlsxwriter 0.5.5-1
+- xlsxwriter 0.5.7-1
+- xlsxwriter 0.6.4-1
+- xlsxwriter 0.6.5-1
+- xlsxwriter 0.6.6-1
+- xlsxwriter 0.6.7-1
+- xlsxwriter 0.7.2-1
+- xlsxwriter 0.7.3-1
+- xlsxwriter 0.7.6-1
+- xlsxwriter 0.7.7-1
+- xlsxwriter 0.8.4-1
+- xlutils 1.7.1-1; depends (xlwt ^= 0.7.5, xlrd ^= 0.9.3)
+- xlutils 1.7.1-2; depends (xlwt ^= 1.0.0, xlrd ^= 0.9.3)
+- xlutils 1.7.1-3; depends (xlwt ^= 1.0.0, xlrd ^= 0.9.4)
+- xlwings 0.2.3-1; depends (psutil ^= 2.1.1, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.15.0)
+- xlwings 0.2.3-2; depends (psutil ^= 2.1.1, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.15.1)
+- xlwings 0.3.0-1; depends (psutil ^= 2.1.1, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.15.1)
+- xlwings 0.3.0-2; depends (psutil ^= 2.1.1, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.15.2)
+- xlwings 0.3.0-3; depends (psutil ^= 2.2.0, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.15.2)
+- xlwings 0.3.2-1; depends (psutil ^= 2.2.0, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.15.2)
+- xlwings 0.3.2-2; depends (psutil ^= 2.2.1, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.15.2)
+- xlwings 0.3.4-1; depends (psutil ^= 2.2.1, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.15.2)
+- xlwings 0.3.4-2; depends (psutil ^= 2.2.1, numpy ^= 1.8.1, appscript ^= 1.0.1, pandas ^= 0.16.0)
+- xlwings 0.3.4-3; depends (psutil ^= 2.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.16.0)
+- xlwings 0.3.5-1; depends (psutil ^= 2.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.16.0)
+- xlwings 0.3.5-2; depends (psutil ^= 2.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.16.1)
+- xlwings 0.3.5-3; depends (psutil ^= 2.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.16.2)
+- xlwings 0.3.6-1; depends (psutil ^= 2.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.16.2)
+- xlwings 0.3.6-2; depends (psutil ^= 3.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.16.2)
+- xlwings 0.4.0-1; depends (psutil ^= 3.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.16.2)
+- xlwings 0.4.1-1; depends (psutil ^= 3.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.16.2)
+- xlwings 0.4.1-2; depends (psutil ^= 3.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.17.1)
+- xlwings 0.6.2-1; depends (psutil ^= 3.2.1, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.17.1)
+- xlwings 0.6.2-2; depends (psutil ^= 3.3.0, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.17.1)
+- xlwings 0.6.4-1; depends (psutil ^= 3.3.0, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.17.1)
+- xlwings 0.7.0-1; depends (psutil ^= 3.3.0, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.17.1)
+- xlwings 0.7.0-2; depends (psutil ^= 3.3.0, numpy ^= 1.9.2, appscript ^= 1.0.1, pandas ^= 0.18.0)
+- xlwings 0.7.0-3; depends (psutil ^= 3.3.0, numpy ^= 1.10.4, appscript ^= 1.0.1, pandas ^= 0.18.0)
+- xlwings 0.7.1-1; depends (psutil ^= 3.3.0, numpy ^= 1.10.4, appscript ^= 1.0.1, pandas ^= 0.18.0)
+- xlwt 0.7.2-3
+- xlwt 0.7.3-1
+- xlwt 0.7.4-1
+- xlwt 0.7.5-1
+- xlwt 1.0.0-1
+- xmltodict 0.9.2-1
+- xray 0.6.1-1; depends (numpy ^= 1.9.2, pandas ^= 0.17.1)
+- xray 0.7.0-1; depends (xarray ^= 0.7.0)
+- xray 0.7.1-1; depends (xarray ^= 0.7.1)
+- xray 0.7.2-2; depends (xarray ^= 0.7.2)
+- xz 5.2.2-1
+- yapf 0.6.2-1
+- zeromq 2.0.7-1
+- zeromq 2.0.8-1
+- zeromq 2.0.10-1
+- zeromq 2.1.1-1
+- zeromq 2.1.4-1
+- zeromq 2.1.7-1
+- zeromq 2.1.9-1
+- zeromq 2.1.10-1
+- zeromq 2.1.11-1
+- zeromq 3.2.0-1
+- zeromq 3.2.4-1
+- zeromq 4.0.4-1
+- zeromq 4.0.5-1
+- zeromq 4.1.3-1; depends (libsodium ^= 1.0.3)
+- zipfile2 0.0.6-1
+- zipfile2 0.0.7-1
+- zipfile2 0.0.8-2
+- zipfile2 0.0.11-1
+- zipfile2 0.0.12-1
+- zipline 0.7.0-1; depends (patsy ^= 0.3.0, pandas ^= 0.15.2, scipy ^= 0.15.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.5.3)
+- zipline 0.7.0-2; depends (patsy ^= 0.3.0, pandas ^= 0.15.2, scipy ^= 0.15.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.6.0)
+- zipline 0.7.0-3; depends (patsy ^= 0.3.0, pandas ^= 0.16.0, scipy ^= 0.15.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.6.0)
+- zipline 0.7.0-4; depends (patsy ^= 0.3.0, pandas ^= 0.16.0, scipy ^= 0.15.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.6.2)
+- zipline 0.7.0-5; depends (patsy ^= 0.3.0, pandas ^= 0.16.0, scipy ^= 0.15.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.7.0)
+- zipline 0.7.0-6; depends (patsy ^= 0.3.0, pandas ^= 0.16.1, scipy ^= 0.15.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.7.0)
+- zipline 0.7.0-7; depends (patsy ^= 0.3.0, pandas ^= 0.16.2, scipy ^= 0.15.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.7.0)
+- zipline 0.7.0-8; depends (patsy ^= 0.4.0, pandas ^= 0.16.2, scipy ^= 0.15.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.7.0)
+- zipline 0.7.0-9; depends (patsy ^= 0.4.0, pandas ^= 0.16.2, scipy ^= 0.16.0, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.7.0)
+- zipline 0.7.0-10; depends (patsy ^= 0.4.0, pandas ^= 0.16.2, scipy ^= 0.16.0, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.8.0)
+- zipline 0.7.0-11; depends (patsy ^= 0.4.0, pandas ^= 0.16.2, scipy ^= 0.16.0, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.8.0)
+- zipline 0.7.0-12; depends (patsy ^= 0.4.0, pandas ^= 0.16.2, scipy ^= 0.16.0, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.8.0)
+- zipline 0.7.0-14; depends (patsy ^= 0.4.0, pandas ^= 0.17.1, scipy ^= 0.16.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.8.0)
+- zipline 0.7.0-15; depends (patsy ^= 0.4.0, pandas ^= 0.17.1, scipy ^= 0.16.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.9.0)
+- zipline 0.7.0-16; depends (patsy ^= 0.4.0, pandas ^= 0.17.1, scipy ^= 0.16.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.9.1)
+- zipline 0.7.0-17; depends (patsy ^= 0.4.1, pandas ^= 0.17.1, scipy ^= 0.16.1, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.9.1)
+- zipline 0.7.0-18; depends (patsy ^= 0.4.1, pandas ^= 0.17.1, scipy ^= 0.17.0, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.9.1)
+- zipline 0.7.0-19; depends (patsy ^= 0.4.1, pandas ^= 0.18.0, scipy ^= 0.17.0, statsmodels ^= 0.6.1, logbook ^= 0.9.0, requests ^= 2.9.1)
+- zope.deprecation 4.1.1-1
+- zope.deprecation 4.1.2-1
+- zope.deprecation 4.1.2-2
+- zope.deprecation 4.1.2-3
+- zope.deprecation 4.1.2-4
+- zope.deprecation 4.1.2-5
+- zope.deprecation 4.1.2-6
+- zope.deprecation 4.1.2-7
+- zope.deprecation 4.1.2-8
+- zope.deprecation 4.1.2-9
+- zope.deprecation 4.1.2-10
+- zope.deprecation 4.1.2-11
+- zope.deprecation 4.1.2-12
+- zope.deprecation 4.1.2-13
+- zope.deprecation 4.1.2-14
+- zope.deprecation 4.1.2-15
+- zope.exceptions 4.0.8-1; depends (zope.interface ^= 4.1.3, setuptools ^= 19.4)
+- zope.exceptions 4.0.8-2; depends (zope.interface ^= 4.1.3, setuptools ^= 20.1.1)
+- zope.exceptions 4.0.8-3; depends (zope.interface ^= 4.1.3, setuptools ^= 20.2.2)
+- zope.exceptions 4.0.8-4; depends (zope.interface ^= 4.1.3, setuptools ^= 20.3.1)
+- zope.exceptions 4.0.8-5; depends (zope.interface ^= 4.1.3, setuptools ^= 20.6.7)
+- zope.interface 3.6.1-2
+- zope.interface 3.6.3-1
+- zope.interface 3.8.0-1
+- zope.interface 4.1.1-1
+- zope.interface 4.1.2-1
+- zope.interface 4.1.2-2; depends (setuptools ^= 14.3.1)
+- zope.interface 4.1.2-3; depends (setuptools ^= 15.1)
+- zope.interface 4.1.2-4; depends (setuptools ^= 15.2)
+- zope.interface 4.1.2-5; depends (setuptools ^= 16.0)
+- zope.interface 4.1.2-6; depends (setuptools ^= 17.1.1)
+- zope.interface 4.1.2-7; depends (setuptools ^= 18.2)
+- zope.interface 4.1.3-1; depends (setuptools ^= 18.2)
+- zope.interface 4.1.3-2; depends (setuptools ^= 18.4)
+- zope.interface 4.1.3-3; depends (setuptools ^= 18.7.1)
+- zope.interface 4.1.3-4; depends (setuptools ^= 19.1.1)
+- zope.interface 4.1.3-5; depends (setuptools ^= 19.4)
+- zope.interface 4.1.3-6; depends (setuptools ^= 20.1.1)
+- zope.interface 4.1.3-7; depends (setuptools ^= 20.2.2)
+- zope.interface 4.1.3-8; depends (setuptools ^= 20.3.1)
+- zope.interface 4.1.3-9; depends (setuptools ^= 20.6.7)
+- zope.sqlalchemy 0.7.6-1; depends (zope.interface ^= 4.1.3, sqlalchemy ^= 1.0.10, setuptools ^= 19.4, transaction ^= 1.4.4)
+- zope.sqlalchemy 0.7.6-2; depends (zope.interface ^= 4.1.3, sqlalchemy ^= 1.0.10, setuptools ^= 20.1.1, transaction ^= 1.4.4)
+- zope.sqlalchemy 0.7.6-3; depends (zope.interface ^= 4.1.3, sqlalchemy ^= 1.0.10, setuptools ^= 20.2.2, transaction ^= 1.4.4)
+- zope.sqlalchemy 0.7.6-4; depends (zope.interface ^= 4.1.3, sqlalchemy ^= 1.0.12, setuptools ^= 20.2.2, transaction ^= 1.4.4)
+- zope.sqlalchemy 0.7.6-5; depends (zope.interface ^= 4.1.3, sqlalchemy ^= 1.0.12, setuptools ^= 20.3.1, transaction ^= 1.4.4)
+- zope.sqlalchemy 0.7.6-6; depends (zope.interface ^= 4.1.3, sqlalchemy ^= 1.0.12, setuptools ^= 20.6.7, transaction ^= 1.4.4)
+- zope.testing 4.5.0-1; depends (zope.interface ^= 4.1.3, zope.exceptions ^= 4.0.8, setuptools ^= 19.4)
+- zope.testing 4.5.0-2; depends (zope.interface ^= 4.1.3, zope.exceptions ^= 4.0.8, setuptools ^= 20.1.1)
+- zope.testing 4.5.0-3; depends (zope.interface ^= 4.1.3, zope.exceptions ^= 4.0.8, setuptools ^= 20.2.2)
+- zope.testing 4.5.0-4; depends (zope.interface ^= 4.1.3, zope.exceptions ^= 4.0.8, setuptools ^= 20.3.1)
+- zope.testing 4.5.0-5; depends (zope.interface ^= 4.1.3, zope.exceptions ^= 4.0.8, setuptools ^= 20.6.7)
+
+marked:
+    - matplotlib
+    - numpy
+    - scipy
+
+installed:
+    - backports_abc 0.4-1
+    - certifi 2015.11.20.1-1
+    - configobj 5.0.6-1
+    - cycler 0.10.0-1
+    - freetype 2.5.3-4
+    - libpng 1.6.12-3
+    - matplotlib 1.5.1-5
+    - mkl 11.1.4-1
+    - numpy 1.10.4-1
+    - pyparsing 2.0.3-1
+    - python_dateutil 2.5.2-1
+    - pytz 2016.3-1
+    - scipy 0.17.0-3
+    - singledispatch 3.4.0.3-1
+    - six 1.10.0-1
+    - ssl_match_hostname 3.4.0.2-1
+    - tornado 4.3-1
+    - wxpython 3.0.2.0-2
+
+request:
+    - operation: "install"
+      requirement: "numpy < 1.8"
+
+transaction:
+    - kind: "remove"
+      package: "scipy 0.17.0-3"
+    - kind: "remove"
+      package: "matplotlib 1.5.1-5"
+    - kind: "remove"
+      package: "numpy 1.10.4-1"
+    - kind: "remove"
+      package: "freetype 2.5.3-4"
+    - kind: "remove"
+      package: "mkl 11.1.4-1"
+    - kind: "remove"
+      package: "libpng 1.6.12-3"
+    - kind: "install"
+      package: "freetype 2.4.4-5"
+    - kind: "install"
+      package: "libpng 1.2.40-5"
+    - kind: "install"
+      package: "mkl 10.3-1"
+    - kind: "install"
+      package: "numpy 1.7.1-3"
+    - kind: "install"
+      package: "matplotlib 1.2.1-1"
+    - kind: "install"
+      package: "scipy 0.13.0-1"
+
+pretty_transaction:
+    - kind: "update"
+      from: "freetype 2.5.3-4"
+      to: "freetype 2.4.4-5"
+    - kind: "update"
+      from: "libpng 1.6.12-3"
+      to: "libpng 1.2.40-5"
+    - kind: "update"
+      from: "mkl 11.1.4-1"
+      to: "mkl 10.3-1"
+    - kind: "update"
+      from: "numpy 1.10.4-1"
+      to: "numpy 1.7.1-3"
+    - kind: "update"
+      from: "matplotlib 1.5.1-5"
+      to: "matplotlib 1.2.1-1"
+    - kind: "update"
+      from: "scipy 0.17.0-3"
+      to: "scipy 0.13.0-1"

--- a/simplesat/tests/no_prefer_installed.yaml
+++ b/simplesat/tests/no_prefer_installed.yaml
@@ -159,8 +159,34 @@ packages:
   - zeromq 4.0.5-1
 
 request:
-    - operation: "install"
+    - operation: "soft_update"
       requirement: "ipython >= 4.0"
+    - operation: "soft_update"
+      requirement: "zeromq"
+    - operation: "soft_update"
+      requirement: "ssl_match_hostname"
+    - operation: "soft_update"
+      requirement: "ptyprocess"
+    - operation: "soft_update"
+      requirement: "certifi"
+    - operation: "soft_update"
+      requirement: "tornado"
+    - operation: "soft_update"
+      requirement: "terminado"
+    - operation: "soft_update"
+      requirement: "pyzmq"
+    - operation: "soft_update"
+      requirement: "mistune"
+    - operation: "soft_update"
+      requirement: "jsonschema"
+    - operation: "soft_update"
+      requirement: "appinst"
+    - operation: "soft_update"
+      requirement: "Pygments"
+    - operation: "soft_update"
+      requirement: "MarkupSafe"
+    - operation: "soft_update"
+      requirement: "Jinja2"
 
 installed:
   - zeromq 4.0.5-1

--- a/simplesat/tests/simple_update_single.yaml
+++ b/simplesat/tests/simple_update_single.yaml
@@ -4,7 +4,7 @@ packages:
     - MKL 10.3-1
 
 request:
-    - operation: "update"
+    - operation: "hard_update"
       requirement: "MKL"
 
 installed:

--- a/simplesat/tests/soft_update_with_deps.yaml
+++ b/simplesat/tests/soft_update_with_deps.yaml
@@ -1,14 +1,16 @@
 packages:
     - MKL 10.2-1
     - MKL 10.3-1
+    - MKL 10.4-1
     - numpy 1.7.1-1; depends (MKL == 10.2-1)
     - numpy 1.8.1-1; depends (MKL == 10.2-1)
     - numpy 1.9.1-1; depends (MKL == 10.3-1)
+    - numpy 2.0.0-1; depends (MKL == 11.0-1)
 
 request:
     - operation: "soft_update"
       requirement: "numpy"
-    - operation: "install"
+    - operation: "soft_update"
       requirement: "MKL"
 
 installed:
@@ -18,10 +20,17 @@ installed:
 transaction:
     - kind: "remove"
       package: "numpy 1.7.1-1"
+    - kind: "remove"
+      package: "MKL 10.2-1"
     - kind: "install"
-      package: "numpy 1.8.1-1"
+      package: "MKL 10.3-1"
+    - kind: "install"
+      package: "numpy 1.9.1-1"
 
 pretty_transaction:
     - kind: "update"
+      from: "MKL 10.2-1"
+      to: "MKL 10.3-1"
+    - kind: "update"
       from: "numpy 1.7.1-1"
-      to: "numpy 1.8.1-1"
+      to: "numpy 1.9.1-1"

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -191,6 +191,12 @@ class TestInstallSet(ScenarioTestAssistant, TestCase):
     def test_simple_numpy(self):
         self._check_solution("simple_numpy_installed.yaml")
 
+    def test_simple_numpy_installed_upgrade(self):
+        self._check_solution("simple_numpy_installed_upgrade.yaml")
+
+    def test_soft_update_with_deps(self):
+        self._check_solution("soft_update_with_deps.yaml")
+
     def test_numpy_downgrade(self):
         self._check_solution("numpy_downgrade.yaml")
 

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -6,7 +6,6 @@ import six
 from simplesat.errors import NoPackageFound, SatisfiabilityError
 from simplesat.dependency_solver import DependencySolver
 from simplesat.pool import Pool
-from simplesat.sat.policy import InstalledFirstPolicy
 from simplesat.test_utils import Scenario
 from simplesat.transaction import (
     InstallOperation, RemoveOperation, UpdateOperation
@@ -69,11 +68,9 @@ class ScenarioTestAssistant(object):
         # When
         pool = Pool(scenario.remote_repositories)
         pool.add_repository(scenario.installed_repository)
-        policy = InstalledFirstPolicy(pool, scenario.installed_repository,
-                                      prefer_installed=prefer_installed)
+
         solver = DependencySolver(
             pool, scenario.remote_repositories, scenario.installed_repository,
-            policy=policy,
         )
 
         # Then

--- a/simplesat/tests/test_scenarios_policy.py
+++ b/simplesat/tests/test_scenarios_policy.py
@@ -200,6 +200,10 @@ class TestInstallSet(ScenarioTestAssistant, TestCase):
     def test_numpy_downgrade(self):
         self._check_solution("numpy_downgrade.yaml")
 
+    def test_complex_numpy_downgrade(self):
+        # Regression test for infinite loop in policy
+        self._check_solution("complex_numpy_downgrade.yaml")
+
     def test_ipython(self):
         self._check_solution("ipython_with_installed.yaml")
 

--- a/simplesat/tests/update_reverse_dependencies_no_prefer_installed.yaml
+++ b/simplesat/tests/update_reverse_dependencies_no_prefer_installed.yaml
@@ -28,9 +28,22 @@ packages:
 
 
 request:
-  - operation: "install"
+  - operation: "soft_update"
     requirement: "E ^= 1.0.0"
-
+  - operation: "soft_update"
+    requirement: "A"
+  - operation: "soft_update"
+    requirement: "B"
+  - operation: "soft_update"
+    requirement: "C"
+  - operation: "soft_update"
+    requirement: "D"
+  - operation: "soft_update"
+    requirement: "X"
+  - operation: "soft_update"
+    requirement: "Y"
+  - operation: "soft_update"
+    requirement: "Z"
 
 marked:
   - E

--- a/simplesat/tests/update_single.yaml
+++ b/simplesat/tests/update_single.yaml
@@ -48,7 +48,7 @@ packages:
     - unrelated 0.2.3-1
 
 request:
-    - operation: "update"
+    - operation: "hard_update"
       requirement: "scipy"
 
 installed:

--- a/simplesat/transaction.py
+++ b/simplesat/transaction.py
@@ -29,16 +29,24 @@ class RemoveOperation(Operation):
 class Transaction(object):
 
     def __init__(self, pool, decisions, installed_package_ids):
+        self._pool = pool
+        self._local_packages = {
+            self._package_key(package_id): package_id
+            for package_id in installed_package_ids
+        }
         self.operations = self._safe_operations(
-            pool, decisions, installed_package_ids)
-        self.pretty_operations = self._as_pretty_operations(
-            pool, self.operations)
+            decisions, installed_package_ids)
+        self.pretty_operations = self._as_pretty_operations(self.operations)
 
     def __iter__(self):
         return iter(self.operations)
 
     def __str__(self):
         return self.to_string(self.operations)
+
+    def _package_key(self, package_id):
+        package = self._pool.id_to_package(package_id)
+        return (package.name, package.version)
 
     @staticmethod
     def to_string(operations):
@@ -78,12 +86,12 @@ class Transaction(object):
 
         return "\n".join(lines)
 
-    def _as_pretty_operations(self, pool, operations):
+    def _as_pretty_operations(self, operations):
         pkg_to_ops = OrderedDict((op.package, [op]) for op in operations)
 
         for pkg in reversed(tuple(pkg_to_ops.keys())):
             if pkg in pkg_to_ops:
-                for update in self._find_other_providers(pool, pkg):
+                for update in self._find_other_providers(pkg):
                     pkg_to_ops[pkg] += pkg_to_ops.pop(update, [])
 
         combine = self._merge_operations
@@ -96,11 +104,11 @@ class Transaction(object):
         first, second = sorted(ops, key=lambda o: rank.index(o.__class__))
         return UpdateOperation(first.package, second.package)
 
-    def _safe_operations(self, pool, decisions, installed_package_ids):
-        graph = package_lit_dependency_graph(pool, decisions, closed=True)
+    def _safe_operations(self, decisions, installed_package_ids):
+        graph = package_lit_dependency_graph(self._pool, decisions,
+                                             closed=True)
         removals = []
         installs = []
-        operations = []
 
         # This builds from the bottom (no dependencies) up
         for group in toposort(graph):
@@ -113,23 +121,40 @@ class Transaction(object):
                       package_id not in installed_package_ids):
                     installs.append(package_id)
 
-        # Removals should happen top down
-        for package_id in reversed(removals):
-            package = pool.id_to_package(package_id)
-            operations.append(RemoveOperation(package))
+        install_operations = []
+        remove_operations = []
 
         # Installations should happen bottom up
         for package_id in installs:
-            package = pool.id_to_package(package_id)
-            operations.append(InstallOperation(package))
+            # The solver may suggest removing a currently installed package and
+            # installing another version of that same package from a different
+            # repo. Filter out operations which would install the same version
+            # of a currently installed package and discard the associated
+            # remove operation.
+            key = self._package_key(package_id)
+            preferred_id = self._local_packages.get(key, package_id)
 
-        return operations
+            if preferred_id != package_id:
+                # Because we are not installing the remote package, do not
+                # remove original version
+                if preferred_id in removals:
+                    removals.remove(preferred_id)
+            else:
+                package = self._pool.id_to_package(package_id)
+                install_operations.append(InstallOperation(package))
 
-    def _find_other_providers(self, pool, package):
+        # Removals should happen top down
+        for package_id in reversed(removals):
+            package = self._pool.id_to_package(package_id)
+            remove_operations.append(RemoveOperation(package))
+
+        return remove_operations + install_operations
+
+    def _find_other_providers(self, package):
         # NOTE: this assumes that the name of the package is also the name of
         # the thing that is being provided. This is not always true. Consider
         # that apache2 and nginx can both provide "webserver", etc.
         requirement = InstallRequirement._from_string(package.name)
         return [
-            p for p in pool.what_provides(requirement) if p != package
+            p for p in self._pool.what_provides(requirement) if p != package
         ]


### PR DESCRIPTION
Motivation:
The initial approach for `soft_update` was to remove those packages from the `installed_repository` passed to the `policy`. Reducing the number of knobs on `DependencySolver` to turn can increase our confidence in use of the solver. Instead of editing the `installed_repository` in a somewhat hacky manner we can include all necessary information in the `Request`.

Changes:
- A new job type `soft_update` is added to `Request`. The policy will prefer the installed versions of all packages except those which have `soft_update` jobs. The existing `update` job is renamed to `hard_update`

- Remove policy as attribute for `DependencySolver`. The `policy` needs to be created with the same `pool` and `installed_repository` as the `DependencySolver`. It strikes me as safer to create the policy when we need it rather than allowing the user to pass it in. This also allows us to customize the policy based on the request. If different policies are added at a later date we can consider the best way to add back this functionality.

- Remove `prefer_installed` flag from `policy`. The `policy` is now created by the `DependencySolver` and is not customizable by the user. The same behavior can be reached by changing the `request`.

@johntyree I'd love to hear your opinion

@cournape Please take a look