### PR TITLE
ENH: support ConstraintsModifiers.remove

### DIFF
--- a/simplesat/constraints/constraint_modifiers.py
+++ b/simplesat/constraints/constraint_modifiers.py
@@ -96,6 +96,21 @@ class ConstraintModifiers(object):
         self.allow_newer.update(other_modifiers.allow_newer)
         self.allow_older.update(other_modifiers.allow_older)
 
+    def remove(self, packages):
+        """ Remove all modifiers related to `packages`.
+
+        Parameters
+        ----------
+        packages : a list, tuple, or set of strings
+            The package names that should be completely removed.
+        """
+        disallowed = (type(b""), type(u""))
+        if isinstance(packages, disallowed):
+            raise TypeError("`packages` should be a collection, not a string.")
+        self.allow_any.difference_update(packages)
+        self.allow_newer.difference_update(packages)
+        self.allow_older.difference_update(packages)
+
     @property
     def targets(self):
         return set.union(self.allow_newer, self.allow_any, self.allow_older)

--- a/simplesat/constraints/constraint_modifiers.py
+++ b/simplesat/constraints/constraint_modifiers.py
@@ -101,7 +101,7 @@ class ConstraintModifiers(object):
 
         Parameters
         ----------
-        packages : a list, tuple, or set of strings
+        packages : an iterable of strings
             The package names that should be completely removed.
         """
         disallowed = (type(b""), type(u""))

--- a/simplesat/constraints/tests/test_constraint_modifiers.py
+++ b/simplesat/constraints/tests/test_constraint_modifiers.py
@@ -41,6 +41,26 @@ class TestConstraintModifiers(unittest.TestCase):
         self.assertEqual(modifiers.allow_newer, set(('u', 'v')))
         self.assertEqual(modifiers.allow_older, set())
 
+    def test_remove(self):
+        # Given
+        modifiers = ConstraintModifiers(allow_any='x',
+                                        allow_newer=('x', 'u', 'v'),
+                                        allow_older=('x', 'y'))
+
+        # When
+        modifiers.remove(['x'])
+
+        # Then
+        self.assertEqual(modifiers.allow_any, set())
+        self.assertEqual(modifiers.allow_newer, set(('u', 'v')))
+        self.assertEqual(modifiers.allow_older, set(['y']))
+        with self.assertRaises(TypeError):
+            modifiers.remove("Don't pass a string")
+        with self.assertRaises(TypeError):
+            modifiers.remove(u"Don't pass unicode")
+        with self.assertRaises(TypeError):
+            modifiers.remove(b"Don't pass bytes")
+
     def test_targets(self):
         # Given
         modifiers = ConstraintModifiers(allow_any=('a', 'b', 'c'),


### PR DESCRIPTION
Raises a `TypeError` if a string is passed instead of an iterable of strings.

Closes #214 