### PR TITLE
Remove broken _unsatisfied_clauses cache

### DIFF
--- a/simplesat/sat/policy/undetermined_clause_policy.py
+++ b/simplesat/sat/policy/undetermined_clause_policy.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from collections import defaultdict
-
 import six
 
 from .policy import IPolicy, pkg_id_to_version

--- a/simplesat/sat/policy/undetermined_clause_policy.py
+++ b/simplesat/sat/policy/undetermined_clause_policy.py
@@ -30,44 +30,17 @@ class UndeterminedClausePolicy(IPolicy):
 
         self._decision_set = set()
         self._requirements = set()
-        self._unsatisfied_clauses = set()
-        self._id_to_clauses = defaultdict(list)
         self._all_ids = set()
 
     def add_requirements(self, package_ids):
         self._requirements.update(package_ids)
 
-    def _update_cache_from_assignments(self, assignments):
-        changelog = assignments.consume_changelog()
-        for key in six.iterkeys(changelog):
-            for clause in self._id_to_clauses[key]:
-                if any(assignments.value(l) for l in clause.lits):
-                    self._unsatisfied_clauses.discard(clause)
-                else:
-                    self._unsatisfied_clauses.add(clause)
-
-    def _build_id_to_clauses(self, clauses):
-        """ Return a mapping from package ids to a list of clauses containing
-        that id.
-        """
-        table = defaultdict(list)
-        for c in clauses:
-            for l in c.lits:
-                table[abs(l)].append(c)
-
-        # Make sure all installed packages appear in the table
-        for pid in self._prefer_installed_pkg_ids:
-            table[pid]
-
-        self._all_ids = set(six.iterkeys(table))
-        return dict(table)
-
     def get_next_package_id(self, assignments, clauses):
         """Get the next unassigned package.
         """
         if assignments.new_keys:
-            self._id_to_clauses = self._build_id_to_clauses(clauses)
-            self._refresh_decision_set(assignments)
+            self._refresh_decision_set(assignments, clauses)
+
         candidate_id = None
         best = self._best_candidate
 
@@ -81,10 +54,11 @@ class UndeterminedClausePolicy(IPolicy):
             candidate_id = best(self._decision_set, assignments, update=True)
 
         if candidate_id is None:
-            self._refresh_decision_set(assignments)
+            self._refresh_decision_set(assignments, clauses)
             candidate_id = best(self._decision_set, assignments)
-            if candidate_id is None:
-                candidate_id = best(self._all_ids, assignments)
+
+        if candidate_id is None:
+            candidate_id = best(self._all_ids, assignments)
 
         assert assignments.get(candidate_id) is None, \
             "Trying to assign to a variable which is already assigned."
@@ -110,12 +84,21 @@ class UndeterminedClausePolicy(IPolicy):
         except ValueError:
             return None
 
-    def _refresh_decision_set(self, assignments):
-        self._update_cache_from_assignments(assignments)
+    def _refresh_decision_set(self, assignments, clauses):
+        assignments.consume_changelog()
+
+        all_ids = {abs(l) for c in clauses for l in c.lits}
+        all_ids.update(self._prefer_installed_pkg_ids)
+        self._all_ids = all_ids
+
+        unsatisfied_clauses = {
+            clause for clause in clauses
+            if not any(assignments.value(l) for l in clause.lits)
+        }
         self._decision_set.clear()
         self._decision_set.update(
             abs(lit)
-            for clause in self._unsatisfied_clauses
+            for clause in unsatisfied_clauses
             for lit in clause.lits
         )
         self._decision_set.difference_update(assignments.assigned_ids)

--- a/simplesat/tests/test_solver.py
+++ b/simplesat/tests/test_solver.py
@@ -602,6 +602,64 @@ class TestSolver(SolverHelpersMixin, unittest.TestCase):
         with self.assertRaises(SatisfiabilityError):
             self.resolve(request)
 
