### PR TITLE
BUG: fix upgrade_all when no candidate is available for a given installed package

### DIFF
--- a/simplesat/dependency_solver.py
+++ b/simplesat/dependency_solver.py
@@ -520,10 +520,14 @@ def _convert_upgrade_request_if_needed(request, remote_repositories,
         for repository in remote_repositories:
             remote_repository.update(repository)
 
-        latest_packages = (
-            remote_repository.find_packages(package.name)[-1]
-            for package in installed_repository
-        )
+        latest_packages = []
+        for package in installed_repository:
+            candidates = remote_repository.find_packages(package.name)
+            # candidates may be empty (e.g. when repository configuration
+            # changed, and an installed package is coming from a repository not
+            # configured in the remote list)
+            if len(candidates) > 0:
+                latest_packages.append(candidates[-1])
 
         for p in latest_packages:
             upgrade_request.install(

--- a/simplesat/tests/test_solver.py
+++ b/simplesat/tests/test_solver.py
@@ -575,6 +575,33 @@ class TestSolver(SolverHelpersMixin, unittest.TestCase):
         with self.assertRaises(SatisfiabilityError):
             self.resolve(request)
 
+    def test_upgrade_no_candidate(self):
+        # Given
+        mkl_11_3_1 = P(u"mkl 11.3.1-1")
+        mkl_2017_0_1_1 = P(u"mkl 2017.0.1-1")
+        mkl_2017_0_1_2 = P(u"mkl 2017.0.1-2")
+
+        numpy_1_10_4 = P(u"numpy 1.10.4-1; depends (mkl ^= 11.3.1)")
+
+        scipy_0_17_1 = P(u"scipy 0.17.1-1; depends (mkl ^= 11.3.1, numpy ^= 1.10.4)")
+
+        gnureadline_6_3 = P(u"gnureadline 6.3-1")
+
+        # gnureadline is not available in the remote repository
+        self.repository.update([
+            mkl_11_3_1, mkl_2017_0_1_1, mkl_2017_0_1_2, numpy_1_10_4,
+            scipy_0_17_1
+        ])
+        self.installed_repository.update([mkl_11_3_1, numpy_1_10_4, scipy_0_17_1])
+        self.installed_repository.update([gnureadline_6_3])
+
+        # When/Then
+        request = Request()
+        request.upgrade()
+
+        with self.assertRaises(SatisfiabilityError):
+            self.resolve(request)
+
 
 class TestSolverWithHint(SolverHelpersMixin, unittest.TestCase):
     def test_no_conflict(self):


### PR DESCRIPTION
@itziakos this should fix the issue you were seeing when running packman upgrade-all