### PR TITLE
Better error on cyclic dependencies

### DIFF
--- a/simplesat/tests/test_transaction.py
+++ b/simplesat/tests/test_transaction.py
@@ -44,6 +44,7 @@ CYCLE_DEF = dedent("""\
     D 1.0.0-1; depends (C ^= 0.0.0)
 """)
 
+
 class TestTransaction(unittest.TestCase):
 
     maxDiff = None

--- a/simplesat/transaction.py
+++ b/simplesat/transaction.py
@@ -104,14 +104,20 @@ class Transaction(object):
         first, second = sorted(ops, key=lambda o: rank.index(o.__class__))
         return UpdateOperation(first.package, second.package)
 
+    def _key_to_pretty_string(self, package_id):
+        if package_id > 0:
+            return '{0}-{1}'.format(*self._package_key(package_id))
+        else:
+            return '-({0}-{1})'.format(
+                *self._package_key(abs(package_id)))
+
     def _safe_operations(self, decisions, installed_package_ids):
         graph = package_lit_dependency_graph(self._pool, decisions,
                                              closed=True)
         removals = []
         installs = []
-
         # This builds from the bottom (no dependencies) up
-        for group in toposort(graph):
+        for group in toposort(graph, self._key_to_pretty_string):
             # Sort the set of independent packages for determinism
             for package_id in sorted(group, key=abs):
                 assert package_id in decisions

--- a/simplesat/utils/graph.py
+++ b/simplesat/utils/graph.py
@@ -11,7 +11,7 @@ import itertools
 from simplesat.constraints.requirement import InstallRequirement
 
 
-def toposort(nodes_to_edges):
+def toposort(nodes_to_edges, id2string=None):
     """Return an iterator over topologically sorted groups of nodes.
 
     Output is a list of sets in
@@ -27,6 +27,9 @@ def toposort(nodes_to_edges):
         nodes and values are all of the nodes on which the key depends.
 
         For example, if node 1 depends on 2, we have ``{1: {2}, 2: set()}``.
+    id2string: function
+        A function to convert package id to user frendly strings for the error
+        messages.
 
     Yields
     ------
@@ -77,9 +80,14 @@ def toposort(nodes_to_edges):
                 for item, dep in six.iteritems(data)
                 if item not in ordered}
     if data:
+        if id2string is None:
+            id2string = repr
         msg = "Cyclic dependencies exist among these items:\n{}"
-        cyclic = '\n'.join(repr(x) for x in six.iteritems(data))
-        raise ValueError(msg.format(cyclic))
+        cyclic = []
+        for key, value in data.items():
+            line = id2string(key) + ' -> ' + str([id2string(x) for x in value])
+            cyclic.append(line)
+        raise ValueError(msg.format('\n'.join(cyclic)))
 
 
 def package_lit_dependency_graph(pool, package_lits, closed=True):

--- a/simplesat/utils/tests/test_graph.py
+++ b/simplesat/utils/tests/test_graph.py
@@ -107,7 +107,7 @@ class TestGraph(unittest.TestCase):
 
     def test_toposort_cycle_with_pretty_print(self):
         # Given
-        id2string = lambda x: bin(x)
+        id2string = lambda x: bin(x)  # noqa
         graph = {
             0: set(),
             1: set(),

--- a/simplesat/utils/tests/test_graph.py
+++ b/simplesat/utils/tests/test_graph.py
@@ -15,6 +15,8 @@ from ..graph import (
 
 class TestGraph(unittest.TestCase):
 
+    maxDiff = None
+
     def test_transitive_neighbors(self):
         # Given
         graph = {
@@ -99,9 +101,36 @@ class TestGraph(unittest.TestCase):
             6: {3, 5},
         }
 
-        # Then
+        # When/Then
         with self.assertRaises(ValueError):
             tuple(toposort(graph))
+
+    def test_toposort_cycle_with_pretty_print(self):
+        # Given
+        id2string = lambda x: bin(x)
+        graph = {
+            0: set(),
+            1: set(),
+            2: {6},
+            3: {0, 2},
+            4: {0},
+            5: {1, 2},
+            6: {3, 5},
+        }
+        expected = dedent("""\
+        Cyclic dependencies exist among these items:
+        0b10 -> ['0b110']
+        0b11 -> ['0b10']
+        0b101 -> ['0b10']
+        0b110 -> ['0b11', '0b101']""")
+
+        # When
+        with self.assertRaises(ValueError) as cm:
+            tuple(toposort(graph, id2string=id2string))
+
+        # Then
+        message = cm.exception.args[0]
+        self.assertEqual(message, expected)
 
 
 class TestDependencyGraph(unittest.TestCase):


### PR DESCRIPTION
- Add support to pass a function to convert package_ids to user friendly strings in toposort.
- Pass a package_id to string function to toposort in the Transaction instance.
- Update tests