### PR TITLE
Use raw strings to make Python 3.12 happy

### DIFF
--- a/simplesat/constraints/package_parser.py
+++ b/simplesat/constraints/package_parser.py
@@ -11,7 +11,7 @@ _DISTRIBUTION_RS = "(?P<distribution>{})".format(_DISTRIBUTION_R)
 _VERSION_RS = "(?P<version>{})".format(_VERSION_R)
 _CONSTRAINT_RS = "(?P<constraint>[^,]*)"
 
-CONSTRAINT_BLOCK_RC = re.compile("(?P<kind>\w+)\s*\((?P<constraints>.*?)\)")  # noqa
+CONSTRAINT_BLOCK_RC = re.compile(r"(?P<kind>\w+)\s*\((?P<constraints>.*?)\)")  # noqa
 PACKAGE_RC = re.compile(_DISTRIBUTION_RS + _WS_RS + _VERSION_RS)
 CONSTRAINT_RC = re.compile(_DISTRIBUTION_RS + _MAYBE_WS_RS + _CONSTRAINT_RS)
 

--- a/simplesat/constraints/requirement.py
+++ b/simplesat/constraints/requirement.py
@@ -16,7 +16,7 @@ from .parser import (
 )
 
 
-_FULL_PACKAGE_RC = re.compile("""\
+_FULL_PACKAGE_RC = re.compile(r"""\
         (?P<name>{})
         (?:-|\s+)
         (?P<version>{})


### PR DESCRIPTION
Python 3.12 [upgraded a `DeprecationWarning` to a `SyntaxWarning`](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes). These `SyntaxWarnings` appear on stdout for any consuming code.

sat-solver had two `re.compile` calls using normal strings with invalid escape sequences. This PR simply makes those normal strings into raw strings to remedy the issue.

### Testing
Tested locally with Rivos code.