### PR TITLE
Fix 7z requirement parsing error

### DIFF
--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -201,7 +201,9 @@ class _RawRequirementParser(object):
             if len(requirement_block) == 3:
                 distribution, operator, version = requirement_block
                 if not isinstance(distribution, DistributionNameToken):
-                    raise InvalidConstraint(msg + ' (bad distirbution name)')
+                    if re.match(_DISTRIBUTION_R, distribution.value) is None:
+                        raise InvalidConstraint(
+                            msg + ' (bad distirbution name)')
                 if not isinstance(version, VersionToken):
                     raise InvalidConstraint(msg + ' (bad version)')
                 name = distribution.value

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -200,10 +200,9 @@ class _RawRequirementParser(object):
 
             if len(requirement_block) == 3:
                 distribution, operator, version = requirement_block
-                if not isinstance(distribution, DistributionNameToken):
-                    if re.match(_DISTRIBUTION_R, distribution.value) is None:
-                        raise InvalidConstraint(
-                            msg + ' (bad distirbution name)')
+                if (not isinstance(distribution, DistributionNameToken) and
+                        re.match(_DISTRIBUTION_R, distribution.value) is None):
+                    raise InvalidConstraint(msg + ' (bad distirbution name)')
                 if not isinstance(version, VersionToken):
                     raise InvalidConstraint(msg + ' (bad version)')
                 name = distribution.value

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -17,7 +17,7 @@ from simplesat.errors import InvalidConstraint
 # case-insensitivity into the regex manually.
 _DISTRIBUTION_NAME_R = r"(?!\.)(?:\.?\w+)+(?<!\.)"
 _DISTRIBUTION_R = "({})".format(_DISTRIBUTION_NAME_R)
-_VERSION_R = r"((?=\d){}(?:-\w+)?)".format(_DISTRIBUTION_NAME_R)
+_VERSION_R = r"((?=\d){}(?:-\w+)?\b(?!\s))".format(_DISTRIBUTION_NAME_R)
 _EQUAL_R = r"=="
 _GEQ_R = r">="
 _GT_R = r">"
@@ -200,8 +200,7 @@ class _RawRequirementParser(object):
 
             if len(requirement_block) == 3:
                 distribution, operator, version = requirement_block
-                if (not isinstance(distribution, DistributionNameToken) and
-                        re.match(_DISTRIBUTION_R, distribution.value) is None):
+                if not isinstance(distribution, DistributionNameToken):
                     raise InvalidConstraint(msg + ' (bad distirbution name)')
                 if not isinstance(version, VersionToken):
                     raise InvalidConstraint(msg + ' (bad version)')

--- a/simplesat/constraints/parser.py
+++ b/simplesat/constraints/parser.py
@@ -17,7 +17,7 @@ from simplesat.errors import InvalidConstraint
 # case-insensitivity into the regex manually.
 _DISTRIBUTION_NAME_R = r"(?!\.)(?:\.?\w+)+(?<!\.)"
 _DISTRIBUTION_R = "({})".format(_DISTRIBUTION_NAME_R)
-_VERSION_R = r"((?=\d){}(?:-\w+)?\b(?!\s))".format(_DISTRIBUTION_NAME_R)
+_VERSION_R = r"((?=\d){}(?:-\w+)?$)".format(_DISTRIBUTION_NAME_R)
 _EQUAL_R = r"=="
 _GEQ_R = r">="
 _GT_R = r">"

--- a/simplesat/constraints/tests/test_package_parser.py
+++ b/simplesat/constraints/tests/test_package_parser.py
@@ -463,6 +463,7 @@ class TestParseScaryPackages(unittest.TestCase):
 
     # NOTE: gathered with 'scripts/index_to_scary_package_strings.py'
     SCARY_PACKAGE_STRINGS = """
+        7z 9.20-1
         wb 19-4
         qt 2.5-1
         pytz 19-4


### PR DESCRIPTION
I am not terribly crazy about this fix, but it is the best I have come up with so far. The main issue seems to be that if a package name starts with a number, it is parsed as a `VersionToken`. The difficulty is that we actually want some valid version constraint strings to also be valid package names. This fix just adds a check to ensure the distribution does not actually match the `_DISTRIBUTION_NAME_R` pattern before raising the error.