### PR TITLE
FEAT: add new solve_with_hint method.

### DIFF
--- a/simplesat/errors.py
+++ b/simplesat/errors.py
@@ -47,3 +47,23 @@ class SatisfiabilityError(SolverException):
     @property
     def reason(self):
         return self.unsat.to_string()
+
+
+class SatisfiabilityErrorWithHint(SatisfiabilityError):
+    """ A satistibiality error class with information about minimally
+    unsatisfiable problem.
+
+    This is used when one wants to give more human-readable error messages
+    about conflicts and other satistiability issues.
+    """
+    def __init__(self, unsat, conflicting_jobs):
+        self.conflicting_jobs = conflicting_jobs
+        super(SatisfiabilityErrorWithHint, self).__init__(unsat)
+
+    @property
+    def hint_pretty_string(self):
+        return (
+            u"The following jobs are conflicting:\n{}".format(
+                u"\n".join("    {}".format(str(job)) for job in self.conflicting_jobs)
+            )
+        )

--- a/simplesat/request.py
+++ b/simplesat/request.py
@@ -17,6 +17,9 @@ class _Job(object):
     requirement = attr(validator=instance_of(Requirement))
     kind = attr(validator=instance_of(JobType))
 
+    def __str__(self):
+        return u"{} {}".format(self.kind.name, self.requirement)
+
 
 @attributes
 class Request(object):


### PR DESCRIPTION
This new method uses exactly the same algorithm as solve, but when a satistifiability error occurs, it computes a minimal unsatistiable set of jobs, which helps giving a more human-readable error message.

As an example, let's say we have a small dependency problem with the following packages:

```
mkl_11_3_1 = P(u"mkl 11.3.1-1")
mkl_2017_0_1_1 = P(u"mkl 2017.0.1-1")
mkl_2017_0_1_2 = P(u"mkl 2017.0.1-2")

numpy_1_10_4 = P(u"numpy 1.10.4-1; depends (mkl ^= 11.3.1)")
numpy_1_11_3 = P(u"numpy 1.11.3-1; depends (mkl ^= 2017.0.1)")

scipy_0_17_1 = P(u"scipy 0.17.1-1; depends (mkl ^= 11.3.1, numpy ^= 1.10.4)")
scipy_0_18_1 = P(u"scipy 0.18.1-1; depends (mkl ^= 2017.0.1, numpy ^= 1.11.3)")
```

Then, trying to install both `scipy 0.18.x` and `MKL < 12` cannot work. With solve, the error message is:

```
Conflicting requirements:
Requirements: 'scipy >= 0.18.0-0'
    Install command rule (+scipy-0.18.1-1)
Requirements: 'scipy >= 0.18.0-0' <- 'numpy ^= 1.11.3'
    scipy-0.18.1-1 requires (+numpy-1.11.3-1)
Requirements: 'scipy >= 0.18.0-0' <- 'numpy ^= 1.11.3' <- 'mkl ^= 2017.0.1'
    numpy-1.11.3-1 requires (+mkl-2017.0.1-1 | +mkl-2017.0.1-2)
Requirements: 'scipy >= 0.18.0-0' <- 'mkl ^= 2017.0.1' <- 'mkl'
    Can only install one of: (+mkl-11.3.1-1 | +mkl-2017.0.1-2)
Requirements: 'mkl < 12-0'
    Install command rule (+mkl-11.3.1-1)
```

With the new `solve_with_hint` method:

```
The following jobs are conflicting:
    install scipy >= 0.18.0-0
    install mkl < 12-0
```