+    def test_up_to_date_package_choices(self):
+        # Given
+        envisage_4_7_2_1 = P(u"envisage 4.7.2-1; depends (apptools ^= 4.4.0, traits ^= 5.1.1)")
+        envisage_4_7_1_1 = P(u"envisage 4.7.1-1")
+        apptools_4_4_0_12 = P(u"apptools 4.4.0-12; depends (traitsui ^= 6.0.0, configobj ^= 5.0.6)")
+        apptools_4_4_0_13 = P(u"apptools 4.4.0-13; depends (traitsui ^= 6.1.0, configobj ^= 5.0.6)")
+        apptools_4_4_0_14 = P(u"apptools 4.4.0-14; depends (traitsui ^= 6.1.1, configobj ^= 5.0.6)")
+        pyface_6_0_0_5 = P(u"pyface 6.0.0-5; depends (pygments ^= 2.2.0, traits ^= 5.1.1)")
+        pyface_6_1_0_1 = P(u"pyface 6.1.0-1; depends (pygments ^= 2.2.0, traits ^= 5.1.1)")
+        pyface_6_1_0_2 = P(u"pyface 6.1.0-2; depends (pygments ^= 2.2.0, traits ^= 5.1.1)")
+        traitsui_6_0_0_3 = P(u"traitsui 6.0.0-3; depends (traits ^= 5.1.0, pyface ^= 6.0.0)")
+        traitsui_6_0_0_4 = P(u"traitsui 6.0.0-4; depends (traits ^= 5.1.1, pyface ^= 6.0.0)")
+        traitsui_6_1_0_1 = P(u"traitsui 6.1.0-1; depends (pyface ^= 6.1.0, traits ^= 5.1.1)")
+        traitsui_6_1_1_1 = P(u"traitsui 6.1.1-1; depends (pyface ^= 6.1.0, traits ^= 5.1.1)")
+        traits_5_1_1_1 = P(u"traits 5.1.1-1")
+        configobj_5_0_6_3 = P(u"configobj 5.0.6-3; depends (six ^= 1.11.0)")
+        six_1_11_0_1 = P(u"six 1.11.0-1")
+        pygments_2_2_0_1 = P(u"pygments 2.2.0-1")
+
+        packages = [
+            apptools_4_4_0_12,
+            apptools_4_4_0_13,
+            apptools_4_4_0_14,
+            configobj_5_0_6_3,
+            envisage_4_7_2_1,
+            envisage_4_7_1_1,
+            pyface_6_0_0_5,
+            pyface_6_1_0_1,
+            pyface_6_1_0_2,
+            pygments_2_2_0_1,
+            six_1_11_0_1,
+            traits_5_1_1_1,
+            traitsui_6_0_0_3,
+            traitsui_6_0_0_4,
+            traitsui_6_1_0_1,
+            traitsui_6_1_1_1,
+        ]
+        for package in packages:
+            self.repository.add_package(package)
+
+        # When
+        request = Request()
+        request.install(R("envisage"))
+        transaction = self.resolve(request)
+
+        # Then
+        expected_operations = [
+            InstallOperation(pygments_2_2_0_1),
+            InstallOperation(six_1_11_0_1),
+            InstallOperation(traits_5_1_1_1),
+            InstallOperation(configobj_5_0_6_3),
+            InstallOperation(pyface_6_1_0_2),
+            InstallOperation(traitsui_6_1_1_1),
+            InstallOperation(apptools_4_4_0_14),
+            InstallOperation(envisage_4_7_2_1),
+        ]
+        self.assertEqualOperations(transaction.operations, expected_operations)
+
 
 class TestSolverWithHint(SolverHelpersMixin, unittest.TestCase):
     def test_no_conflict(self):
@@ -690,4 +748,3 @@ class TestSolverWithHint(SolverHelpersMixin, unittest.TestCase):
 
         self.assertMultiLineEqual(
             ctx.exception.hint_pretty_string, r_hint_pretty_string)
-

--- a/simplesat/tests/test_solver.py
+++ b/simplesat/tests/test_solver.py
@@ -604,61 +604,37 @@ class TestSolver(SolverHelpersMixin, unittest.TestCase):
 
     def test_up_to_date_package_choices(self):
         # Given
