### PR TITLE
add pypi publish workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,29 @@
+name: Publish new release to pypi
+
+on:
+  # Triggers the workflow when simplesat is released on Github
+  release:
+    types:
+        - released
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
       actions: read
       contents: write
       statuses: write
-      id-token: write
     runs-on: ubuntu-latest
     steps:
     - name: Clone the source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,16 +44,6 @@ jobs:
       run: python -m pip install build wheel requests
     - name: build wheel
       run: python -m build -s -w -n -x
-    - name: sign archives
-      uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46
-      with:
-        inputs: |
-          dist/simplesat*.whl
-          dist/simplesat*.tar.gz
-        verify: true
-        verify-cert-identity: https://github.com/enthought/sat-solver/.github/workflows/release.yml@refs/tags/${{github.ref_name}}
-        verify-oidc-issuer: https://token.actions.githubusercontent.com
-        upload-signing-artifacts: true
     - name: Prepare release
       uses:  ./.github/actions/prepare-release
       with:


### PR DESCRIPTION
We add a separate pypi.yml workflow to upload wheels to pypi. The wheels are signed and attestation is generated 