### PR TITLE
MAINT: Fix deprecated attribute 'convert' to comply with attrs 19.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@
 Changes since 0.7.0
 ===================
 
+* Fix deprecated `convert` attribute in `constraint_modifiers.py` to
+  comply with attrs package release 19.2.0 (see also
+  https://www.attrs.org/en/stable/changelog.html).
+
 Version 0.7.0
 =============
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ POST_RELEASE = None
 
 
 INSTALL_REQUIRES = [
-    "attrs >= 16.1.0",
+    "attrs >= 17.4.0",
     "okonomiyaki >= 0.16.6",
     "six >= 1.10.0"
 ]

--- a/simplesat/constraints/constraint_modifiers.py
+++ b/simplesat/constraints/constraint_modifiers.py
@@ -77,7 +77,7 @@ def as_set(container):
     return set(container)
 
 
-_coerced_set = dict(default=(), convert=as_set,
+_coerced_set = dict(default=(), converter=as_set,
                     validator=instance_of(set))
 
 


### PR DESCRIPTION
The attrs package 19.2.0, which has been released yesterday, deprecates the attribute `convert`. It's basically just renamed to `converter`, so the fix is lightweight. See also

* https://www.attrs.org/en/stable/changelog.html
* https://github.com/python-attrs/attrs/issues/307
* https://github.com/python-attrs/attrs/issues/504

Let me know if I should change anything in this PR.