-        envisage_4_7_2_1 = P(u"envisage 4.7.2-1; depends (apptools ^= 4.4.0, traits ^= 5.1.1)")
-        envisage_4_7_1_1 = P(u"envisage 4.7.1-1")
-        apptools_4_4_0_12 = P(u"apptools 4.4.0-12; depends (traitsui ^= 6.0.0, configobj ^= 5.0.6)")
-        apptools_4_4_0_13 = P(u"apptools 4.4.0-13; depends (traitsui ^= 6.1.0, configobj ^= 5.0.6)")
-        apptools_4_4_0_14 = P(u"apptools 4.4.0-14; depends (traitsui ^= 6.1.1, configobj ^= 5.0.6)")
-        pyface_6_0_0_5 = P(u"pyface 6.0.0-5; depends (pygments ^= 2.2.0, traits ^= 5.1.1)")
-        pyface_6_1_0_1 = P(u"pyface 6.1.0-1; depends (pygments ^= 2.2.0, traits ^= 5.1.1)")
-        pyface_6_1_0_2 = P(u"pyface 6.1.0-2; depends (pygments ^= 2.2.0, traits ^= 5.1.1)")
-        traitsui_6_0_0_3 = P(u"traitsui 6.0.0-3; depends (traits ^= 5.1.0, pyface ^= 6.0.0)")
-        traitsui_6_0_0_4 = P(u"traitsui 6.0.0-4; depends (traits ^= 5.1.1, pyface ^= 6.0.0)")
-        traitsui_6_1_0_1 = P(u"traitsui 6.1.0-1; depends (pyface ^= 6.1.0, traits ^= 5.1.1)")
-        traitsui_6_1_1_1 = P(u"traitsui 6.1.1-1; depends (pyface ^= 6.1.0, traits ^= 5.1.1)")
-        traits_5_1_1_1 = P(u"traits 5.1.1-1")
-        configobj_5_0_6_3 = P(u"configobj 5.0.6-3; depends (six ^= 1.11.0)")
-        six_1_11_0_1 = P(u"six 1.11.0-1")
-        pygments_2_2_0_1 = P(u"pygments 2.2.0-1")
-
-        packages = [
-            apptools_4_4_0_12,
-            apptools_4_4_0_13,
-            apptools_4_4_0_14,
-            configobj_5_0_6_3,
-            envisage_4_7_2_1,
-            envisage_4_7_1_1,
-            pyface_6_0_0_5,
-            pyface_6_1_0_1,
-            pyface_6_1_0_2,
-            pygments_2_2_0_1,
-            six_1_11_0_1,
-            traits_5_1_1_1,
-            traitsui_6_0_0_3,
-            traitsui_6_0_0_4,
-            traitsui_6_1_0_1,
-            traitsui_6_1_1_1,
-        ]
-        for package in packages:
-            self.repository.add_package(package)
+        packages = u"""
+            envisage 4.7.2-1; depends (apptools ^= 4.4.0, traits ^= 5.1.1)
+            apptools 4.4.0-12; depends (traitsui ^= 6.0.0)
+            apptools 4.4.0-14; depends (traitsui ^= 6.1.1)
+            traitsui 6.0.0-3; depends (traits ^= 5.1.0)
+            traitsui 6.0.0-4; depends (traits ^= 5.1.1)
+            traitsui 6.1.1-1; depends (traits ^= 5.1.1)
+            traits 5.1.0-1
+            traits 5.1.1-1
+        """
+        for package in packages.strip().splitlines():
+            self.repository.add_package(P(package.strip()))
 
         # When
         request = Request()
         request.install(R("envisage"))
         transaction = self.resolve(request)
+        packages = {
+            operation.package.name: str(operation.package.version)
+            for operation in transaction.operations
+        }
 
         # Then
-        expected_operations = [
-            InstallOperation(pygments_2_2_0_1),
-            InstallOperation(six_1_11_0_1),
-            InstallOperation(traits_5_1_1_1),
-            InstallOperation(configobj_5_0_6_3),
-            InstallOperation(pyface_6_1_0_2),
-            InstallOperation(traitsui_6_1_1_1),
-            InstallOperation(apptools_4_4_0_14),
-            InstallOperation(envisage_4_7_2_1),
-        ]
-        self.assertEqualOperations(transaction.operations, expected_operations)
+        expected_packages = {
+            "traits": "5.1.1-1",
+            "traitsui": "6.1.1-1",
+            "apptools": "4.4.0-14",
+            "envisage": "4.7.2-1",
+        }
+        self.assertEqual(packages, expected_packages)
+
 
 
 class TestSolverWithHint(SolverHelpersMixin, unittest.TestCase):


### PR DESCRIPTION
Fixes #268, by removing the machinery for the `_unsatisfied_clauses` cache. That machinery is broken in two ways:

- the `_unsatisfied_clauses` set isn't ever initialised properly
- the collection of unsatisfied clauses isn't updated when the set of clauses changes (as can happen with the current solver algorithm)

I'd really like to get rid of the changelog too, but we're currently using it for logging purposes.